### PR TITLE
Fix for connecting to non-tls instances

### DIFF
--- a/apps/metrics/src/index.js
+++ b/apps/metrics/src/index.js
@@ -30,11 +30,12 @@ async function main() {
       password: process.env.VALKEY_PASSWORD,
     } : undefined
 
+  const useTLS = process.env.VALKEY_TLS === "true"
   const client = await GlideClient.createClient({
     addresses,
     credentials,
-    useTLS: process.env.VALKEY_TLS === "true" ? true : false,
-    ...(process.env.VALKEY_VERIFY_CERT === "false" && {
+    useTLS,
+    ...(useTLS && process.env.VALKEY_VERIFY_CERT === "false" && {
       advancedConfiguration: {
         tlsAdvancedConfiguration: {
           insecure: true,

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -32,11 +32,12 @@ export async function connectToValkey(
   try {
     // If we've connected to the same host using IP addr or vice versa, return
     returnIfDuplicateConnection(payload, clients, ws)
+    const useTLS = payload.connectionDetails.tls
     const standaloneClient = await GlideClient.createClient({
       addresses,
       credentials,
-      useTLS: payload.connectionDetails.tls,
-      ...(payload.connectionDetails.verifyTlsCertificate === false && {
+      useTLS,
+      ...(useTLS && payload.connectionDetails.verifyTlsCertificate === false && {
         advancedConfiguration: {
           tlsAdvancedConfiguration: {
             insecure: true,
@@ -182,11 +183,12 @@ async function connectToCluster(
       payload: { clusterId, clusterNodes },
     }),
   )
+  const useTLS = payload.connectionDetails.tls
   const clusterClient = await GlideClusterClient.createClient({
     addresses,
     credentials,
-    useTLS: payload.connectionDetails.tls,
-    ...(payload.connectionDetails.verifyTlsCertificate === false && {
+    useTLS,
+    ...(useTLS && payload.connectionDetails.verifyTlsCertificate === false && {
       advancedConfiguration: {
         tlsAdvancedConfiguration: {
           insecure: true,


### PR DESCRIPTION

When connecting to a non-tls enabled instance, the application tried to set advanced configuration, which isn't available when tls is set to false. The fix is a conditional check for tls and only disable certificate verification if tls is enabled.

