### PR TITLE
refactor key details for all key types with ui primitives

### DIFF
--- a/apps/frontend/src/components/key-browser/key-details/key-details-hash.tsx
+++ b/apps/frontend/src/components/key-browser/key-details/key-details-hash.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react"
-import { Check, Pencil, X, Trash, Plus } from "lucide-react"
+import { Trash, Plus, X } from "lucide-react"
 import { CustomTooltip } from "../../ui/custom-tooltip"
 import { Button } from "../../ui/button"
 import { Input } from "../../ui/input"
+import { EditActionButtons } from "../../ui/edit-action-buttons"
 import DeleteModal from "../../ui/delete-modal"
 import { useAppDispatch } from "@/hooks/hooks"
 import { updateKeyRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
@@ -147,36 +148,12 @@ export default function KeyDetailsHash(
           <div className="font-semibold text-left">Key</div>
           <div className="col-span-2 font-semibold text-left">Value</div>
           <div className="flex justify-end gap-1">
-            {!readOnly && (isEditable ? (
-              <>
-                <CustomTooltip content="Save" side={"left"}>
-                  <Button
-                    onClick={handleSave}
-                    variant={"secondary"}
-                  >
-                    <Check />
-                  </Button>
-                </CustomTooltip>
-                <CustomTooltip content="Cancel">
-                  <Button
-                    onClick={handleEdit}
-                    variant={"destructiveGhost"}
-                  >
-                    <X />
-                  </Button>
-                </CustomTooltip>
-              </>
-            ) : (
-              <CustomTooltip content="Edit">
-                <Button
-                  className="mr-1"
-                  onClick={handleEdit}
-                  variant={"ghost"}
-                >
-                  <Pencil />
-                </Button>
-              </CustomTooltip>
-            ))}
+            <EditActionButtons
+              isEditable={isEditable}
+              onEdit={handleEdit}
+              onSave={handleSave}
+              readOnly={readOnly}
+            />
           </div>
         </div>
         {selectedKeyInfo.elements

--- a/apps/frontend/src/components/key-browser/key-details/key-details-json.tsx
+++ b/apps/frontend/src/components/key-browser/key-details/key-details-json.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react"
-import { Check, Pencil, X, TriangleAlert } from "lucide-react"
+import { TriangleAlert } from "lucide-react"
 import { KEY_TYPES } from "@common/src/constants"
 import { useSelector } from "react-redux"
-import { CustomTooltip } from "../../ui/custom-tooltip"
-import { Button } from "../../ui/button"
+import { EditActionButtons } from "../../ui/edit-action-buttons"
+import { Textarea } from "../../ui/textarea"
 import { useAppDispatch } from "@/hooks/hooks"
 import { updateKeyRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
 import { selectJsonModuleAvailable } from "@/state/valkey-features/connection/connectionSelectors"
+import { cn } from "@/lib/utils"
 
 interface KeyDetailsJsonProps {
   selectedKey: string;
@@ -75,44 +76,20 @@ export default function KeyDetailsJson(
   return (
     <div className="flex items-center justify-center w-full p-4">
       <table className="table-auto w-full overflow-hidden">
-        <thead className="bg-tw-dark-border opacity-85 text-white">
+        <thead className={cn("bg-muted/60 text-foreground")}>
           <tr>
             <th className="w-full py-3 px-4 text-left font-semibold">
               JSON Value
             </th>
             <th className="">
-              {!readOnly && (isEditable ? (
-                <div className="flex gap-1">
-                  <CustomTooltip content="Save">
-                    <Button
-                      className="text-tw-primary hover:text-tw-primary"
-                      onClick={handleSave}
-                      variant={"secondary"}
-                    >
-                      <Check />
-                    </Button>
-                  </CustomTooltip>
-                  <CustomTooltip content="Cancel">
-                    <Button
-                      onClick={handleEdit}
-                      variant={"destructiveGhost"}
-                    >
-                      <X />
-                    </Button>
-                  </CustomTooltip>
-                </div>
-              ) : (
-                <CustomTooltip content={jsonModuleAvailable ? "Edit" : "JSON module not available"}>
-                  <Button
-                    className="mr-1"
-                    disabled={!jsonModuleAvailable}
-                    onClick={handleEdit}
-                    variant={"ghost"}
-                  >
-                    <Pencil />
-                  </Button>
-                </CustomTooltip>
-              ))}
+              <EditActionButtons
+                disabled={!jsonModuleAvailable}
+                disabledTooltip="JSON module not available"
+                isEditable={isEditable}
+                onEdit={handleEdit}
+                onSave={handleSave}
+                readOnly={readOnly}
+              />
             </th>
           </tr>
         </thead>
@@ -130,13 +107,12 @@ export default function KeyDetailsJson(
             </tr>
           )}
           <tr>
-            <td className="py-3 px-4 font-light dark:text-white" colSpan={2}>
+            <td className={cn("py-3 px-4 font-light text-foreground")} colSpan={2}>
               {isEditable ? (
                 <div>
-                  <textarea
+                  <Textarea
                     autoFocus
-                    className="w-full p-2 dark:bg-tw-dark-bg dark:border-tw-dark-border border rounded focus:outline-none
-                      focus:ring-2 focus:ring-tw-primary min-h-[400px] font-mono text-sm"
+                    className="min-h-[400px] font-mono text-sm"
                     onChange={(e) => setEditedValue(e.target.value)}
                     value={editedValue}
                   />

--- a/apps/frontend/src/components/key-browser/key-details/key-details-list.tsx
+++ b/apps/frontend/src/components/key-browser/key-details/key-details-list.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react"
-import { Check, Pencil, X, Trash, Plus } from "lucide-react"
+import { Trash, Plus, X } from "lucide-react"
 import { CustomTooltip } from "../../ui/custom-tooltip"
 import { Button } from "../../ui/button"
+import { Input } from "../../ui/input"
+import { EditActionButtons } from "../../ui/edit-action-buttons"
 import DeleteModal from "../../ui/delete-modal"
 import { useAppDispatch } from "@/hooks/hooks"
 import { updateKeyRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
+import { cn } from "@/lib/utils"
 
 interface KeyDetailsListProps {
   selectedKey: string;
@@ -129,55 +132,28 @@ export default function KeyDetailsList(
   return (
     <div className="flex items-center justify-center w-full p-4">
       <div className="w-full">
-        <div className="grid grid-cols-4 gap-4 bg-tw-dark-border opacity-85 text-white items-center py-1 px-4">
+        <div className={cn("grid grid-cols-4 gap-4 items-center py-1 px-4", "bg-muted/60 text-foreground")}>
           <div className="font-semibold text-left">Index</div>
           <div className="col-span-2 font-semibold text-left">Elements</div>
           <div className="flex justify-end gap-1">
-            {!readOnly && (isEditable ? (
-              <>
-                <CustomTooltip content="Save" side={"left"}>
-                  <Button
-                    className="text-tw-primary hover:text-tw-primary"
-                    onClick={handleSave}
-                    variant={"secondary"}
-                  >
-                    <Check />
-                  </Button>
-                </CustomTooltip>
-                <CustomTooltip content="Cancel">
-                  <Button
-                    onClick={handleEdit}
-                    variant={"destructiveGhost"}
-                  >
-                    <X />
-                  </Button>
-                </CustomTooltip>
-              </>
-            ) : (
-              <CustomTooltip content="Edit">
-                <Button
-                  className="mr-1"
-                  onClick={handleEdit}
-                  variant={"ghost"}
-                >
-                  <Pencil />
-                </Button>
-              </CustomTooltip>
-            ))}
+            <EditActionButtons
+              isEditable={isEditable}
+              onEdit={handleEdit}
+              onSave={handleSave}
+              readOnly={readOnly}
+            />
           </div>
         </div>
         {selectedKeyInfo.elements
           .map((element: string, index: number) => ({ element, index }))
           .filter(({ index }) => !deletedIndices.has(index))
           .map(({ element, index }) => (
-            <div className="grid grid-cols-4 gap-4 py-3 px-4 border-b border-tw-dark-border font-light dark:text-white" key={index}>
+            <div className={cn("grid grid-cols-4 gap-4 py-3 px-4 border-b border-border font-light text-foreground")} key={index}>
               <div>{index}</div>
               <div className="col-span-3">
                 {isEditable ? (
                   <div className="flex gap-2 relative">
-                    <input
-                      className="w-full p-2 dark:bg-tw-dark-bg dark:border-tw-dark-border border rounded focus:outline-none
-                                        focus:ring-2 focus:ring-tw-primary"
+                    <Input
                       onChange={(e) => handleListFieldChange(index, e.target.value)}
                       type="text"
                       value={editedListValues[index] || ""}
@@ -206,13 +182,11 @@ export default function KeyDetailsList(
             </div>
           ))}
         {isEditable && newItems.map((newItem) => (
-          <div className="grid grid-cols-4 gap-4 py-3 px-4 border-b border-tw-dark-border font-light dark:text-white" key={newItem.tempId}>
+          <div className={cn("grid grid-cols-4 gap-4 py-3 px-4 border-b border-border font-light text-foreground")} key={newItem.tempId}>
             <div>New</div>
             <div className="col-span-3">
               <div className="flex gap-2">
-                <input
-                  className="w-full p-2 dark:bg-tw-dark-bg dark:border-tw-dark-border border rounded focus:outline-none
-                                    focus:ring-2 focus:ring-tw-primary"
+                <Input
                   onChange={(e) => handleNewItemChange(newItem.tempId, e.target.value)}
                   placeholder="Enter value"
                   type="text"

--- a/apps/frontend/src/components/key-browser/key-details/key-details-set.tsx
+++ b/apps/frontend/src/components/key-browser/key-details/key-details-set.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react"
-import { Check, Pencil, X, Trash, Plus } from "lucide-react"
+import { Trash, Plus, X } from "lucide-react"
 import { CustomTooltip } from "../../ui/custom-tooltip"
 import { Button } from "../../ui/button"
+import { Input } from "../../ui/input"
+import { EditActionButtons } from "../../ui/edit-action-buttons"
 import DeleteModal from "../../ui/delete-modal"
 import { useAppDispatch } from "@/hooks/hooks"
 import { updateKeyRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
+import { cn } from "@/lib/utils"
 
 interface KeyDetailsSetProps {
   selectedKey: string;
@@ -126,55 +129,28 @@ export default function KeyDetailsSet(
   return (
     <div className="flex items-center justify-center w-full p-4">
       <div className="w-full">
-        <div className="grid grid-cols-4 gap-4 bg-tw-dark-border opacity-85 text-white items-center py-1 px-4">
+        <div className={cn("grid grid-cols-4 gap-4 items-center py-1 px-4", "bg-muted/60 text-foreground")}>
           <div className="font-semibold text-left">Index</div>
           <div className="col-span-2 font-semibold text-left">Value</div>
           <div className="flex justify-end gap-1">
-            {!readOnly && (isEditable ? (
-              <>
-                <CustomTooltip content="Save" side={"left"}>
-                  <Button
-                    className="text-tw-primary hover:text-tw-primary"
-                    onClick={handleSave}
-                    variant={"secondary"}
-                  >
-                    <Check />
-                  </Button>
-                </CustomTooltip>
-                <CustomTooltip content="Cancel">
-                  <Button
-                    onClick={handleEdit}
-                    variant={"destructiveGhost"}
-                  >
-                    <X />
-                  </Button>
-                </CustomTooltip>
-              </>
-            ) : (
-              <CustomTooltip content="Edit">
-                <Button
-                  className="mr-1"
-                  onClick={handleEdit}
-                  variant={"ghost"}
-                >
-                  <Pencil />
-                </Button>
-              </CustomTooltip>
-            ))}
+            <EditActionButtons
+              isEditable={isEditable}
+              onEdit={handleEdit}
+              onSave={handleSave}
+              readOnly={readOnly}
+            />
           </div>
         </div>
         {selectedKeyInfo.elements
           .map((element: string, index: number) => ({ element, index }))
           .filter(({ element }) => !deletedValues.has(element))
           .map(({ element, index }) => (
-            <div className="grid grid-cols-4 gap-4 py-3 px-4 border-b border-tw-dark-border font-light dark:text-white" key={index}>
+            <div className={cn("grid grid-cols-4 gap-4 py-3 px-4 border-b border-border font-light text-foreground")} key={index}>
               <div>{index}</div>
               <div className="col-span-3">
                 {isEditable ? (
                   <div className="flex gap-2 relative">
-                    <input
-                      className="w-full p-2 dark:bg-tw-dark-bg dark:border-tw-dark-border border rounded focus:outline-none
-                                        focus:ring-2 focus:ring-tw-primary"
+                    <Input
                       onChange={(e) => handleSetFieldChange(index, e.target.value)}
                       type="text"
                       value={editedSetValues[index] || ""}
@@ -203,13 +179,11 @@ export default function KeyDetailsSet(
             </div>
           ))}
         {isEditable && newItems.map((newItem) => (
-          <div className="grid grid-cols-4 gap-4 py-3 px-4 border-b border-tw-dark-border font-light dark:text-white" key={newItem.tempId}>
+          <div className={cn("grid grid-cols-4 gap-4 py-3 px-4 border-b border-border font-light text-foreground")} key={newItem.tempId}>
             <div>New</div>
             <div className="col-span-3">
               <div className="flex gap-2">
-                <input
-                  className="w-full p-2 dark:bg-tw-dark-bg dark:border-tw-dark-border border rounded focus:outline-none
-                                    focus:ring-2 focus:ring-tw-primary"
+                <Input
                   onChange={(e) => handleNewItemChange(newItem.tempId, e.target.value)}
                   placeholder="Enter value"
                   type="text"

--- a/apps/frontend/src/components/key-browser/key-details/key-details-stream.tsx
+++ b/apps/frontend/src/components/key-browser/key-details/key-details-stream.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils"
+
 interface KeyDetailsStreamProps {
   selectedKey: string;
   selectedKeyInfo: {
@@ -22,11 +24,11 @@ export default function KeyDetailsStream(
     <div className="flex flex-col w-full p-4 space-y-4">
       {selectedKeyInfo?.elements.map((entry, index: number) => (
         <div className="overflow-hidden" key={index}>
-          <div className="bg-tw-dark-border opacity-85 text-white py-2 px-4 font-semibold">
+          <div className={cn("bg-muted/60 text-foreground py-2 px-4 font-semibold")}>
             Entry ID: {entry.key} <span className="text-xs font-light">({new Date(Number(entry.key.split("-")[0])).toLocaleString()})</span>
           </div>
           <table className="table-auto w-full">
-            <thead className="bg-tw-dark-border opacity-70 text-white">
+            <thead className={cn("bg-muted/50 text-foreground")}>
               <tr>
                 <th className="w-1/2 py-3 px-4 text-left font-semibold">
                   Field
@@ -39,10 +41,10 @@ export default function KeyDetailsStream(
             <tbody>
               {entry.value.map(([field, value], fieldIndex: number) => (
                 <tr key={fieldIndex}>
-                  <td className="py-3 px-4 border-b border-tw-dark-border font-light dark:text-white">
+                  <td className={cn("py-3 px-4 border-b border-border font-light text-foreground")}>
                     {field}
                   </td>
-                  <td className="py-3 px-4 border-b border-tw-dark-border font-light dark:text-white">
+                  <td className={cn("py-3 px-4 border-b border-border font-light text-foreground")}>
                     {value}
                   </td>
                 </tr>

--- a/apps/frontend/src/components/key-browser/key-details/key-details-string.tsx
+++ b/apps/frontend/src/components/key-browser/key-details/key-details-string.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react"
-import { Check, Pencil, X } from "lucide-react"
-import { CustomTooltip } from "../../ui/custom-tooltip"
-import { Button } from "../../ui/button"
+import { EditActionButtons } from "../../ui/edit-action-buttons"
+import { Textarea } from "../../ui/textarea"
 import { useAppDispatch } from "@/hooks/hooks"
 import { updateKeyRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
+import { cn } from "@/lib/utils"
 
 interface KeyDetailsStringProps {
   selectedKey: string;
@@ -50,55 +50,28 @@ export default function KeyDetailsString(
   return (
     <div className="flex items-center justify-center w-full p-4">
       <table className="table-auto w-full overflow-hidden">
-        <thead className="bg-tw-dark-border opacity-85 text-white">
+        <thead className={cn("bg-muted/60 text-foreground")}>
           <tr>
             <th className="w-full py-3 px-4 text-left font-semibold">
               Value
             </th>
             <th className="">
-              {!readOnly && (isEditable ? (
-                <div className="flex gap-1">
-                  <CustomTooltip content="Save">
-                    <Button
-                      className="text-tw-primary hover:text-tw-primary"
-                      onClick={handleSave}
-                      variant={"secondary"}
-                    >
-                      <Check />
-                    </Button>
-                  </CustomTooltip>
-                  <CustomTooltip content="Cancel">
-                    <Button
-                      onClick={handleEdit}
-                      variant={"destructiveGhost"}
-                    >
-                      <X />
-                    </Button>
-                  </CustomTooltip>
-                </div>
-              ) : (
-                <CustomTooltip content="Edit">
-                  <Button
-                    className="mr-1"
-                    onClick={handleEdit}
-                    variant={"ghost"}
-                  >
-                    <Pencil />
-                  </Button>
-                </CustomTooltip>
-              ))}
-              
+              <EditActionButtons
+                isEditable={isEditable}
+                onEdit={handleEdit}
+                onSave={handleSave}
+                readOnly={readOnly}
+              />
             </th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td className="py-3 px-4 font-light dark:text-white" colSpan={2}>
+            <td className={cn("py-3 px-4 font-light text-foreground")} colSpan={2}>
               {isEditable ? (
-                <textarea
+                <Textarea
                   autoFocus
-                  className="w-full p-2 dark:bg-tw-dark-bg dark:border-tw-dark-border border rounded focus:outline-none 
-                    focus:ring-2 focus:ring-blue-500 min-h-[100px]"
+                  className="min-h-[100px]"
                   onChange={(e) => setEditedValue(e.target.value)}
                   value={editedValue}
                 />

--- a/apps/frontend/src/components/key-browser/key-details/key-details-zset.tsx
+++ b/apps/frontend/src/components/key-browser/key-details/key-details-zset.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react"
-import { Check, Pencil, X } from "lucide-react"
-import { CustomTooltip } from "../../ui/custom-tooltip"
-import { Button } from "../../ui/button"
+import { Input } from "../../ui/input"
+import { EditActionButtons } from "../../ui/edit-action-buttons"
 import { useAppDispatch } from "@/hooks/hooks"
 import { updateKeyRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
+import { cn } from "@/lib/utils"
 
 interface ZSetElement {
   key: string;
@@ -75,51 +75,24 @@ export default function KeyDetailsZSet(
   return (
     <div className="flex items-center justify-center w-full p-4">
       <div className="w-full">
-        <div className="grid grid-cols-4 gap-4 bg-tw-dark-border opacity-85 text-white items-center py-1 px-4">
+        <div className={cn("grid grid-cols-4 gap-4 items-center py-1 px-4", "bg-muted/60 text-foreground")}>
           <div className="font-semibold text-left">Key</div>
           <div className="col-span-2 font-semibold text-left">Value</div>
           <div className="flex justify-end gap-1">
-            {!readOnly && (isEditable ? (
-              <>
-                <CustomTooltip content="Save" side={"left"}>
-                  <Button
-                    className="text-tw-primary hover:text-tw-primary"
-                    onClick={handleSave}
-                    variant={"secondary"}
-                  >
-                    <Check />
-                  </Button>
-                </CustomTooltip>
-                <CustomTooltip content="Cancel" side={"top"}>
-                  <Button
-                    onClick={handleEdit}
-                    variant={"destructiveGhost"}
-                  >
-                    <X />
-                  </Button>
-                </CustomTooltip>
-              </>
-            ) : (
-              <CustomTooltip content="Edit">
-                <Button
-                  className="mr-1"
-                  onClick={handleEdit}
-                  variant={"ghost"}
-                >
-                  <Pencil />
-                </Button>
-              </CustomTooltip>
-            ))}
+            <EditActionButtons
+              isEditable={isEditable}
+              onEdit={handleEdit}
+              onSave={handleSave}
+              readOnly={readOnly}
+            />
           </div>
         </div>
         {selectedKeyInfo.elements.map((element: ZSetElement, index: number) => (
-          <div className="grid grid-cols-4 gap-4 py-3 px-4 border-b border-tw-dark-border font-light dark:text-white" key={index}>
+          <div className={cn("grid grid-cols-4 gap-4 py-3 px-4 border-b border-border font-light text-foreground")} key={index}>
             <div>{element.key}</div>
             <div className="col-span-3">
               {isEditable ? (
-                <input
-                  className="w-full p-2 dark:bg-tw-dark-bg dark:border-tw-dark-border border rounded focus:outline-none
-                                    focus:ring-2 focus:ring-tw-primary"
+                <Input
                   onChange={(e) => handleValueChange(index, e.target.value)}
                   step="any"
                   type="number"

--- a/apps/frontend/src/components/key-browser/key-details/key-details.tsx
+++ b/apps/frontend/src/components/key-browser/key-details/key-details.tsx
@@ -2,8 +2,9 @@ import { Key, Trash, X } from "lucide-react"
 import { useState } from "react"
 import { convertTTL } from "@common/src/ttl-conversion"
 import { formatBytes } from "@common/src/bytes-conversion"
-import { CustomTooltip } from "../../ui/custom-tooltip"
 import { Button } from "../../ui/button"
+import { Panel } from "../../ui/panel"
+import { InfoChip } from "../../ui/info-chip"
 import DeleteModal from "../../ui/delete-modal"
 import KeyDetailsString from "./key-details-string"
 import KeyDetailsHash from "./key-details-hash"
@@ -14,6 +15,7 @@ import KeyDetailsStream from "./key-details-stream"
 import KeyDetailsJson from "./key-details-json"
 import { useAppDispatch } from "@/hooks/hooks"
 import { deleteKeyRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
+import { CustomTooltip } from "@/components/ui/custom-tooltip"
 
 interface BaseKeyInfo {
   name: string;
@@ -89,7 +91,7 @@ export default function KeyDetails({ selectedKey, selectedKeyInfo, connectionId,
 
   return (
     <div className="pl-2 h-full">
-      <div className="h-full dark:border-tw-dark-border border rounded overflow-hidden">
+      <Panel className="dark:border-tw-dark-border">
         {selectedKey && selectedKeyInfo ? (
           <div className="h-full p-4 text-sm font-light overflow-y-auto">
             {/* Header Section */}
@@ -99,31 +101,25 @@ export default function KeyDetails({ selectedKey, selectedKeyInfo, connectionId,
                 {selectedKey}
               </span>
               <div className="space-x-2 flex items-center relative">
-                
+
                 {!readOnly && (
-                  <CustomTooltip content="TTL">
-                    <span className="text-xs px-2 py-1 rounded-full border-2 border-tw-primary text-tw-primary dark:text-white">
-                      {convertTTL(selectedKeyInfo.ttl)}
-                    </span>
-                  </CustomTooltip>
+                  <InfoChip tooltip="TTL">
+                    {convertTTL(selectedKeyInfo.ttl)}
+                  </InfoChip>
                 )}
-                <CustomTooltip content="Type">
-                  <span className={`text-xs px-2 py-1 rounded-full ${readOnly ? "" : "border-2 border-tw-primary"} text-tw-primary dark:text-white`}>
-                    {selectedKeyInfo.type === "ReJSON-RL" ? "json" : selectedKeyInfo.type}
-                  </span>
-                </CustomTooltip>
-                {!readOnly && (<CustomTooltip content="Size">
-                  <span className={"text-xs px-2 py-1 rounded-full border-2 border-tw-primary text-tw-primary dark:text-white"}>
+                <InfoChip showBorder={!readOnly} tooltip="Type">
+                  {selectedKeyInfo.type === "ReJSON-RL" ? "json" : selectedKeyInfo.type}
+                </InfoChip>
+                {!readOnly && (
+                  <InfoChip tooltip="Size">
                     {formatBytes(selectedKeyInfo.size)}
-                  </span>
-                </CustomTooltip>)}
-                
+                  </InfoChip>
+                )}
+
                 {selectedKeyInfo.collectionSize !== undefined && (
-                  <CustomTooltip content="Collection size">
-                    <span className={`text-xs px-2 py-1 rounded-full ${readOnly ? "" : "border-2 border-tw-primary"} text-tw-primary dark:text-white`}>
-                      {selectedKeyInfo.collectionSize.toLocaleString()}
-                    </span>
-                  </CustomTooltip>
+                  <InfoChip showBorder={!readOnly} tooltip="Collection size">
+                    {selectedKeyInfo.collectionSize.toLocaleString()}
+                  </InfoChip>
                 )}
                 {readOnly && (
                   <button
@@ -225,7 +221,7 @@ export default function KeyDetails({ selectedKey, selectedKeyInfo, connectionId,
             Select a key to see details
           </div>
         )}
-      </div>
+      </Panel>
     </div>
   )
 }

--- a/apps/frontend/src/components/ui/edit-action-buttons.tsx
+++ b/apps/frontend/src/components/ui/edit-action-buttons.tsx
@@ -1,0 +1,57 @@
+import { Check, Pencil, X } from "lucide-react"
+import { CustomTooltip } from "./custom-tooltip"
+import { Button } from "./button"
+
+interface EditActionButtonsProps {
+  isEditable: boolean
+  readOnly: boolean
+  onSave: () => void
+  onEdit: () => void
+  disabled?: boolean
+  disabledTooltip?: string
+}
+
+export function EditActionButtons({
+  isEditable,
+  readOnly,
+  onSave,
+  onEdit,
+  disabled = false,
+  disabledTooltip,
+}: EditActionButtonsProps) {
+  if (readOnly) return null
+
+  if (isEditable) {
+    return (
+      <div className="flex gap-1">
+        <CustomTooltip content="Save" side="left">
+          <Button
+            className="text-tw-primary hover:text-tw-primary"
+            onClick={onSave}
+            variant="secondary"
+          >
+            <Check />
+          </Button>
+        </CustomTooltip>
+        <CustomTooltip content="Cancel">
+          <Button onClick={onEdit} variant="destructiveGhost">
+            <X />
+          </Button>
+        </CustomTooltip>
+      </div>
+    )
+  }
+
+  return (
+    <CustomTooltip content={disabled && disabledTooltip ? disabledTooltip : "Edit"}>
+      <Button
+        className="mr-1"
+        disabled={disabled}
+        onClick={onEdit}
+        variant="ghost"
+      >
+        <Pencil />
+      </Button>
+    </CustomTooltip>
+  )
+}

--- a/apps/frontend/src/components/ui/info-chip.tsx
+++ b/apps/frontend/src/components/ui/info-chip.tsx
@@ -1,0 +1,31 @@
+import { CustomTooltip } from "./custom-tooltip"
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+interface InfoChipProps {
+  children: ReactNode
+  tooltip: string
+  showBorder?: boolean
+  className?: string
+}
+
+export function InfoChip({
+  children,
+  tooltip,
+  showBorder = true,
+  className,
+}: InfoChipProps) {
+  return (
+    <CustomTooltip content={tooltip}>
+      <span
+        className={cn(
+          "text-xs px-2 py-1 rounded-full text-tw-primary dark:text-white",
+          showBorder && "border-2 border-tw-primary",
+          className,
+        )}
+      >
+        {children}
+      </span>
+    </CustomTooltip>
+  )
+}


### PR DESCRIPTION
## Description

Include a summary of the change.
Build reusable primitives from key-details of different key types and refactor with these primitives
Replace custom TextArea and Inputs with primitives from the UI folder  

### Change Visualization

Include a screenshot/video of before and after the change.

https://github.com/user-attachments/assets/144b168e-5261-4ed8-a1c1-7f8dc03a21f5


