### PR TITLE
Fix bug with cluster connect and prompted connection

### DIFF
--- a/apps/frontend/src/components/connection/Connection.tsx
+++ b/apps/frontend/src/components/connection/Connection.tsx
@@ -57,7 +57,7 @@ export function Connection() {
 
   const promptedConnection = connections[passwordPromptConnectionId as string]
   const isPromptConnecting = promptedConnection?.status === CONNECTING
-  const promptErrorMessage = promptedConnection.errorMessage
+  const promptErrorMessage = promptedConnection?.errorMessage
   const promptConnectionLabel = promptedConnection
     ? promptedConnection.connectionDetails.alias
       || `${promptedConnection.connectionDetails.host}:${promptedConnection.connectionDetails.port}`

--- a/apps/frontend/src/state/valkey-features/connection/connectionSlice.ts
+++ b/apps/frontend/src/state/valkey-features/connection/connectionSlice.ts
@@ -152,7 +152,7 @@ const connectionSlice = createSlice({
     clusterConnectFulfilled: (state, action) => {
       const { 
         connectionId, 
-        connectedNode, 
+        address, 
         connectionDetails } = action.payload
       const { clusterId, keyEvictionPolicy, clusterSlotStatsEnabled, jsonModuleAvailable } = connectionDetails
 
@@ -163,7 +163,7 @@ const connectionSlice = createSlice({
       connectionState.connectionDetails.keyEvictionPolicy = keyEvictionPolicy
       connectionState.connectionDetails.clusterSlotStatsEnabled = clusterSlotStatsEnabled
       connectionState.connectionDetails.jsonModuleAvailable = jsonModuleAvailable
-      if (connectedNode) connectionState.connectedNode = connectedNode
+      if (address) connectionState.connectedNode = address
       delete connectionState.reconnect
       connectionState.connectionHistory ??= []
       connectionState.connectionHistory.push({ timestamp: Date.now(), event: CONNECTED })

--- a/apps/frontend/src/state/valkey-features/connection/connectionSlice.ts
+++ b/apps/frontend/src/state/valkey-features/connection/connectionSlice.ts
@@ -152,7 +152,7 @@ const connectionSlice = createSlice({
     clusterConnectFulfilled: (state, action) => {
       const { 
         connectionId, 
-        address, 
+        connectedNode, 
         connectionDetails } = action.payload
       const { clusterId, keyEvictionPolicy, clusterSlotStatsEnabled, jsonModuleAvailable } = connectionDetails
 
@@ -163,7 +163,7 @@ const connectionSlice = createSlice({
       connectionState.connectionDetails.keyEvictionPolicy = keyEvictionPolicy
       connectionState.connectionDetails.clusterSlotStatsEnabled = clusterSlotStatsEnabled
       connectionState.connectionDetails.jsonModuleAvailable = jsonModuleAvailable
-      if (address) connectionState.connectedNode = address
+      if (connectedNode) connectionState.connectedNode = connectedNode
       delete connectionState.reconnect
       connectionState.connectionHistory ??= []
       connectionState.connectionHistory.push({ timestamp: Date.now(), event: CONNECTED })

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -316,6 +316,7 @@ export async function connectToCluster(
           payload: {
             connectionId,
             connectedNode: addresses[0],
+            address: addresses[0],
             connectionDetails: {
               clusterId,
               keyEvictionPolicy,

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -310,24 +310,8 @@ export async function connectToCluster(
       if (!clusterNodesMap.get(clusterId)?.includes(nodeConnectionId)) clusterNodesMap.get(clusterId)?.push(nodeConnectionId)
       if (!metricsServerMap.has(connectionId)) await startMetricsServer(payload.connectionDetails, connectionId)
       // Add connectedNode to payload 
-      ws.send(
-        JSON.stringify({
-          type: VALKEY.CONNECTION.clusterConnectFulfilled,
-          payload: {
-            connectionId,
-            connectedNode: addresses[0],
-            address: addresses[0],
-            connectionDetails: {
-              clusterId,
-              keyEvictionPolicy,
-              clusterSlotStatsEnabled,
-              jsonModuleAvailable,
-            },
-          },
-        }),
-      )
-      return clusterClient
     }
+    
     ws.send(
       JSON.stringify({
         type: VALKEY.CONNECTION.clusterConnectFulfilled,

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -338,6 +338,7 @@ export async function connectToCluster(
             clusterSlotStatsEnabled,
             jsonModuleAvailable,
           },
+          address: addresses[0],
         },
       }),
     )

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -310,8 +310,24 @@ export async function connectToCluster(
       if (!clusterNodesMap.get(clusterId)?.includes(nodeConnectionId)) clusterNodesMap.get(clusterId)?.push(nodeConnectionId)
       if (!metricsServerMap.has(connectionId)) await startMetricsServer(payload.connectionDetails, connectionId)
       // Add connectedNode to payload 
+      ws.send(
+        JSON.stringify({
+          type: VALKEY.CONNECTION.clusterConnectFulfilled,
+          payload: {
+            connectionId,
+            connectedNode: addresses[0],
+            address: addresses[0],
+            connectionDetails: {
+              clusterId,
+              keyEvictionPolicy,
+              clusterSlotStatsEnabled,
+              jsonModuleAvailable,
+            },
+          },
+        }),
+      )
+      return clusterClient
     }
-    
     ws.send(
       JSON.stringify({
         type: VALKEY.CONNECTION.clusterConnectFulfilled,


### PR DESCRIPTION
## Description

Since address was not included in clusterConnectFulfilled, the app was not able to set dashboard data for clusters. In addition, prompted connection is not always defined, so the app threw an error when it tries to access promptedConnection.errorMessage in Connection.tsx.

