### PR TITLE
add color support for Zset, stream and JSON key types

### DIFF
--- a/apps/frontend/src/components/ui/donut-chart.tsx
+++ b/apps/frontend/src/components/ui/donut-chart.tsx
@@ -69,6 +69,9 @@ export default function DonutChart() {
     "Hash": "var(--tw-chart1)",
     "List": "var(--tw-chart4)",
     "String": "var(--tw-chart2)",
+    "Zset": "var(--tw-chart5)",
+    "Stream": "var(--tw-chart6)",
+    "ReJSON-RL": "var(--tw-chart7)",
   }
 
   const CustomTooltip = ({ active, payload }: TooltipProps) => {

--- a/apps/frontend/src/css/index.css
+++ b/apps/frontend/src/css/index.css
@@ -49,6 +49,9 @@
   --color-tw-chart2: var(--tw-chart2);
   --color-tw-chart3: var(--tw-chart3);
   --color-tw-chart4: var(--tw-chart4);
+  --color-tw-chart5: var(--tw-chart5);
+  --color-tw-chart6: var(--tw-chart6);
+  --color-tw-chart7: var(--tw-chart7);
 }
 
 :root {
@@ -94,6 +97,9 @@
   --tw-chart2: #FF8042;
   --tw-chart3: #FFBB28;
   --tw-chart4: #009688;
+  --tw-chart5: #8BC34A;
+  --tw-chart6: #FF5722;
+  --tw-chart7: #03A9F4;
 }
 
 .dark {


### PR DESCRIPTION
## Description

Include a summary of the change.
add color support for Zset, stream and JSON key types

### Change Visualization

Include a screenshot/video of before and after the change.
<img width="912" height="925" alt="image" src="https://github.com/user-attachments/assets/179c831d-fd9d-4f29-94b1-51d783f677a0" />
