### PR TITLE
Fix build workflow Github token

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build-and-test:
+  build:
     runs-on: macos-latest
     steps:
     - name: Checkout code
@@ -22,3 +22,5 @@ jobs:
       run: npm ci
     - name: Package unsigned mac app
       run: npm run package:mac:nosign
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix Workflow error `GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"` as seen in https://github.com/valkey-io/valkey-admin/actions/runs/20765981347/job/59632061673

This error has been acknowledged by the electron builder community - https://github.com/electron-userland/electron-builder/issues/4883