### PR TITLE
Fix missing shell import

### DIFF
--- a/apps/frontend/electron.main.js
+++ b/apps/frontend/electron.main.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-const { app, BrowserWindow, ipcMain, safeStorage } = require("electron")
+const { app, BrowserWindow, ipcMain, safeStorage, shell } = require("electron")
 const path = require("path")
 const { fork } = require("child_process")
 


### PR DESCRIPTION
## Description

Missing the shell import that led to a Javascript error when Github icon was clicked.

This import fixes the issue.

## Screenshot

<img width="2356" height="1508" alt="image" src="https://github.com/user-attachments/assets/20c02d13-154f-4d61-9c8a-8bdb59ccd101" />


