### PR TITLE
fix monitorEnabled for getHotKeysEpic

### DIFF
--- a/apps/frontend/src/state/epics/valkeyEpics.ts
+++ b/apps/frontend/src/state/epics/valkeyEpics.ts
@@ -31,7 +31,7 @@ import { setClusterData } from "../valkey-features/cluster/clusterSlice.ts"
 import { setConfig, updateConfig, updateConfigFulfilled } from "../valkey-features/config/configSlice.ts"
 import { cpuUsageRequested } from "../valkey-features/cpu/cpuSlice.ts"
 import { memoryUsageRequested } from "../valkey-features/memory/memorySlice.ts"
-import { monitorRequested, saveMonitorSettingsRequested } from "../valkey-features/monitor/monitorSlice.ts"
+import { monitorRequested, saveMonitorSettingsRequested, selectMonitorRunning } from "../valkey-features/monitor/monitorSlice.ts"
 import { secureStorage } from "../../utils/secureStorage.ts"
 import { selectIsAtConnectionLimit } from "../valkey-features/connection/connectionSelectors.ts"
 import type { Store } from "@reduxjs/toolkit"
@@ -363,7 +363,7 @@ export const getHotKeysEpic = (store: Store) =>
       const socket = getSocket()
       const state = store.getState()
       const connection = state.valkeyConnection.connections[connectionId]
-      const monitorEnabled = state.config[connectionId].monitoring.monitorEnabled
+      const monitorEnabled = selectMonitorRunning(connectionId)(state)
       const lfuEnabled = connection.connectionDetails.keyEvictionPolicy?.includes("lfu") ?? false
       const clusterSlotStatsEnabled = connection.connectionDetails.clusterSlotStatsEnabled ?? false
 

--- a/apps/metrics/src/handlers/monitor-handler.js
+++ b/apps/metrics/src/handlers/monitor-handler.js
@@ -1,5 +1,5 @@
 import { getCollectorMeta } from "../init-collectors.js"
-import { ACTION, MONITOR, MODE } from "../utils/constants.js"
+import { ACTION, MONITOR } from "../utils/constants.js"
 import { calculateHotKeysFromMonitor } from "../analyzers/calculate-hot-keys.js"
 import { startMonitor, stopMonitor } from "../init-collectors.js"
 import { enrichHotKeys } from "../analyzers/enrich-hot-keys.js"
@@ -10,21 +10,15 @@ const toResponse = ({ isRunning, willCompleteAt }) => ({
   checkAt: willCompleteAt,
 })
 
-export const useMonitor = async (req, res, cfg, client) => {
-  let monitorResponse = {}
+export const useMonitor = async (res, client) => {
   const { isRunning, willCompleteAt: checkAt } = getCollectorMeta(MONITOR) 
   try {
     if (!isRunning) {
-      monitorResponse = await monitorHandler(ACTION.START, cfg)
-      return res.json(monitorResponse)
+      return res.status(400).json({ error: "Monitor is not running" })
     }
     if (Date.now() > checkAt) {
       const hotKeys = await Streamer.monitor().then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
-      if (req.query.mode !== MODE.CONTINUOUS) {
-        await monitorHandler(ACTION.STOP, cfg) 
-      }
-      monitorResponse = await monitorHandler(ACTION.STATUS, cfg)
-      return res.json({ hotKeys, ...monitorResponse })
+      return res.json({ hotKeys, ...toResponse(getCollectorMeta(MONITOR)) })
     }
     return res.json({ checkAt })
   } catch (e) {

--- a/apps/metrics/src/index.js
+++ b/apps/metrics/src/index.js
@@ -80,7 +80,7 @@ async function main() {
       const hotKeys = await calculateHotKeysFromHotSlots(client, req.query.count).then(enrichHotKeys(client))
       return res.json({ hotKeys })
     }
-    else useMonitor(req, res, getConfig(), client)
+    else useMonitor(res, client)
   })
 
   app.post("/update-config", async (req, res) => {

--- a/apps/metrics/src/init-collectors.js
+++ b/apps/metrics/src/init-collectors.js
@@ -73,6 +73,7 @@ const startMonitor = (cfg) => {
     next: (logs) => {
       updateCollectorMeta(monitorEpic.name, {
         lastUpdatedAt: Date.now(),
+        willCompleteAt: Date.now() + monitorEpic.monitoringDuration,
       })
       console.debug(`[${monitorEpic.name}] monitor cycle complete (${logs.length} logs)`)
     },

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -68,8 +68,13 @@ export const hotKeysRequested = withDeps<Deps, void>(
       try {
         console.debug("[Hot keys] Fetching from:", url.href)
         const initialResponse = await fetch(url)
+        if (!initialResponse.ok) {
+          const errorBody = await initialResponse.json() as { error?: string }
+          sendHotKeysError(ws, connectionId, errorBody.error ?? `HTTP ${initialResponse.status}`)
+          return
+        }
         const initialParsedResponse: HotKeysResponse = await initialResponse.json() as HotKeysResponse
-        // Initial request starts monitoring and returns when to fetch results (`checkAt`).
+        // Reads monitor data and returns when to fetch results (`checkAt`).
         if (initialParsedResponse.checkAt) {
           const delay = initialParsedResponse.checkAt - Date.now()
           // Schedule the follow-up request for when the monitor cycle finishes


### PR DESCRIPTION
## Description

This PR changes 3 things with monitor with relation to hotKeys:

- Hot Keys checks if monitor is enabled as a fallback to get the hot keys. However, it accesses a value that doesn't exist. This fix replaces that with the exported function selectMonitorRunning().
- Previously useMonitor (used by hotKeys) starts and stops the monitor. Monitor's lifecycle should be controlled purely by the monitor endpoint. This fix changes useMonitor to purely return monitor data.
- willCompleteAt within the monitor response was not being updated based on cycles. i.e. it was set in the first run to be Date.now() + monitoring duration, then never updated again. This fix updates willCompleteAt for each cycle.

