### PR TITLE
Limit key size fetched by key browser to 2KB

### DIFF
--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -11,6 +11,7 @@ import {
 import pLimit from "p-limit"
 import { VALKEY, VALKEY_CLIENT } from "../../../common/src/constants.ts"
 import { buildScanCommandArgs } from "./valkey-client-commands.ts"
+import { formatBytes } from "../../../common/src/bytes-conversion.ts"
 
 interface EnrichedKeyInfo {
   name: string;
@@ -64,7 +65,7 @@ export async function getKeyInfo(
           if (commands.sizeCmd){
             keyInfo.collectionSize = await (client.customCommand([commands.sizeCmd, key])) as number
           }
-          keyInfo.elements = `Keys above ${VALKEY_CLIENT.KEY_VALUE_SIZE_LIMIT / 1000}KB are not displayed in UI.`
+          keyInfo.elements = `This key is ${formatBytes(memoryUsage)}, which is larger than the maximum display size of ${formatBytes(VALKEY_CLIENT.KEY_VALUE_SIZE_LIMIT)}.`
 
           return keyInfo
         } 

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -130,7 +130,7 @@ export const VALKEY_CLIENT = {
     defaultPayloadPattern: "*",
     defaultCount: 50,
   } ,
-  KEY_VALUE_SIZE_LIMIT: 2000, // 2KB
+  KEY_VALUE_SIZE_LIMIT: 2048, // 2KiB
 }
 export const COMMANDLOG_TYPE = {
   SLOW: "slow",


### PR DESCRIPTION
## Description

For keys with size >2KB, do not fetch their value in key browser, instead, return a message stating that keys above 2KB are not displayed in the UI.

### Change Visualization

<img width="1202" height="806" alt="image" src="https://github.com/user-attachments/assets/fcd80e58-5415-4e3e-ba3d-2407a0c26a15" />


