### PR TITLE
Fix large keys crashing non-string keys from display in key browser

### DIFF
--- a/apps/frontend/src/components/key-browser/key-details/key-details.tsx
+++ b/apps/frontend/src/components/key-browser/key-details/key-details.tsx
@@ -23,6 +23,7 @@ interface BaseKeyInfo {
   ttl: number;
   size: number;
   collectionSize?: number;
+  elementsWarning?: string;
 }
 
 interface ElementInfo {
@@ -155,68 +156,76 @@ export default function KeyDetails({ selectedKey, selectedKeyInfo, connectionId,
               </div>
             </div>
 
-            {/* show different key types */}
-            {selectedKeyInfo.type === "string" && (
-              <KeyDetailsString
-                connectionId={connectionId}
-                readOnly={readOnly}
-                selectedKey={selectedKey}
-                selectedKeyInfo={selectedKeyInfo}
-              />
-            )}
+            {selectedKeyInfo.elementsWarning ? (
+              <div className="text-center text-muted-foreground py-8">
+                <Typography variant="bodySm">{selectedKeyInfo.elementsWarning}</Typography>
+              </div>
+            ) : (
+              <>
+                {/* show different key types */}
+                {selectedKeyInfo.type === "string" && (
+                  <KeyDetailsString
+                    connectionId={connectionId}
+                    readOnly={readOnly}
+                    selectedKey={selectedKey}
+                    selectedKeyInfo={selectedKeyInfo}
+                  />
+                )}
 
-            {selectedKeyInfo.type === "hash" && (
-              <KeyDetailsHash
-                connectionId={connectionId}
-                readOnly={readOnly}
-                selectedKey={selectedKey}
-                selectedKeyInfo={selectedKeyInfo}
-              />
-            )}
+                {selectedKeyInfo.type === "hash" && (
+                  <KeyDetailsHash
+                    connectionId={connectionId}
+                    readOnly={readOnly}
+                    selectedKey={selectedKey}
+                    selectedKeyInfo={selectedKeyInfo}
+                  />
+                )}
 
-            {selectedKeyInfo.type === "list" && (
-              <KeyDetailsList
-                connectionId={connectionId}
-                readOnly={readOnly}
-                selectedKey={selectedKey}
-                selectedKeyInfo={selectedKeyInfo}
-              />
-            )}
+                {selectedKeyInfo.type === "list" && (
+                  <KeyDetailsList
+                    connectionId={connectionId}
+                    readOnly={readOnly}
+                    selectedKey={selectedKey}
+                    selectedKeyInfo={selectedKeyInfo}
+                  />
+                )}
 
-            {selectedKeyInfo.type === "set" && (
-              <KeyDetailsSet
-                connectionId={connectionId}
-                readOnly={readOnly}
-                selectedKey={selectedKey}
-                selectedKeyInfo={selectedKeyInfo}
-              />
-            )}
+                {selectedKeyInfo.type === "set" && (
+                  <KeyDetailsSet
+                    connectionId={connectionId}
+                    readOnly={readOnly}
+                    selectedKey={selectedKey}
+                    selectedKeyInfo={selectedKeyInfo}
+                  />
+                )}
 
-            {selectedKeyInfo.type === "zset" && (
-              <KeyDetailsZSet
-                connectionId={connectionId}
-                readOnly={readOnly}
-                selectedKey={selectedKey}
-                selectedKeyInfo={selectedKeyInfo}
-              />
-            )}
+                {selectedKeyInfo.type === "zset" && (
+                  <KeyDetailsZSet
+                    connectionId={connectionId}
+                    readOnly={readOnly}
+                    selectedKey={selectedKey}
+                    selectedKeyInfo={selectedKeyInfo}
+                  />
+                )}
 
-            {selectedKeyInfo.type === "stream" && (
-              <KeyDetailsStream
-                connectionId={connectionId}
-                readOnly={readOnly}
-                selectedKey={selectedKey}
-                selectedKeyInfo={selectedKeyInfo}
-              />
-            )}
+                {selectedKeyInfo.type === "stream" && (
+                  <KeyDetailsStream
+                    connectionId={connectionId}
+                    readOnly={readOnly}
+                    selectedKey={selectedKey}
+                    selectedKeyInfo={selectedKeyInfo}
+                  />
+                )}
 
-            {selectedKeyInfo.type === "ReJSON-RL" && (
-              <KeyDetailsJson
-                connectionId={connectionId}
-                readOnly={readOnly}
-                selectedKey={selectedKey}
-                selectedKeyInfo={selectedKeyInfo}
-              />
+                {selectedKeyInfo.type === "ReJSON-RL" && (
+                  <KeyDetailsJson
+                    connectionId={connectionId}
+                    readOnly={readOnly}
+                    selectedKey={selectedKey}
+                    selectedKeyInfo={selectedKeyInfo}
+                  />
+                )}
+              </>
             )}
           </div>
         ) : (

--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -21,6 +21,7 @@ interface EnrichedKeyInfo {
   collectionSize?: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   elements?: any; // this can be array, object, or string depending on the key type.
+  elementsWarning?: string; // alternative for elements when they cannot be displayed.
 }
 
 async function getScanKeyInfo(
@@ -147,7 +148,7 @@ export async function getKeyInfo(
       if (commands.sizeCmd){
         keyInfo.collectionSize = await (client.customCommand([commands.sizeCmd, key])) as number
       }
-      keyInfo.elements = `This key is ${formatBytes(memoryUsage)}, which is larger than the maximum display size of ${formatBytes(VALKEY_CLIENT.KEY_VALUE_SIZE_LIMIT)}.`
+      keyInfo.elementsWarning = `This key is ${formatBytes(memoryUsage)}, which is larger than the maximum display size of ${formatBytes(VALKEY_CLIENT.KEY_VALUE_SIZE_LIMIT)}.`
 
       return keyInfo
     }


### PR DESCRIPTION
## Description

Adds alternative elementsWarning that acts as the alternative to elements. This single string is displayed if there's a reason why elements cannot be populated. Currently only occurs if size is larger than threshold.

### Change Visualization

<img width="1208" height="805" alt="image" src="https://github.com/user-attachments/assets/beb87dde-d28b-40e1-9724-1c3e013030a8" />

