### PR TITLE
fix: enable cluster shard/node switching and improve dropdown usability

### DIFF
--- a/apps/frontend/src/components/cluster-topology/cluster-node.tsx
+++ b/apps/frontend/src/components/cluster-topology/cluster-node.tsx
@@ -43,8 +43,8 @@ export function ClusterNode({
       const connectionDetails: ConnectionDetails = {
         host: primary.host,
         port: primary.port.toString(),
-        ...(primary.username && primary.password && {
-          username: primary.username,
+        ...(primary.password && {
+          username: primary.username ?? "",
           password: await secureStorage.encrypt(primary.password),
         }),
         tls: primary.tls,

--- a/apps/frontend/src/components/ui/app-header.tsx
+++ b/apps/frontend/src/components/ui/app-header.tsx
@@ -19,9 +19,11 @@ type AppHeaderProps = {
 function AppHeader({ title, icon, className }: AppHeaderProps) {
   const [isOpen, setIsOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const badgeRef = useRef<HTMLDivElement>(null)
   const navigate = useNavigate()
   const { id, clusterId } = useParams<{ id: string; clusterId: string }>()
-  const { host, port, username, alias } = useSelector(selectConnectionDetails(id!))
+  const connectionDetails = useSelector(selectConnectionDetails(id!)) ?? {} as Partial<ReturnType<ReturnType<typeof selectConnectionDetails>>>
+  const { host, port, username, alias } = connectionDetails as { host?: string; port?: string; username?: string; alias?: string }
   const clusterData = useSelector(selectCluster(clusterId!))
   const ToggleIcon = isOpen ? CircleChevronUp : CircleChevronDown
 
@@ -34,6 +36,14 @@ function AppHeader({ title, icon, className }: AppHeaderProps) {
     state.valkeyConnection?.connections,
   )
 
+  // For cluster mode, consider connected if any node in the cluster is connected
+  const isClusterConnected = clusterId
+    ? Object.values(allConnections ?? {}).some(
+      (conn) => conn.connectionDetails.clusterId === clusterId && conn.status === CONNECTED,
+    )
+    : isConnected
+  const effectiveConnected = isConnected || isClusterConnected
+
   const handleNavigate = (primaryKey: string) => {
     navigate(`/${clusterId}/${primaryKey}/dashboard`)
     setIsOpen(false)
@@ -42,7 +52,10 @@ function AppHeader({ title, icon, className }: AppHeaderProps) {
   // for closing the dropdown when we click anywhere in screen
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current && !dropdownRef.current.contains(event.target as Node) &&
+        badgeRef.current && !badgeRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false)
       }
     }
@@ -75,7 +88,12 @@ function AppHeader({ title, icon, className }: AppHeaderProps) {
           </Typography>
           <div>
             <Badge
-              className="h-5 w-auto text-nowrap px-2 py-4 flex items-center gap-2 justify-between cursor-pointer"
+              className={cn(
+                "h-5 w-auto text-nowrap px-2 py-4 flex items-center gap-2 justify-between",
+                effectiveConnected ? "cursor-pointer" : "cursor-not-allowed",
+              )}
+              onClick={() => effectiveConnected && setIsOpen(!isOpen)}
+              ref={badgeRef}
               variant="default"
             >
               <div className="flex flex-col gap-1">
@@ -83,33 +101,30 @@ function AppHeader({ title, icon, className }: AppHeaderProps) {
                   className="flex items-center"
                   variant="bodySm"
                 >
-                  <Dot className={isConnected ? "text-green-500" : "text-gray-400"} size={45} />
+                  <Dot className={effectiveConnected ? "text-green-500" : "text-gray-400"} size={45} />
                   {id}
                 </Typography>
               </div>
-              <button aria-label="Toggle dropdown" disabled={!isConnected} onClick={() => isConnected && setIsOpen(!isOpen)}>
-                <ToggleIcon
-                  className={isConnected
-                    ? "text-primary cursor-pointer hover:text-primary/80"
-                    : "text-gray-400 cursor-not-allowed"
-                  }
-                  size={18}
-                />
-              </button>
+              <ToggleIcon
+                className={effectiveConnected
+                  ? "text-primary hover:text-primary/80"
+                  : "text-gray-400"
+                }
+                size={18}
+              />
             </Badge>
             {isOpen && (
               <div className="p-4 w-auto text-nowrap py-3 border bg-gray-50 dark:bg-gray-800 text-sm dark:border-tw-dark-border
                 rounded z-100 absolute top-10 right-0" ref={dropdownRef}>
                 <ul className="space-y-2">
                   {Object.entries(clusterData.clusterNodes).map(([primaryKey, primary]) => {
-                    const nodeIsConnected = allConnections?.[primaryKey]?.status === CONNECTED
+                    const isCurrentNode = primaryKey === id
 
                     return (
                       <li className="flex flex-col gap-1" key={primaryKey}>
-                        <button className="flex items-center cursor-pointer hover:bg-primary/20"
-                          disabled={!nodeIsConnected}
+                        <button className={`flex items-center cursor-pointer hover:bg-primary/20 ${isCurrentNode ? "bg-primary/10" : ""}`}
                           onClick={() => handleNavigate(primaryKey)}>
-                          <Dot className={nodeIsConnected ? "text-green-500" : "text-gray-400"} size={45} />
+                          <Dot className={isCurrentNode ? "text-green-500" : "text-primary"} size={45} />
                           <Typography variant="bodySm">
                             {`${primary.host}:${primary.port}`}
                           </Typography>

--- a/apps/frontend/src/hooks/useIsConnected.ts
+++ b/apps/frontend/src/hooks/useIsConnected.ts
@@ -1,12 +1,21 @@
 import { useSelector } from "react-redux"
 import { useParams } from "react-router"
 import { CONNECTED } from "@common/src/constants.ts"
-import { selectStatus } from "@/state/valkey-features/connection/connectionSelectors.ts"
+import { selectStatus, selectConnections } from "@/state/valkey-features/connection/connectionSelectors.ts"
 
 const useIsConnected = (): boolean => {
-  const { id } = useParams<{ id: string }>()
+  const { id, clusterId } = useParams<{ id: string; clusterId: string }>()
   const status = useSelector(selectStatus(id!))
-  return status === CONNECTED 
+  const connections = useSelector(selectConnections)
+
+  // For cluster routes, consider connected if ANY node in the same cluster is connected
+  if (clusterId && status !== CONNECTED) {
+    return Object.values(connections).some(
+      (conn) => conn.connectionDetails.clusterId === clusterId && conn.status === CONNECTED,
+    )
+  }
+
+  return status === CONNECTED
 }
 
 export default useIsConnected

--- a/apps/server/src/actions/cluster.ts
+++ b/apps/server/src/actions/cluster.ts
@@ -1,10 +1,11 @@
 import { GlideClusterClient } from "@valkey/valkey-glide"
 import { type Deps, withDeps } from "./utils"
 import { setClusterDashboardData } from "../set-dashboard-data"
+import { resolveClient } from "../utils"
 
 export const setClusterData = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, action }) => {
-    const connection = clients.get(connectionId)
+  async ({ ws, clients, connectionId, clusterNodesMap, action }) => {
+    const connection = resolveClient(connectionId, clients, clusterNodesMap)
 
     if (connection && connection.client instanceof GlideClusterClient) {
       const { clusterId } = action.payload 

--- a/apps/server/src/actions/command.ts
+++ b/apps/server/src/actions/command.ts
@@ -1,6 +1,7 @@
 import { VALKEY } from "valkey-common"
 import { sendValkeyRunCommand } from "../send-command"
 import { type Deps, withDeps } from "./utils"
+import { resolveClient } from "../utils"
 
 type CommandAction = {
   command: string
@@ -8,8 +9,8 @@ type CommandAction = {
 }
 
 export const sendRequested = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, action }) => {
-    const connection = clients.get(connectionId!)
+  async ({ ws, clients, connectionId, clusterNodesMap, action }) => {
+    const connection = resolveClient(connectionId, clients, clusterNodesMap)
 
     if (connection) {
       await sendValkeyRunCommand(connection.client, ws, action.payload as CommandAction)

--- a/apps/server/src/actions/keys.ts
+++ b/apps/server/src/actions/keys.ts
@@ -1,6 +1,7 @@
 import { VALKEY } from "valkey-common"
 import { addKey, deleteKey, getKeyInfoSingle, getKeys, updateKey } from "../keys-browser"
 import { type Deps, withDeps } from "./utils"
+import { resolveClient } from "../utils"
 
 type GetKeysPayload = {
   connectionId: string;
@@ -9,8 +10,8 @@ type GetKeysPayload = {
 }
 
 export const getKeysRequested = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, action }) => {
-    const connection = clients.get(connectionId)
+  async ({ ws, clients, connectionId, clusterNodesMap, action }) => {
+    const connection = resolveClient(connectionId, clients, clusterNodesMap)
 
     if (connection) {
       await getKeys(connection.client, ws, action.payload as GetKeysPayload)
@@ -34,11 +35,11 @@ interface KeyPayload {
 }
 
 export const getKeyTypeRequested = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, action }) => {
+  async ({ ws, clients, connectionId, clusterNodesMap, action }) => {
     const { key } = action.payload as unknown as KeyPayload
 
     console.debug("Handling getKeyTypeRequested for key:", key)
-    const connection = clients.get(connectionId)
+    const connection = resolveClient(connectionId, clients, clusterNodesMap)
 
     if (connection) {
       await getKeyInfoSingle(connection.client, ws, action.payload as unknown as KeyPayload)
@@ -59,11 +60,11 @@ export const getKeyTypeRequested = withDeps<Deps, void>(
 )
 
 export const deleteKeyRequested = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, action }) => {
+  async ({ ws, clients, connectionId, clusterNodesMap, action }) => {
     const { key } = action.payload as unknown as KeyPayload
 
     console.debug("Handling deleteKeyRequested for key:", key)
-    const connection = clients.get(connectionId)
+    const connection = resolveClient(connectionId, clients, clusterNodesMap)
 
     if (connection) {
       await deleteKey(connection.client, ws, action.payload as unknown as KeyPayload)
@@ -97,11 +98,11 @@ interface AddKeyRequestedPayload extends KeyPayload {
 }
 
 export const addKeyRequested = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, action }) => {
+  async ({ ws, clients, connectionId, clusterNodesMap, action }) => {
     const { key } = action.payload as unknown as KeyPayload
 
     console.debug("Handling addKeyRequested for key:", key)
-    const connection = clients.get(connectionId)
+    const connection = resolveClient(connectionId, clients, clusterNodesMap)
     if (connection) {
       await addKey(connection.client, ws, action.payload as unknown as AddKeyRequestedPayload)
     } else {
@@ -121,11 +122,11 @@ export const addKeyRequested = withDeps<Deps, void>(
 )
 
 export const updateKeyRequested = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, action }) => {
+  async ({ ws, clients, connectionId, clusterNodesMap, action }) => {
     const { key } = action.payload as unknown as KeyPayload
 
     console.debug("Handling updateKeyRequested for key:", key)
-    const connection = clients.get(connectionId)
+    const connection = resolveClient(connectionId, clients, clusterNodesMap)
     if (connection) {
       await updateKey(connection.client, ws, action.payload as unknown as AddKeyRequestedPayload)
     } else {

--- a/apps/server/src/actions/stats.ts
+++ b/apps/server/src/actions/stats.ts
@@ -1,10 +1,11 @@
 import { GlideClient, GlideClusterClient } from "@valkey/valkey-glide"
 import { type Deps, withDeps } from "./utils"
 import { setDashboardData } from "../set-dashboard-data"
+import { resolveClient } from "../utils"
 
 export const setData = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, action }) => {
-    const connection = clients.get(connectionId)
+  async ({ ws, clients, connectionId, clusterNodesMap, action }) => {
+    const connection = resolveClient(connectionId, clients, clusterNodesMap)
     const { address } = action.payload
     await setDashboardData(connectionId, connection?.client as GlideClient | GlideClusterClient, ws, address as {host: string, port: number} )
   },

--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -141,3 +141,29 @@ export async function isLastConnectedClusterNode(
   const currentClusterId = connection?.clusterId
   return clusterNodesMap.get(currentClusterId!)?.length === 1
 }
+
+/**
+ * Resolve the Glide client for a connectionId. Falls back to the cluster client
+ * when the requested node wasn't individually connected (e.g. switching shards
+ * in the header dropdown).
+ */
+export function resolveClient(
+  connectionId: string,
+  clients: Map<string, { client: GlideClient | GlideClusterClient; clusterId?: string }>,
+  clusterNodesMap: Map<string, string[]>,
+): { client: GlideClient | GlideClusterClient; clusterId?: string } | undefined {
+  const direct = clients.get(connectionId)
+  if (direct) return direct
+
+  // Find a cluster that contains a connected node sharing the same cluster
+  for (const [clusterId, nodeIds] of clusterNodesMap.entries()) {
+    const connectedPeer = nodeIds.find((nid) => clients.has(nid))
+    if (connectedPeer) {
+      const peer = clients.get(connectedPeer)!
+      if (peer.client instanceof GlideClusterClient) {
+        return { client: peer.client, clusterId }
+      }
+    }
+  }
+  return undefined
+}

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -16,6 +16,9 @@ RUN npm run build:all
 # -------- Production Runtime --------
 FROM node:22-bookworm-slim
 
+# Install CA certificates for TLS connections to ElastiCache
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary

Fixes the inability to switch between Valkey cluster shards/nodes when connected to a cluster environment (e.g., ElastiCache with 6 shards, 18 nodes). Also includes credential fix from #252 and a dropdown usability improvement.

## Bug Fixes

### 1. Cluster node switching disabled in header dropdown (`app-header.tsx`)

**Root cause:** The dropdown iterated over all cluster nodes discovered via `CLUSTER SLOTS`, but checked `allConnections[primaryKey].status === CONNECTED` per node. Since only the entry node gets `CONNECTED` status in the Redux store, all other shard buttons were `disabled`.

**Fix:** Removed per-node disabled check. All nodes in the dropdown are now clickable when any node in the cluster is connected. Added `isCurrentNode` highlighting and cluster-wide `effectiveConnected` check for the toggle button.

### 2. Route guard redirecting to `/connect` on shard switch (`useIsConnected.ts`)

**Root cause:** `RequireConnection` → `useIsConnected` checked `selectStatus(id)` for the specific node in the URL. When navigating to a different shard, that node's status was `Not Connected`, causing a redirect.

**Fix:** For cluster routes (when `clusterId` is present), check if ANY node in the same cluster is connected, not just the specific `:id` node.

### 3. Server-side client lookup failure for non-entry nodes (`utils.ts`, action handlers)

**Root cause:** `clients.get(connectionId)` returned `undefined` for shard nodes that weren't the original entry point, because only the entry node's connectionId is stored in the server's `clients` map. The `GlideClusterClient` can route to any node, but the lookup failed.

**Fix:** Added `resolveClient()` utility that falls back to finding the cluster client via `clusterNodesMap` when direct lookup fails. Updated `stats.ts`, `keys.ts`, `cluster.ts`, and `command.ts` handlers to use it.

### 4. Crash when navigating to undiscovered shard (`app-header.tsx`)

**Root cause:** `selectConnectionDetails(id!)` returned `undefined` for nodes that had no entry in `valkeyConnection` state (e.g., shard 6 never individually connected), causing destructuring to throw.

**Fix:** Added safe fallback: `?? {}` with proper type casting.

### 5. Credential passing for empty username (from #252) (`cluster-node.tsx`)

**Root cause:** `primary.username && primary.password` short-circuits to `false` when username is `""` (e.g., ElastiCache `default` user), dropping both credentials and causing NOAUTH errors.

**Fix:** Gate only on `primary.password` and default username to `primary.username ?? ""`.

### 6. Missing CA certificates for TLS (`Dockerfile.app`)

**Fix:** Install `ca-certificates` in the production runtime image for TLS connections to ElastiCache.

## UX Enhancement

### 7. Dropdown triggered by entire badge, not just chevron icon (`app-header.tsx`)

**Problem:** The node switcher dropdown could only be opened by clicking the tiny chevron icon — the node name text was not clickable.

**Fix:** Moved `onClick` handler to the `Badge` component so the entire area (text + icon) toggles the dropdown. Added `badgeRef` to the outside-click handler to prevent mousedown/click event conflicts.

## Files Changed

| File | Change |
|------|--------|
| `apps/frontend/src/hooks/useIsConnected.ts` | Cluster-aware connection check |
| `apps/frontend/src/components/ui/app-header.tsx` | Dropdown fixes + usability |
| `apps/frontend/src/components/cluster-topology/cluster-node.tsx` | Credential fix |
| `apps/server/src/utils.ts` | `resolveClient()` helper |
| `apps/server/src/actions/stats.ts` | Use `resolveClient` |
| `apps/server/src/actions/keys.ts` | Use `resolveClient` |
| `apps/server/src/actions/cluster.ts` | Use `resolveClient` |
| `apps/server/src/actions/command.ts` | Use `resolveClient` |
| `docker/Dockerfile.app` | Add ca-certificates |

## Testing

Tested against a live ElastiCache Valkey cluster (6 shards, 2 replicas per shard, TLS enabled):
- ✅ Connect to cluster via single node
- ✅ Switch between all 6 shard primaries via header dropdown
- ✅ Switch to shard with no prior connection history
- ✅ Dropdown toggles on text click (not just icon)
- ✅ No console errors on any navigation
- ✅ Dashboard loads correct per-shard data after switch