### PR TITLE
 Aggregate hot keys across cluster nodes

### DIFF
--- a/apps/frontend/src/components/monitoring/Monitoring.tsx
+++ b/apps/frontend/src/components/monitoring/Monitoring.tsx
@@ -17,7 +17,7 @@ import { Button } from "../ui/button"
 import type { RootState } from "@/store"
 import { commandLogsRequested, selectCommandLogs } from "@/state/valkey-features/commandlogs/commandLogsSlice"
 import { useAppDispatch } from "@/hooks/hooks"
-import { hotKeysRequested, selectHotKeys, selectHotKeysStatus, selectHotKeysError } from "@/state/valkey-features/hotkeys/hotKeysSlice"
+import { hotKeysRequested, selectHotKeys, selectHotKeysStatus, selectHotKeysError, selectHotKeysNodeErrors } from "@/state/valkey-features/hotkeys/hotKeysSlice"
 import { selectMonitorRunning } from "@/state/valkey-features/monitor/monitorSlice"
 import { getKeyTypeRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
 import { selectKeys } from "@/state/valkey-features/keys/keyBrowserSelectors"
@@ -50,6 +50,7 @@ export const Monitoring = () => {
   const hotKeysData = useSelector((state: RootState) => selectHotKeys(hotKeysId)(state))
   const hotKeysStatus = useSelector((state: RootState) => selectHotKeysStatus(hotKeysId)(state))
   const hotKeysErrorMessage = useSelector((state: RootState) => selectHotKeysError(hotKeysId)(state))
+  const hotKeysNodeErrors = useSelector((state: RootState) => selectHotKeysNodeErrors(hotKeysId)(state))
   const monitorRunning = useSelector(selectMonitorRunning(id!))
   const keys: KeyInfo[] = useSelector(selectKeys(id!))
 
@@ -187,6 +188,7 @@ export const Monitoring = () => {
                 data={hotKeysData}
                 errorMessage={hotKeysErrorMessage as string | null}
                 monitorRunning={monitorRunning}
+                nodeErrors={hotKeysNodeErrors}
                 onKeyClick={handleKeyClick}
                 onStartMonitoring={() => setConfigOpen(true)}
                 selectedKey={selectedKey}

--- a/apps/frontend/src/components/monitoring/Monitoring.tsx
+++ b/apps/frontend/src/components/monitoring/Monitoring.tsx
@@ -46,9 +46,10 @@ export const Monitoring = () => {
   const commandLogsSlowData = useSelector((state: RootState) => selectCommandLogs(id!, COMMANDLOG_TYPE.SLOW)(state))
   const commandLogsLargeRequestData = useSelector((state: RootState) => selectCommandLogs(id!, COMMANDLOG_TYPE.LARGE_REQUEST)(state))
   const commandLogsLargeReplyData = useSelector((state: RootState) => selectCommandLogs(id!, COMMANDLOG_TYPE.LARGE_REPLY)(state))
-  const hotKeysData = useSelector((state: RootState) => selectHotKeys(id!)(state))
-  const hotKeysStatus = useSelector((state: RootState) => selectHotKeysStatus(id!)(state))
-  const hotKeysErrorMessage = useSelector((state: RootState) => selectHotKeysError(id!)(state))
+  const hotKeysId = clusterId ?? id!
+  const hotKeysData = useSelector((state: RootState) => selectHotKeys(hotKeysId)(state))
+  const hotKeysStatus = useSelector((state: RootState) => selectHotKeysStatus(hotKeysId)(state))
+  const hotKeysErrorMessage = useSelector((state: RootState) => selectHotKeysError(hotKeysId)(state))
   const monitorRunning = useSelector(selectMonitorRunning(id!))
   const keys: KeyInfo[] = useSelector(selectKeys(id!))
 

--- a/apps/frontend/src/components/monitoring/Monitoring.tsx
+++ b/apps/frontend/src/components/monitoring/Monitoring.tsx
@@ -18,7 +18,7 @@ import type { RootState } from "@/store"
 import { commandLogsRequested, selectCommandLogs } from "@/state/valkey-features/commandlogs/commandLogsSlice"
 import { useAppDispatch } from "@/hooks/hooks"
 import {
-  hotKeysRequested, selectHotKeys, selectHotKeysStatus, selectHotKeysError, selectHotKeysNodeErrors,
+  hotKeysRequested, selectHotKeys, selectHotKeysStatus, selectHotKeysError, selectHotKeysNodeErrors
 } from "@/state/valkey-features/hotkeys/hotKeysSlice"
 import { selectMonitorRunning } from "@/state/valkey-features/monitor/monitorSlice"
 import { getKeyTypeRequested } from "@/state/valkey-features/keys/keyBrowserSlice"

--- a/apps/frontend/src/components/monitoring/Monitoring.tsx
+++ b/apps/frontend/src/components/monitoring/Monitoring.tsx
@@ -17,7 +17,9 @@ import { Button } from "../ui/button"
 import type { RootState } from "@/store"
 import { commandLogsRequested, selectCommandLogs } from "@/state/valkey-features/commandlogs/commandLogsSlice"
 import { useAppDispatch } from "@/hooks/hooks"
-import { hotKeysRequested, selectHotKeys, selectHotKeysStatus, selectHotKeysError, selectHotKeysNodeErrors } from "@/state/valkey-features/hotkeys/hotKeysSlice"
+import {
+  hotKeysRequested, selectHotKeys, selectHotKeysStatus, selectHotKeysError, selectHotKeysNodeErrors,
+} from "@/state/valkey-features/hotkeys/hotKeysSlice"
 import { selectMonitorRunning } from "@/state/valkey-features/monitor/monitorSlice"
 import { getKeyTypeRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
 import { selectKeys } from "@/state/valkey-features/keys/keyBrowserSelectors"

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -45,7 +45,8 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
   }
 
   const nodeErrorsBanner = nodeErrors && nodeErrors.length > 0 && (
-    <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border border-yellow-200 dark:border-yellow-700 flex items-start gap-2">
+    <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border
+      border-yellow-200 dark:border-yellow-700 flex items-start gap-2">
       <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
       <div>
         <Typography variant="bodySm">

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -44,146 +44,152 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
     return <LoadingState message="Loading hot keys..." />
   }
 
+  const nodeErrorsBanner = nodeErrors && nodeErrors.length > 0 && (
+    <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border border-yellow-200 dark:border-yellow-700">
+      <div className="flex items-start gap-2">
+        <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
+        <div>
+          <Typography variant="bodySm">
+            Hot keys data is partial —{" "}
+            {nodeErrors.length} metrics server{nodeErrors.length > 1 ? "s" : ""} failed to respond or are not connected:
+          </Typography>
+          <ul className="mt-1 space-y-0.5">
+            {nodeErrors.map(({ connectionId, error }) => (
+              <li key={connectionId}>
+                <Typography variant="bodySm">
+                  <span className="font-mono">{connectionId}</span>: {error}
+                </Typography>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+
   return sortedHotKeys.length > 0 ? (
     <>
-      {nodeErrors && nodeErrors.length > 0 && (
-        <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border border-yellow-200 dark:border-yellow-700">
-          <div className="flex items-start gap-2">
-            <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
-            <div>
-              <Typography variant="bodySm">
-                Hot keys data is partial — {nodeErrors.length} metrics server{nodeErrors.length > 1 ? "s" : ""} failed to respond:
-              </Typography>
-              <ul className="mt-1 space-y-0.5">
-                {nodeErrors.map(({ connectionId, error }) => (
-                  <li key={connectionId}>
-                    <Typography variant="bodySm">
-                      <span className="font-mono">{connectionId}</span>: {error}
-                    </Typography>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        </div>
-      )}
+      {nodeErrorsBanner}
       <TableContainer
         header={
-        <>
-          <StaticTableHeader
-            icon={<Flame className="text-primary" size={16} />}
-            label="Key Name"
-            width="w-2/5"
-          />
-          <SortableTableHeader
-            active={true}
-            className="text-center"
-            label="Access Count"
-            onClick={toggleSortOrder}
-            sortOrder={sortOrder}
-            width="w-1/5"
-          />
-          <StaticTableHeader className="text-center" label="Size" width="w-1/5" />
-          <StaticTableHeader className="text-center" label="TTL" width="w-1/5" />
-        </>
-      }
-    >
-      {sortedHotKeys.map(([keyName, count, size, ttl], index) => {
-        const isDeleted = ttl === -2
-        return (
-          <tr
-            className={`group border-b dark:border-tw-dark-border transition-all duration-200 cursor-pointer
+          <>
+            <StaticTableHeader
+              icon={<Flame className="text-primary" size={16} />}
+              label="Key Name"
+              width="w-2/5"
+            />
+            <SortableTableHeader
+              active={true}
+              className="text-center"
+              label="Access Count"
+              onClick={toggleSortOrder}
+              sortOrder={sortOrder}
+              width="w-1/5"
+            />
+            <StaticTableHeader className="text-center" label="Size" width="w-1/5" />
+            <StaticTableHeader className="text-center" label="TTL" width="w-1/5" />
+          </>
+        }
+      >
+        {sortedHotKeys.map(([keyName, count, size, ttl], index) => {
+          const isDeleted = ttl === -2
+          return (
+            <tr
+              className={`group border-b dark:border-tw-dark-border transition-all duration-200 cursor-pointer
                         ${isDeleted
-            ? "opacity-75"
-            : selectedKey === keyName
-              ? "bg-primary/10 hover:bg-primary/10"
-              : "hover:bg-gray-50 dark:hover:bg-neutral-800/50"
-          }`}
-            key={`${keyName}-${index}`}
-            onClick={() => onKeyClick?.(keyName)}
-          >
-            {/* key name */}
-            <td className="px-4 py-3 w-2/5">
-              <div className="flex items-center gap-2">
-                <Typography className={`truncate
+              ? "opacity-75"
+              : selectedKey === keyName
+                ? "bg-primary/10 hover:bg-primary/10"
+                : "hover:bg-gray-50 dark:hover:bg-neutral-800/50"
+            }`}
+              key={`${keyName}-${index}`}
+              onClick={() => onKeyClick?.(keyName)}
+            >
+              {/* key name */}
+              <td className="px-4 py-3 w-2/5">
+                <div className="flex items-center gap-2">
+                  <Typography className={`truncate
                             ${isDeleted
-            ? "line-through opacity-75" : ""
-          }`} variant={"code"}>
-                  {keyName}
-                </Typography>
-                {isDeleted && (
-                  <span className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full
+              ? "line-through opacity-75" : ""
+            }`} variant={"code"}>
+                    {keyName}
+                  </Typography>
+                  {isDeleted && (
+                    <span className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full
                              bg-red-200 dark:bg-red-400">
-                    <AlertCircle size={12} />
-                    DELETED
-                  </span>
-                )}
-                {!isDeleted && (
-                  <button
-                    aria-label = "Copy key name"
-                    className="p-1 rounded text-primary hover:bg-primary/20"
-                    onClick={(e) => handleCopyKey(keyName, e)}
-                  >
-                    <Copy size={14} />
-                  </button>
-                )}
-              </div>
-            </td>
+                      <AlertCircle size={12} />
+                      DELETED
+                    </span>
+                  )}
+                  {!isDeleted && (
+                    <button
+                      aria-label = "Copy key name"
+                      className="p-1 rounded text-primary hover:bg-primary/20"
+                      onClick={(e) => handleCopyKey(keyName, e)}
+                    >
+                      <Copy size={14} />
+                    </button>
+                  )}
+                </div>
+              </td>
 
-            {/* access count */}
-            <td className="px-4 py-3 w-1/5 text-center">
-              <Typography variant={"bodySm"}>
-                {count.toLocaleString()}
-              </Typography>
-            </td>
+              {/* access count */}
+              <td className="px-4 py-3 w-1/5 text-center">
+                <Typography variant={"bodySm"}>
+                  {count.toLocaleString()}
+                </Typography>
+              </td>
 
-            {/* size */}
-            <td className="px-4 py-3 w-1/5 text-center">
-              <Typography variant={"bodySm"}>
-                {isDeleted ? "—" : formatBytes(size!)}
-              </Typography>
-            </td>
+              {/* size */}
+              <td className="px-4 py-3 w-1/5 text-center">
+                <Typography variant={"bodySm"}>
+                  {isDeleted ? "—" : formatBytes(size!)}
+                </Typography>
+              </td>
 
-            {/* ttl */}
-            <td className="px-4 py-3 w-1/5 text-center">
-              <Typography variant={"bodySm"}>
-                {isDeleted ? "—" : convertTTL(ttl)}
-              </Typography>
-            </td>
-          </tr>
-        )
-      })}
-    </TableContainer>
+              {/* ttl */}
+              <td className="px-4 py-3 w-1/5 text-center">
+                <Typography variant={"bodySm"}>
+                  {isDeleted ? "—" : convertTTL(ttl)}
+                </Typography>
+              </td>
+            </tr>
+          )
+        })}
+      </TableContainer>
     </>
   ) : (
-    <EmptyState
-      action={
-        (errorMessage || !monitorRunning) && (
-          <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">
-            <div className="flex items-start gap-2">
-              <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
-              <Typography variant="bodySm">
-                {!monitorRunning && onStartMonitoring ? (
-                  <>
-                    Monitor is not running.{" "}
-                    <button
-                      className="text-primary underline hover:opacity-80"
-                      onClick={onStartMonitoring}
-                      type="button"
-                    >
-                      Start Monitoring
-                    </button>
-                  </>
-                ) : (
-                  errorMessage
-                )}
-              </Typography>
+    <>
+      {nodeErrorsBanner}
+      <EmptyState
+        action={
+          (errorMessage || !monitorRunning) && (
+            <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
+                <Typography variant="bodySm">
+                  {!monitorRunning && onStartMonitoring ? (
+                    <>
+                      Monitor is not running.{" "}
+                      <button
+                        className="text-primary underline hover:opacity-80"
+                        onClick={onStartMonitoring}
+                        type="button"
+                      >
+                        Start Monitoring
+                      </button>
+                    </>
+                  ) : (
+                    errorMessage
+                  )}
+                </Typography>
+              </div>
             </div>
-          </div>
-        )
-      }
-      icon={<Flame size={48} />}
-      title="No Hot Keys Found"
-    />
+          )
+        }
+        icon={<Flame size={48} />}
+        title="No Hot Keys Found"
+      />
+    </>
   )
 }

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -46,24 +46,20 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
 
   const nodeErrorsBanner = nodeErrors && nodeErrors.length > 0 && (
     <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border border-yellow-200 dark:border-yellow-700">
-      <div className="flex items-start gap-2">
-        <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
-        <div>
-          <Typography variant="bodySm">
-            Hot keys data is partial —{" "}
-            {nodeErrors.length} metrics server{nodeErrors.length > 1 ? "s" : ""} failed to respond or are not connected:
-          </Typography>
-          <ul className="mt-1 space-y-0.5">
-            {nodeErrors.map(({ connectionId, error }) => (
-              <li key={connectionId}>
-                <Typography variant="bodySm">
-                  <span className="font-mono">{connectionId}</span>: {error}
-                </Typography>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
+      <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
+      <Typography variant="bodySm">
+        Hot keys data is partial —{" "}
+        {nodeErrors.length} metrics server{nodeErrors.length > 1 ? "s" : ""} failed to respond or are not connected:
+      </Typography>
+      <ul className="mt-1 space-y-0.5">
+        {nodeErrors.map(({ connectionId, error }) => (
+          <li key={connectionId}>
+            <Typography variant="bodySm">
+              <span className="font-mono">{connectionId}</span>: {error}
+            </Typography>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 
@@ -165,25 +161,23 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
         action={
           (errorMessage || !monitorRunning) && (
             <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">
-              <div className="flex items-start gap-2">
-                <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
-                <Typography variant="bodySm">
-                  {!monitorRunning && onStartMonitoring ? (
-                    <>
-                      Monitor is not running.{" "}
-                      <button
-                        className="text-primary underline hover:opacity-80"
-                        onClick={onStartMonitoring}
-                        type="button"
-                      >
-                        Start Monitoring
-                      </button>
-                    </>
-                  ) : (
-                    errorMessage
-                  )}
-                </Typography>
-              </div>
+              <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
+              <Typography variant="bodySm">
+                {!monitorRunning && onStartMonitoring ? (
+                  <>
+                    Monitor is not running.{" "}
+                    <button
+                      className="text-primary underline hover:opacity-80"
+                      onClick={onStartMonitoring}
+                      type="button"
+                    >
+                      Start Monitoring
+                    </button>
+                  </>
+                ) : (
+                  errorMessage
+                )}
+              </Typography>
             </div>
           )
         }

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -47,19 +47,21 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
   const nodeErrorsBanner = nodeErrors && nodeErrors.length > 0 && (
     <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border border-yellow-200 dark:border-yellow-700 flex items-start gap-2">
       <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
-      <Typography variant="bodySm">
-        Hot keys data is partial —{" "}
-        {nodeErrors.length} metrics server{nodeErrors.length > 1 ? "s" : ""} failed to respond or are not connected:
-      </Typography>
-      <ul className="mt-1 space-y-0.5">
-        {nodeErrors.map(({ connectionId, error }) => (
-          <li key={connectionId}>
-            <Typography variant="bodySm">
-              <span className="font-mono">{connectionId}</span>: {error}
-            </Typography>
-          </li>
-        ))}
-      </ul>
+      <div>
+        <Typography variant="bodySm">
+          Hot keys data is partial —{" "}
+          {nodeErrors.length} metrics server{nodeErrors.length > 1 ? "s" : ""} failed to respond or are not connected:
+        </Typography>
+        <ul className="mt-1 space-y-0.5">
+          {nodeErrors.map(({ connectionId, error }) => (
+            <li key={connectionId}>
+              <Typography variant="bodySm">
+                <span className="font-mono">{connectionId}</span>: {error}
+              </Typography>
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   )
 

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -160,7 +160,7 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
       <EmptyState
         action={
           (errorMessage || !monitorRunning) && (
-            <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 rounded-md">
+            <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 rounded-md flex items-start gap-2">
               <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
               <Typography variant="bodySm">
                 {!monitorRunning && onStartMonitoring ? (

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -45,7 +45,7 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
   }
 
   const nodeErrorsBanner = nodeErrors && nodeErrors.length > 0 && (
-    <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border border-yellow-200 dark:border-yellow-700">
+    <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border border-yellow-200 dark:border-yellow-700 flex items-start gap-2">
       <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
       <Typography variant="bodySm">
         Hot keys data is partial —{" "}

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -16,12 +16,13 @@ interface HotKeysProps {
   errorMessage: string | null
   status?: string
   monitorRunning?: boolean
+  nodeErrors?: { connectionId: string; error: string }[]
   onKeyClick?: (keyName: string) => void
   onStartMonitoring?: () => void
   selectedKey?: string | null
 }
 
-export function HotKeys({ data, errorMessage, status, monitorRunning, onKeyClick, onStartMonitoring, selectedKey }: HotKeysProps) {
+export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors, onKeyClick, onStartMonitoring, selectedKey }: HotKeysProps) {
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc")
 
   const toggleSortOrder = () => {
@@ -44,8 +45,30 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, onKeyClick
   }
 
   return sortedHotKeys.length > 0 ? (
-    <TableContainer
-      header={
+    <>
+      {nodeErrors && nodeErrors.length > 0 && (
+        <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border border-yellow-200 dark:border-yellow-700">
+          <div className="flex items-start gap-2">
+            <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
+            <div>
+              <Typography variant="bodySm">
+                Hot keys data is partial — {nodeErrors.length} metrics server{nodeErrors.length > 1 ? "s" : ""} failed to respond:
+              </Typography>
+              <ul className="mt-1 space-y-0.5">
+                {nodeErrors.map(({ connectionId, error }) => (
+                  <li key={connectionId}>
+                    <Typography variant="bodySm">
+                      <span className="font-mono">{connectionId}</span>: {error}
+                    </Typography>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+      <TableContainer
+        header={
         <>
           <StaticTableHeader
             icon={<Flame className="text-primary" size={16} />}
@@ -131,6 +154,7 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, onKeyClick
         )
       })}
     </TableContainer>
+    </>
   ) : (
     <EmptyState
       action={

--- a/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
+++ b/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
@@ -15,6 +15,9 @@ export const selectHotKeysStatus = (id: string) => (state: RootState) =>
 export const selectHotKeysError = (id: string) => (state: RootState) =>
   R.path([VALKEY.HOTKEYS.name, id, "error"], state)
 
+export const selectHotKeysNodeErrors = (id: string) => (state: RootState) =>
+  R.path([VALKEY.HOTKEYS.name, id, "nodeErrors"], state) ?? []
+
 interface HotKeysState {
   [connectionId: string]: {
     hotKeys: [string, number, number | null, number][]
@@ -22,6 +25,7 @@ interface HotKeysState {
     monitorRunning: boolean,
     nodeId: string | null,
     error?: JSONObject | null,
+    nodeErrors?: { connectionId: string; error: string }[],
     status: HotKeysStatus,
   }
 }
@@ -52,6 +56,7 @@ const hotKeysSlice = createSlice({
     hotKeysFulfilled: (state, action) => {
       const { hotKeys, monitorRunning, checkAt, nodeId } = action.payload.parsedResponse
       const connectionId = action.payload.connectionId
+      const nodeErrors = action.payload.nodeErrors ?? []
       if (!state[connectionId]) {
         state[connectionId] = {
           hotKeys: [],
@@ -64,8 +69,9 @@ const hotKeysSlice = createSlice({
       state[connectionId] = {
         hotKeys,
         checkAt,
-        monitorRunning, 
+        monitorRunning,
         nodeId,
+        nodeErrors,
         status: FULFILLED,
       }
       

--- a/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
+++ b/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
@@ -33,9 +33,10 @@ const hotKeysSlice = createSlice({
   initialState: initialHotKeysState,
   reducers: {
     hotKeysRequested: (state, action) => {
-      const connectionId = action.payload.connectionId
-      if (!state[connectionId]) {
-        state[connectionId] = {
+      const { connectionId, clusterId } = action.payload
+      const id = clusterId ?? connectionId
+      if (!state[id]) {
+        state[id] = {
           hotKeys: [],
           checkAt: null,
           monitorRunning: false,
@@ -43,9 +44,9 @@ const hotKeysSlice = createSlice({
           status: PENDING,
         }
       } else {
-        state[connectionId].status = PENDING
-        state[connectionId].hotKeys = []
-        state[connectionId].error = null
+        state[id].status = PENDING
+        state[id].hotKeys = []
+        state[id].error = null
       }
     },
     hotKeysFulfilled: (state, action) => {

--- a/apps/metrics/src/analyzers/calculate-hot-keys.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys.js
@@ -52,14 +52,25 @@ const ACCESS_COMMANDS = [
 
 const CUT_OFF_FREQUENCY = 1
 
+const MULTI_KEY_COMMANDS = new Set(["mget", "json.mget"])
+const INTERLEAVED_KEY_COMMANDS = new Set(["mset"])
+
 export const calculateHotKeysFromMonitor = (rows) =>
   R.pipe(
     R.reduce((acc, { command }) => {
       const [cmd, ...args] = command.split(" ").filter(Boolean)
-      if (ACCESS_COMMANDS.includes(cmd.trim().toLowerCase())) {
-        args.forEach((key) => {
-          acc[key] = acc[key] ? acc[key] + 1 : 1
-        })
+      const normalizedCmd = cmd.trim().toLowerCase()
+      if (!ACCESS_COMMANDS.includes(normalizedCmd)) return acc
+
+      if (MULTI_KEY_COMMANDS.has(normalizedCmd)) {
+        args.forEach((key) => { acc[key] = (acc[key] ?? 0) + 1 })
+      } else if (INTERLEAVED_KEY_COMMANDS.has(normalizedCmd)) {
+        for (let i = 0; i < args.length; i += 2) {
+          acc[args[i]] = (acc[args[i]] ?? 0) + 1
+        }
+      } else {
+        const key = args[0]
+        if (key) acc[key] = (acc[key] ?? 0) + 1
       }
       return acc
     }, {}),

--- a/apps/metrics/src/analyzers/calculate-hot-keys.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys.js
@@ -65,9 +65,7 @@ export const calculateHotKeysFromMonitor = (rows) =>
       if (MULTI_KEY_COMMANDS.has(normalizedCmd)) {
         args.forEach((key) => { acc[key] = (acc[key] ?? 0) + 1 })
       } else if (INTERLEAVED_KEY_COMMANDS.has(normalizedCmd)) {
-        for (let i = 0; i < args.length; i += 2) {
-          acc[args[i]] = (acc[args[i]] ?? 0) + 1
-        }
+        R.splitEvery(2, args).forEach(([key]) => { acc[key] = (acc[key] ?? 0) + 1 })
       } else {
         const key = args[0]
         if (key) acc[key] = (acc[key] ?? 0) + 1

--- a/apps/server/src/__tests__/connection.test.ts
+++ b/apps/server/src/__tests__/connection.test.ts
@@ -117,7 +117,7 @@ describe("connectToValkey", () => {
     }
 
     try {
-      const result = await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap, {})
+      await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap, {})
       const connection = clients.get(payload.connectionId)
       assert.strictEqual(connection.client, mockClusterClient)
 

--- a/apps/server/src/__tests__/connection.test.ts
+++ b/apps/server/src/__tests__/connection.test.ts
@@ -27,7 +27,7 @@ describe("connectToValkey", () => {
   let mockWs: any
   let messages: string[]
   let clients: Map<string, any>
-  let clusterNodesMap: Map<string, string[]>
+  let connectedNodesByCluster: Map<string, string[]>
   let metricsServerMap: MetricsServerMap
   beforeEach(() => {
     messages = []
@@ -35,7 +35,7 @@ describe("connectToValkey", () => {
       send: mock.fn((msg: string) => messages.push(msg)),
     }
     clients = new Map()
-    clusterNodesMap = new Map() 
+    connectedNodesByCluster = new Map() 
     metricsServerMap = new Map()
     metricsServerMap.set(DEFAULT_PAYLOAD.connectionId, {
       metricsURI: "http://localhost:1234",
@@ -51,7 +51,7 @@ describe("connectToValkey", () => {
     }
     mock.restoreAll()
     clients.clear()
-    clusterNodesMap.clear()
+    connectedNodesByCluster.clear()
     resetNodeWatchers()
   })
 
@@ -117,7 +117,7 @@ describe("connectToValkey", () => {
     }
 
     try {
-      const result = await connectToValkey(mockWs, payload, clients, clusterNodesMap, metricsServerMap)
+      const result = await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap)
 
       assert.ok(result)
       assert.strictEqual(mockStandaloneClient.close.mock.calls.length, 2)
@@ -170,7 +170,7 @@ describe("connectToValkey", () => {
     }
 
     try {
-      const result = await connectToValkey(mockWs, payload, clients, clusterNodesMap, metricsServerMap)
+      const result = await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap)
 
       assert.ok(result)
       const connection = clients.get(payload.connectionId)
@@ -240,7 +240,7 @@ describe("connectToValkey", () => {
     }
 
     try {
-      await connectToValkey(mockWs, iamPayload, clients, clusterNodesMap, metricsServerMap)
+      await connectToValkey(mockWs, iamPayload, clients, connectedNodesByCluster, metricsServerMap)
 
       const calls = (GlideClusterClient.createClient as unknown as ReturnType<typeof mock.fn>).mock.calls
       assert.ok(calls.length > 0)
@@ -263,7 +263,7 @@ describe("connectToValkey", () => {
     mock.method(dns, "reverse", async () => ["localhost"])
 
     try {
-      const result = await connectToValkey(mockWs, DEFAULT_PAYLOAD, clients, clusterNodesMap, metricsServerMap)
+      const result = await connectToValkey(mockWs, DEFAULT_PAYLOAD, clients, connectedNodesByCluster, metricsServerMap)
 
       assert.strictEqual(result, undefined)
       assert.strictEqual(clients.has(DEFAULT_PAYLOAD.connectionId), false)
@@ -312,7 +312,7 @@ describe("connectToValkey", () => {
     }
 
     try {
-      await connectToValkey(mockWs, alternate_payload, clients, clusterNodesMap, metricsServerMap)
+      await connectToValkey(mockWs, alternate_payload, clients, connectedNodesByCluster, metricsServerMap)
       assert.strictEqual((GlideClient.createClient as any).mock.calls.length, 1)
 
       const config = (GlideClient.createClient as any).mock.calls[0].arguments[0]
@@ -343,7 +343,7 @@ describe("connectToValkey", () => {
     payload.connectionId = uniqueConnID
 
     try {
-      await connectToValkey(mockWs, payload, clients, clusterNodesMap, metricsServerMap)
+      await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap)
 
       assert.strictEqual(clients.size, 1)
       assert.ok(clients.has(uniqueConnID))

--- a/apps/server/src/__tests__/connection.test.ts
+++ b/apps/server/src/__tests__/connection.test.ts
@@ -117,10 +117,7 @@ describe("connectToValkey", () => {
     }
 
     try {
-      const result = await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap)
-
-      assert.ok(result)
-      assert.strictEqual(mockStandaloneClient.close.mock.calls.length, 1)
+      const result = await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap, {})
       const connection = clients.get(payload.connectionId)
       assert.strictEqual(connection.client, mockClusterClient)
 
@@ -170,7 +167,7 @@ describe("connectToValkey", () => {
     }
 
     try {
-      const result = await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap)
+      const result = await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap, {})
 
       assert.ok(result)
       const connection = clients.get(payload.connectionId)
@@ -240,7 +237,7 @@ describe("connectToValkey", () => {
     }
 
     try {
-      await connectToValkey(mockWs, iamPayload, clients, connectedNodesByCluster, metricsServerMap)
+      await connectToValkey(mockWs, iamPayload, clients, connectedNodesByCluster, metricsServerMap, {})
 
       const calls = (GlideClusterClient.createClient as unknown as ReturnType<typeof mock.fn>).mock.calls
       assert.ok(calls.length > 0)
@@ -263,7 +260,7 @@ describe("connectToValkey", () => {
     mock.method(dns, "reverse", async () => ["localhost"])
 
     try {
-      const result = await connectToValkey(mockWs, DEFAULT_PAYLOAD, clients, connectedNodesByCluster, metricsServerMap)
+      const result = await connectToValkey(mockWs, DEFAULT_PAYLOAD, clients, connectedNodesByCluster, metricsServerMap, {})
 
       assert.strictEqual(result, undefined)
       assert.strictEqual(clients.has(DEFAULT_PAYLOAD.connectionId), false)
@@ -312,7 +309,7 @@ describe("connectToValkey", () => {
     }
 
     try {
-      await connectToValkey(mockWs, alternate_payload, clients, connectedNodesByCluster, metricsServerMap)
+      await connectToValkey(mockWs, alternate_payload, clients, connectedNodesByCluster, metricsServerMap, {})
       assert.strictEqual((GlideClient.createClient as any).mock.calls.length, 1)
 
       const config = (GlideClient.createClient as any).mock.calls[0].arguments[0]
@@ -343,9 +340,7 @@ describe("connectToValkey", () => {
     payload.connectionId = uniqueConnID
 
     try {
-      await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap)
-
-      assert.strictEqual(clients.size, 1)
+      await connectToValkey(mockWs, payload, clients, connectedNodesByCluster, metricsServerMap, {})
       assert.ok(clients.has(uniqueConnID))
       const connection = clients.get(uniqueConnID)
       assert.strictEqual(connection.client, mockStandaloneClient)

--- a/apps/server/src/__tests__/monitorAction.test.ts
+++ b/apps/server/src/__tests__/monitorAction.test.ts
@@ -17,7 +17,7 @@ describe("monitorAction", () => {
   let mockWs: any
   let messages: string[]
   let metricsServerMap: Map<string, any>
-  let clusterNodesMap: Map<string, string[]>
+  let connectedNodesByCluster: Map<string, string[]>
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
@@ -26,7 +26,7 @@ describe("monitorAction", () => {
       send: mock.fn((msg: string) => messages.push(msg)),
     }
     metricsServerMap = new Map()
-    clusterNodesMap = new Map()
+    connectedNodesByCluster = new Map()
   })
 
   afterEach(() => {
@@ -47,7 +47,7 @@ describe("monitorAction", () => {
     globalThis.fetch = (async () => { throw error }) as any
   }
 
-  const deps = () => ({ ws: mockWs, metricsServerMap, clusterNodesMap, clients: new Map(), connectionId: "" } as any)
+  const deps = () => ({ ws: mockWs, metricsServerMap, connectedNodesByCluster, clients: new Map(), connectionId: "" } as any)
 
   describe("status request", () => {
     it("should call GET /monitor?action=status and send monitorFulfilled", async () => {
@@ -171,7 +171,7 @@ describe("monitorAction", () => {
     it("should send requests to all cluster nodes", async () => {
       metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
       metricsServerMap.set("node-2", { metricsURI: "http://localhost:9002" })
-      clusterNodesMap.set("cluster-1", ["node-1", "node-2"])
+      connectedNodesByCluster.set("cluster-1", ["node-1", "node-2"])
 
       const fetchCalls = mockFetch({ monitorRunning: true, checkAt: 55555 })
 
@@ -298,7 +298,7 @@ describe("saveMonitorSettingsRequested", () => {
   let mockWs: any
   let messages: string[]
   let metricsServerMap: Map<string, any>
-  let clusterNodesMap: Map<string, string[]>
+  let connectedNodesByCluster: Map<string, string[]>
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
@@ -307,7 +307,7 @@ describe("saveMonitorSettingsRequested", () => {
       send: mock.fn((msg: string) => messages.push(msg)),
     }
     metricsServerMap = new Map()
-    clusterNodesMap = new Map()
+    connectedNodesByCluster = new Map()
   })
 
   afterEach(() => {
@@ -330,7 +330,7 @@ describe("saveMonitorSettingsRequested", () => {
     return fetchCalls
   }
 
-  const deps = () => ({ ws: mockWs, metricsServerMap, clusterNodesMap, clients: new Map(), connectionId: "" } as any)
+  const deps = () => ({ ws: mockWs, metricsServerMap, connectedNodesByCluster, clients: new Map(), connectionId: "" } as any)
 
   it("should call only updateConfig when config is present but monitorAction is absent", async () => {
     metricsServerMap.set("conn-1", { metricsURI: "http://localhost:9999" })
@@ -445,7 +445,7 @@ describe("saveMonitorSettingsRequested", () => {
   it("should fan out across cluster nodes for both config and monitor", async () => {
     metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
     metricsServerMap.set("node-2", { metricsURI: "http://localhost:9002" })
-    clusterNodesMap.set("cluster-1", ["node-1", "node-2"])
+    connectedNodesByCluster.set("cluster-1", ["node-1", "node-2"])
 
     const fetchCalls = mockFetchRouted({
       "/update-config": { body: { success: true, message: "", data: {} } },

--- a/apps/server/src/actions/commandLogs.ts
+++ b/apps/server/src/actions/commandLogs.ts
@@ -76,9 +76,9 @@ const sendCommandLogsError = (
 }
 
 export const commandLogsRequested = withDeps<Deps, void>(
-  async ({ ws, metricsServerMap, action, clusterNodesMap }) => {
+  async ({ ws, metricsServerMap, action, connectedNodesByCluster }) => {
     const { connectionId, clusterId } = action.payload
-    const connectionIds = clusterId ? clusterNodesMap.get(clusterId as string) ?? [] : [connectionId]
+    const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
     const commandLogType: CommandLogType = action.payload.commandLogType as CommandLogType
 
     const promises = connectionIds.map(async (connectionId: string) => {

--- a/apps/server/src/actions/config.ts
+++ b/apps/server/src/actions/config.ts
@@ -10,9 +10,9 @@ interface ParsedResponse  {
 }
 
 export const updateConfig = withDeps<Deps, void>(
-  async ({ ws, metricsServerMap, action, clusterNodesMap }) => {
+  async ({ ws, metricsServerMap, action, connectedNodesByCluster }) => {
     const { connectionId, clusterId, config } = action.payload
-    const connectionIds = clusterId ? clusterNodesMap.get(clusterId as string) ?? [] : [connectionId]
+    const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
 
     const promises = connectionIds.map(async (connectionId: string) => {
       const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
@@ -60,9 +60,9 @@ export const updateConfig = withDeps<Deps, void>(
 
 // TODO: Add frontend component to dispatch this
 export const enableClusterSlotStats = withDeps<Deps, void>(
-  async ({ clients, action, clusterNodesMap }) => {
+  async ({ clients, action, connectedNodesByCluster }) => {
     const { connectionId, clusterId } = action.payload
-    const connectionIds = clusterId ? clusterNodesMap.get(clusterId as string) ?? [] : [connectionId]
+    const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
     
     const promises = connectionIds.map(async (connectionId: string) => {
       const connection = clients.get(connectionId)

--- a/apps/server/src/actions/connection.ts
+++ b/apps/server/src/actions/connection.ts
@@ -28,8 +28,8 @@ type ConnectPayload = {
 }
 
 export const connectPending = withDeps<Deps, void>(
-  async ({ ws, clients, action, clusterNodesMap, metricsServerMap }) => {
-    await connectToValkey(ws, action.payload as ConnectPayload, clients, clusterNodesMap, metricsServerMap)
+  async ({ ws, clients, action, connectedNodesByCluster, metricsServerMap, clusterNodesRegistry }) => {
+    await connectToValkey(ws, action.payload as ConnectPayload, clients, connectedNodesByCluster, metricsServerMap, clusterNodesRegistry)
   },
 )
 
@@ -52,7 +52,7 @@ export const resetConnection = withDeps<Deps, void>(
 )
 
 export const closeConnection = withDeps<Deps, void>(
-  async ({ ws, clients, action, metricsServerMap, clusterNodesMap }) => {
+  async ({ ws, clients, action, metricsServerMap, connectedNodesByCluster }) => {
     const { connectionId } = action.payload
     const connection = clients.get(connectionId)
     const clusterId = connection?.clusterId
@@ -68,12 +68,12 @@ export const closeConnection = withDeps<Deps, void>(
     if (getWatcherCount(connectionId) > 0) {
       return
     }
-    const nodes = clusterNodesMap.get(clusterId!)
+    const nodes = connectedNodesByCluster.get(clusterId!)
 
     // Remove node from cluster map accordingly
     if (clusterId && nodes) {
       if (nodes.length === 1) {
-        clusterNodesMap.delete(clusterId)
+        connectedNodesByCluster.delete(clusterId)
       } else {
         const index = nodes.indexOf(connectionId)
         if (index !== -1) {

--- a/apps/server/src/actions/cpuUsage.ts
+++ b/apps/server/src/actions/cpuUsage.ts
@@ -49,9 +49,9 @@ type RequestPayload = {
 }
 
 export const cpuUsageRequested = withDeps<Deps, void>(
-  async ({ ws, metricsServerMap, action, clusterNodesMap }) => {
+  async ({ ws, metricsServerMap, action, connectedNodesByCluster }) => {
     const { connectionId, clusterId, timeRange = "12h" } = action.payload as unknown as RequestPayload
-    const connectionIds = clusterId ? clusterNodesMap.get(clusterId as string) ?? [] : [connectionId]
+    const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
 
     const promises = connectionIds.map(async (connectionId: string) => {
       const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -10,10 +10,16 @@ type HotKeysResponse = {
   monitorRunning: boolean
 }
 
+type NodeError = {
+  connectionId: string
+  error: string
+}
+
 const sendHotKeysFulfilled = (
   ws: WebSocket,
   connectionId: string,
   parsedResponse: HotKeysResponse,
+  nodeErrors?: NodeError[],
 ) => {
   ws.send(
     JSON.stringify({
@@ -21,6 +27,7 @@ const sendHotKeysFulfilled = (
       payload: {
         connectionId,
         parsedResponse,
+        ...(nodeErrors?.length ? { nodeErrors } : {}),
       },
     }),
   )
@@ -70,8 +77,11 @@ export const hotKeysRequested = withDeps<Deps, void>(
         const initialResponse = await fetch(url)
         if (!initialResponse.ok) {
           const errorBody = await initialResponse.json() as { error?: string }
-          sendHotKeysError(ws, connectionId, errorBody.error ?? `HTTP ${initialResponse.status}`)
-          return
+          if (!nodes) {
+            sendHotKeysError(ws, connectionId, errorBody.error ?? `HTTP ${initialResponse.status}`)
+            return
+          }
+          return { connectionId, error: errorBody.error ?? `HTTP ${initialResponse.status}` } as NodeError
         }
         const initialParsedResponse: HotKeysResponse = await initialResponse.json() as HotKeysResponse
         // Reads monitor data and returns when to fetch results (`checkAt`).
@@ -85,11 +95,17 @@ export const hotKeysRequested = withDeps<Deps, void>(
           return initialParsedResponse
         }
       } catch (error) {
-        sendHotKeysError(ws, connectionId, error)
-        return
+        if (!nodes) {
+          sendHotKeysError(ws, connectionId, error)
+          return
+        }
+        return { connectionId, error: error instanceof Error ? error.message : String(error) } as NodeError
       }
     })
-    const results = (await Promise.all(promises)).filter((r): r is HotKeysResponse => !!r?.hotKeys)
+
+    const settled = await Promise.all(promises)
+    const results = settled.filter((r): r is HotKeysResponse => !!r && "hotKeys" in r)
+    const nodeErrors = nodes ? settled.filter((r): r is NodeError => !!r && "error" in r) : []
 
     if (results.length === 0) return
 
@@ -108,5 +124,5 @@ export const hotKeysRequested = withDeps<Deps, void>(
       R.sort(([, a]: [string, number], [, b]: [string, number]) => b - a),
     )(results)
     const { monitorRunning, checkAt, nodeId } = results[0]
-    sendHotKeysFulfilled(ws, clusterId as string, { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId } as unknown as HotKeysResponse)
+    sendHotKeysFulfilled(ws, clusterId as string, { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId } as unknown as HotKeysResponse, nodeErrors)
   })

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -1,10 +1,11 @@
 import { type WebSocket } from "ws"
 import { VALKEY } from "valkey-common"
+import * as R from "ramda"
 import { withDeps, Deps } from "./utils"
 
 type HotKeysResponse = {
   nodeId: string
-  hotkeys: [[]]
+  hotKeys: [[]]
   checkAt: number
   monitorRunning: boolean
 }
@@ -76,25 +77,36 @@ export const hotKeysRequested = withDeps<Deps, void>(
         // Reads monitor data and returns when to fetch results (`checkAt`).
         if (initialParsedResponse.checkAt) {
           const delay = initialParsedResponse.checkAt - Date.now()
-          // Schedule the follow-up request for when the monitor cycle finishes
-          setTimeout(async () => {
-            try {
-              const dataResponse = await fetch(`${metricsServerURI}/hot-keys`)
-              const dataParsedResponse = await dataResponse.json() as HotKeysResponse
-              sendHotKeysFulfilled(ws, connectionId, dataParsedResponse)
-            } catch (error) {
-              sendHotKeysError(ws, connectionId, error)
-            }
-          }, delay)
+          await new Promise((resolve) => setTimeout(resolve, delay))
+          const dataResponse = await fetch(`${metricsServerURI}/hot-keys`)
+          return await dataResponse.json() as HotKeysResponse
         }
         else {
-          sendHotKeysFulfilled(ws, connectionId, initialParsedResponse)
+          return initialParsedResponse
         }
       } catch (error) {
         sendHotKeysError(ws, connectionId, error)
+        return
       }
     })
-    await Promise.all(promises)
+    const results = (await Promise.all(promises)).filter((r): r is HotKeysResponse => !!r?.hotKeys)
 
-  },
-)
+    if (results.length === 0) return
+
+    if (!nodes) {
+      sendHotKeysFulfilled(ws, connectionId, results[0])
+      return
+    }
+
+    const aggregatedHotKeys = R.pipe(
+      R.chain(({ hotKeys }: HotKeysResponse) => hotKeys as unknown as [string, number][]),
+      R.reduce((acc, [key, count]: [string, number]) => ({
+        ...acc,
+        [key]: (acc[key] ?? 0) + count,
+      }), {} as Record<string, number>),
+      R.toPairs,
+      R.sort(([, a]: [string, number], [, b]: [string, number]) => b - a),
+    )(results)
+    const { monitorRunning, checkAt, nodeId } = results[0]
+    sendHotKeysFulfilled(ws, clusterId as string, { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId } as unknown as HotKeysResponse)
+  })

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -129,7 +129,7 @@ export const hotKeysRequested = withDeps<Deps, void>(
         [key]: [key, (acc[key]?.[1] ?? 0) + count, acc[key]?.[2] ?? size, acc[key]?.[3] ?? ttl],
       }), {} as Record<string, [string, number, number | null, number]>),
       R.values,
-      R.sort(([, a]: [string, number], [, b]: [string, number]) => b - a),
+      R.sort(R.descend(R.prop(1))),
     )(results)
     const { monitorRunning, checkAt, nodeId } = results[0]
     const aggregatedResponse = { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId } as unknown as HotKeysResponse

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -43,9 +43,17 @@ const sendHotKeysError = (
 }
 
 export const hotKeysRequested = withDeps<Deps, void>(
-  async ({ ws, metricsServerMap, action, clusterNodesMap }) => {
+  async ({ ws, metricsServerMap, action, clusterNodesRegistry }) => {
     const { connectionId, clusterId, lfuEnabled, clusterSlotStatsEnabled } = action.payload
-    const connectionIds = clusterId ? clusterNodesMap.get(clusterId as string) ?? [] : [connectionId]
+    
+    const nodes =
+      typeof clusterId === "string"
+        ? clusterNodesRegistry[clusterId]
+        : undefined
+
+    const connectionIds = nodes
+      ? Object.keys(nodes)
+      : [connectionId]
     
     const promises = connectionIds.map(async (connectionId: string) => {
       const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -123,12 +123,12 @@ export const hotKeysRequested = withDeps<Deps, void>(
     }
 
     const aggregatedHotKeys = R.pipe(
-      R.chain(({ hotKeys }: HotKeysResponse) => hotKeys as unknown as [string, number][]),
-      R.reduce((acc, [key, count]: [string, number]) => ({
+      R.chain(({ hotKeys }: HotKeysResponse) => hotKeys as unknown as [string, number, number | null, number][]),
+      R.reduce((acc, [key, count, size, ttl]: [string, number, number | null, number]) => ({
         ...acc,
-        [key]: (acc[key] ?? 0) + count,
-      }), {} as Record<string, number>),
-      R.toPairs,
+        [key]: [key, (acc[key]?.[1] ?? 0) + count, acc[key]?.[2] ?? size, acc[key]?.[3] ?? ttl],
+      }), {} as Record<string, [string, number, number | null, number]>),
+      R.values,
       R.sort(([, a]: [string, number], [, b]: [string, number]) => b - a),
     )(results)
     const { monitorRunning, checkAt, nodeId } = results[0]

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -66,9 +66,11 @@ export const hotKeysRequested = withDeps<Deps, void>(
     const promises = connectionIds.map(async (connectionId: string) => {
       const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
       if (!metricsServerURI) {
-        // We could sendHotKeysError here similar to below, but in another PR
-        console.warn("Metrics server not started for node: ", connectionId)
-        return
+        if (!nodes) {
+          console.warn("Metrics server not started for node: ", connectionId)
+          return
+        }
+        return { connectionId, error: "Metrics server not started" } as NodeError
       }
       const url = new URL("/hot-keys", metricsServerURI)
       if (clusterSlotStatsEnabled && lfuEnabled) url.searchParams.set("useHotSlots", "true")
@@ -107,7 +109,13 @@ export const hotKeysRequested = withDeps<Deps, void>(
     const results = settled.filter((r): r is HotKeysResponse => !!r && "hotKeys" in r)
     const nodeErrors = nodes ? settled.filter((r): r is NodeError => !!r && "error" in r) : []
 
-    if (results.length === 0) return
+    if (results.length === 0) {
+      if (nodes) {
+        const emptyResponse = { hotKeys: [], monitorRunning: false, checkAt: 0, nodeId: "" } as unknown as HotKeysResponse
+        sendHotKeysFulfilled(ws, clusterId as string, emptyResponse, nodeErrors)
+      }
+      return
+    }
 
     if (!nodes) {
       sendHotKeysFulfilled(ws, connectionId, results[0])
@@ -124,5 +132,6 @@ export const hotKeysRequested = withDeps<Deps, void>(
       R.sort(([, a]: [string, number], [, b]: [string, number]) => b - a),
     )(results)
     const { monitorRunning, checkAt, nodeId } = results[0]
-    sendHotKeysFulfilled(ws, clusterId as string, { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId } as unknown as HotKeysResponse, nodeErrors)
+    const aggregatedResponse = { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId } as unknown as HotKeysResponse
+    sendHotKeysFulfilled(ws, clusterId as string, aggregatedResponse, nodeErrors)
   })

--- a/apps/server/src/actions/memoryUsage.ts
+++ b/apps/server/src/actions/memoryUsage.ts
@@ -56,9 +56,9 @@ type RequestPayload = {
 }
 
 export const memoryUsageRequested = withDeps<Deps, void>(
-  async ({ ws, metricsServerMap, action, clusterNodesMap }) => {
+  async ({ ws, metricsServerMap, action, connectedNodesByCluster }) => {
     const { connectionId, clusterId, timeRange = "12h" } = action.payload as unknown as RequestPayload
-    const connectionIds = clusterId ? clusterNodesMap.get(clusterId as string) ?? [] : [connectionId]
+    const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
     const promises = connectionIds.map(async (connectionId: string) => {
       const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
 

--- a/apps/server/src/actions/monitorAction.ts
+++ b/apps/server/src/actions/monitorAction.ts
@@ -45,9 +45,9 @@ const sendMonitorError = (
 }
 
 export const monitorRequested = withDeps<Deps, void>(
-  async ({ ws, metricsServerMap, action, clusterNodesMap }) => {
+  async ({ ws, metricsServerMap, action, connectedNodesByCluster }) => {
     const { connectionId, clusterId, monitorAction } = action.payload
-    const connectionIds = clusterId ? clusterNodesMap.get(clusterId as string) ?? [] : [connectionId]
+    const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
 
     const promises = connectionIds.map(async (connectionId: string) => {
       const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
@@ -85,8 +85,8 @@ export const monitorRequested = withDeps<Deps, void>(
   })
 
 export const saveMonitorSettingsRequested = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, metricsServerMap, clusterNodesMap, action }) => {
-    const deps: Deps = { ws, clients, connectionId, metricsServerMap, clusterNodesMap }
+  async ({ ws, clients, connectionId, metricsServerMap, connectedNodesByCluster, action }) => {
+    const deps: Deps = { ws, clients, connectionId, metricsServerMap, connectedNodesByCluster }
     const { config, monitorAction } = action.payload
 
     if (config) {

--- a/apps/server/src/actions/utils.ts
+++ b/apps/server/src/actions/utils.ts
@@ -1,6 +1,6 @@
 import { type GlideClient, type GlideClusterClient } from "@valkey/valkey-glide"
 import { FETCH_TIMEOUT_MS } from "valkey-common"
-import { MetricsServerMap } from "../metrics-orchestrator"
+import { ClusterRegistry, MetricsServerMap } from "../metrics-orchestrator"
 import type WebSocket from "ws"
 
 export type Deps = {
@@ -8,7 +8,8 @@ export type Deps = {
   clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId?: string}>
   connectionId: string,
   metricsServerMap: MetricsServerMap,
-  clusterNodesMap: Map<string, string[]>,
+  connectedNodesByCluster: Map<string, string[]>,
+  clusterNodesRegistry: ClusterRegistry,
 }
 
 export type ReduxAction = {

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -308,6 +308,7 @@ export async function connectToCluster(
       clients.set(nodeConnectionId, { client: clusterClient, clusterId })
       if (!connectedNodesByCluster.get(clusterId)?.includes(nodeConnectionId)) connectedNodesByCluster.get(clusterId)?.push(nodeConnectionId)
       if (!metricsServerMap.has(connectionId)) await startMetricsServer(payload.connectionDetails, connectionId)
+      if (!metricsServerMap.has(nodeConnectionId)) await startMetricsServer(payload.connectionDetails, nodeConnectionId)
       // Add connectedNode to payload 
       ws.send(
         JSON.stringify({

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -227,7 +227,7 @@ export async function connectToCluster(
     }
     const useClusterEndpoint = payload.connectionDetails.endpointType === "cluster-endpoint"
     if (useClusterEndpoint) {
-      const firstNode = Object.values(connectedNodesByCluster)[0]
+      const firstNode = Object.values(discoveredClusterNodes)[0]
       ws.send(
         JSON.stringify({
           type: VALKEY.CONNECTION.configEndpointRedirect,

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -210,7 +210,6 @@ export async function connectToCluster(
   credentials: ServerCredentials | undefined,
   connectedNodesByCluster: Map<string, string[]>,
   clusterNodesRegistry: ClusterRegistry,
-  configEndpointId?: string,
 ): Promise<GlideClusterClient | undefined> {
 
   const { connectionId } = payload
@@ -228,7 +227,7 @@ export async function connectToCluster(
     }
     const useClusterEndpoint = payload.connectionDetails.endpointType === "cluster-endpoint"
     if (useClusterEndpoint) {
-      const firstNode = Object.values(clusterNodes)[0]
+      const firstNode = Object.values(connectedNodesByCluster)[0]
       ws.send(
         JSON.stringify({
           type: VALKEY.CONNECTION.configEndpointRedirect,

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -80,7 +80,9 @@ export async function connectToValkey(
       useTLS,
       verifyTlsCertificate,
     })
-    
+    // Need to set for metrics server to be able to register
+    clients.set(connectionId, { client: standaloneClient })
+
     // In cluster-orchestrator mode, metrics sidecars register themselves.
     if (process.env.USE_CLUSTER_ORCHESTRATOR !== "true" && !metricsServerMap.has(payload.connectionId)) {
       await startMetricsServer(payload.connectionDetails, payload.connectionId)
@@ -90,6 +92,7 @@ export async function connectToValkey(
     const jsonModuleAvailable = await checkJsonModuleAvailability(standaloneClient)
     
     if (endpointType === "cluster-endpoint" || await belongsToCluster(standaloneClient)) {
+      clients.delete(connectionId)
       return connectToCluster(
         ws, 
         standaloneClient,
@@ -101,8 +104,6 @@ export async function connectToValkey(
         clusterNodesRegistry,
       )
     }
-
-    clients.set(connectionId, { client: standaloneClient })
 
     const connectionInfo = {
       type: VALKEY.CONNECTION.standaloneConnectFulfilled,

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -13,7 +13,7 @@ import {
   returnExistingClusterClient } from "./utils"
 import { checkJsonModuleAvailability } from "./check-json-module"
 import { type ConnectionDetails } from "./actions/connection"
-import { MetricsServerMap, startMetricsServer } from "./metrics-orchestrator"
+import { ClusterRegistry, MetricsServerMap, startMetricsServer } from "./metrics-orchestrator"
 import { subscribe } from "./node-watchers"
 import { createClusterValkeyClient, createStandaloneValkeyClient } from "./valkey-client"
 
@@ -25,8 +25,9 @@ export async function connectToValkey(
     isRetry?: boolean
   },
   clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId?: string }>,
-  clusterNodesMap: Map<string, string[]>,
+  connectedNodesByCluster: Map<string, string[]>,
   metricsServerMap: MetricsServerMap,
+  clusterNodesRegistry: ClusterRegistry,
 ) {
   
   const { 
@@ -81,8 +82,9 @@ export async function connectToValkey(
         payload, 
         addresses, 
         credentials, 
-        clusterNodesMap,
+        connectedNodesByCluster,
         metricsServerMap,
+        clusterNodesRegistry,
       )
     }
 
@@ -111,8 +113,9 @@ export async function connectToValkey(
         payload, 
         addresses, 
         credentials, 
-        clusterNodesMap,
+        connectedNodesByCluster,
         metricsServerMap,
+        clusterNodesRegistry,
       )
     }
 
@@ -166,7 +169,7 @@ export async function discoverCluster(client: GlideClient | GlideClusterClient, 
     // First primary node's ID
     const clusterId = R.path([0, 2, 2], response)
 
-    const clusterNodes = response.reduce((acc, slotRange) => {
+    const discoveredClusterNodes = response.reduce((acc, slotRange) => {
       const [, , ...nodes] = slotRange
       const [primaryHost, primaryPort] = nodes[0]
       const primaryKey = sanitizeUrl(`${primaryHost}-${primaryPort}`)
@@ -205,7 +208,7 @@ export async function discoverCluster(client: GlideClient | GlideClusterClient, 
       replicas: { id: string; host: string; port: number }[];
     }>)
 
-    return { clusterNodes, clusterId }
+    return { discoveredClusterNodes, clusterId }
   } catch (err) {
     console.error("Error discovering cluster:", err)
     throw new Error("Failed to discover cluster") 
@@ -219,10 +222,12 @@ export async function connectToCluster(
   payload: { connectionDetails: ConnectionDetails, connectionId: string, isRetry?: boolean},
   addresses: { host: string, port: number }[],
   credentials: ServerCredentials | undefined,
-  clusterNodesMap: Map<string, string[]>,
+  connectedNodesByCluster: Map<string, string[]>,
   metricsServerMap: MetricsServerMap,
+  clusterNodesRegistry: ClusterRegistry,
   configEndpointId?: string,
 ): Promise<GlideClusterClient | undefined> {
+
   const { connectionId } = payload
   const { verifyTlsCertificate, tls: useTLS } = payload.connectionDetails
   try {
@@ -230,27 +235,27 @@ export async function connectToCluster(
     const discoveryClient = await createStandaloneValkeyClient({ addresses, credentials, useTLS, verifyTlsCertificate })
     let clusterClient: GlideClusterClient 
 
-    // TODO: Optimize to not call discoverCluster when configEndpointId is available
     // It implies we already discovered cluster nodes once
-    const { clusterNodes, clusterId: initialClusterId } = await discoverCluster(discoveryClient, payload)
+    const { discoveredClusterNodes, clusterId: initialClusterId } = await discoverCluster(discoveryClient, payload)
     discoveryClient.close()
     let clusterId = initialClusterId
-    if (Object.keys(clusterNodes).length < 3) {
+    if (Object.keys(discoveredClusterNodes).length < 3) {
       throw new Error("Unable to discover cluster")
     }
     const useClusterEndpoint = payload.connectionDetails.endpointType === "cluster-endpoint"
     // Reconnect using a real node address instead of the clustercfg endpoint
     if (useClusterEndpoint) {
       return await connectToFirstNode(
-        clusterNodes,
+        discoveredClusterNodes,
         ws,
         clients,
-        clusterNodesMap,
+        connectedNodesByCluster,
         payload,
+        clusterNodesRegistry,
       )
     }
 
-    const existingClusterConnection = await clusterClientExists(clusterNodes, clients)
+    const existingClusterConnection = await clusterClientExists(discoveredClusterNodes, clients)
     if (existingClusterConnection) {
       clusterId = existingClusterConnection.clusterId
       if (payload.isRetry) {
@@ -271,9 +276,10 @@ export async function connectToCluster(
           existingClusterConnection,
           clients,
           payload.connectionId,
-          clusterNodesMap,
+          connectedNodesByCluster,
+          clusterNodesRegistry,
           ws,
-          clusterNodes,
+          discoveredClusterNodes,
         )
       }
     } 
@@ -283,11 +289,12 @@ export async function connectToCluster(
       ws.send(
         JSON.stringify({
           type: VALKEY.CLUSTER.addCluster,
-          payload: { clusterId, clusterNodes }, //TODO: strip credentials (this will impact connecting from Cluster Topology)
+          payload: { clusterId, discoveredClusterNodes }, 
         }),
       )
+      clusterNodesRegistry[clusterId] = discoveredClusterNodes
       clients.set(connectionId, { client: clusterClient, clusterId })
-      clusterNodesMap.set(clusterId, [connectionId])
+      connectedNodesByCluster.set(clusterId, [connectionId])
       subscribe(payload.connectionId, ws)
     }
 
@@ -299,7 +306,7 @@ export async function connectToCluster(
     if (configEndpointId) {
       const nodeConnectionId = sanitizeUrl(`${payload.connectionDetails.host}-${payload.connectionDetails.port}`)
       clients.set(nodeConnectionId, { client: clusterClient, clusterId })
-      if (!clusterNodesMap.get(clusterId)?.includes(nodeConnectionId)) clusterNodesMap.get(clusterId)?.push(nodeConnectionId)
+      if (!connectedNodesByCluster.get(clusterId)?.includes(nodeConnectionId)) connectedNodesByCluster.get(clusterId)?.push(nodeConnectionId)
       if (!metricsServerMap.has(connectionId)) await startMetricsServer(payload.connectionDetails, connectionId)
       // Add connectedNode to payload 
       ws.send(

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -289,7 +289,7 @@ export async function connectToCluster(
       ws.send(
         JSON.stringify({
           type: VALKEY.CLUSTER.addCluster,
-          payload: { clusterId, discoveredClusterNodes }, 
+          payload: { clusterId, clusterNodes: discoveredClusterNodes }, 
         }),
       )
       clusterNodesRegistry[clusterId] = discoveredClusterNodes

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -113,7 +113,7 @@ async function refreshAllClusterRegistries() {
       if (!clientEntry) return
 
       const updatedNodes = clusterNodesRegistry[clusterId]
-      // Am I being too safe here?
+      // Am I being too defensive here?
       if (!updatedNodes) return
 
       wss.clients.forEach((ws) => {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -32,8 +32,7 @@ import {
   clusterNodesRegistry,
   initialConnectionDetails,
   cleanupOrchestratorResources,
-  clients,
-  updateClusterNodeRegistry
+  clients
 } from "./metrics-orchestrator"
 import type { Request, Response } from "express"
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -33,7 +33,7 @@ import {
   initialConnectionDetails,
   cleanupOrchestratorResources,
   clients,
-  getInitialClient
+  updateClusterNodeRegistry
 } from "./metrics-orchestrator"
 import type { Request, Response } from "express"
 
@@ -87,21 +87,16 @@ async function runReconcileLoop() {
     return
   }
 
-  let initialClient
   let consecutiveFailures = 0
   const MAX_FAILURES = 5
 
   while (true) {
     try {
-      if (!initialClient) {
-        initialClient = await getInitialClient()
-      }
-      await reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap, initialConnectionDetails, initialClient)
+      await reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap, initialConnectionDetails)
       consecutiveFailures = 0
-      await delay(5000)
+      await delay(10000)
     } catch (err) {
       console.error("Failed to reconcile metrics servers", err)
-      initialClient = undefined
       consecutiveFailures++
       if (consecutiveFailures >= MAX_FAILURES) {
         console.error(`Orchestrator failed ${MAX_FAILURES} consecutive times. Stopping reconcile loop.`)
@@ -112,11 +107,45 @@ async function runReconcileLoop() {
   }
 }
 
+async function refreshAllClusterRegistries() {
+  await Promise.all(
+    Object.entries(clusterNodesRegistry).map(async ([clusterId]) => {
+      const clientEntry = [...clients.values()].find((e) => e.clusterId === clusterId)
+      if (!clientEntry) return
+
+      const updatedNodes = clusterNodesRegistry[clusterId]
+      // Am I being too safe here?
+      if (!updatedNodes) return
+
+      wss.clients.forEach((ws) => {
+        ws.send(JSON.stringify({
+          type: VALKEY.CLUSTER.updateClusterInfo,
+          payload: { clusterId, clusterNodes: updatedNodes },
+        }))
+      })
+    }),
+  )
+}
+
+async function refreshAllClusterRegistriesLoop() {
+  while (true) {
+    try {
+      await refreshAllClusterRegistries()
+      const refreshInterval = process.env.TOPOLOGY_REFRESH_INTERVAL
+      await delay( refreshInterval ? Number(refreshInterval) : 30000)
+    } catch (err) {
+      console.warn("Unable to refresh cluster topologies. ", err)
+    }
+  }
+}
+
 server.listen(port, () => {
   console.log(`Server running at http://localhost:${port}`)
   if (process.send) { // Check if process.send is available (i.e., if forked)
     process.send({ type: "websocket-ready" }) // Send a ready message to the parent process
   }
+  refreshAllClusterRegistriesLoop()
+
   if (process.env.USE_CLUSTER_ORCHESTRATOR === "true") {
     runReconcileLoop()
   }
@@ -135,7 +164,7 @@ wss.on("connection", (ws: AliveWebSocket) => {
   ws.isAlive = true
   ws.on("pong", () => {ws.isAlive = true})
   // This is a simplified cluster node map that stores clusterIds and their corresponding nodeIds
-  const clusterNodesMap: Map<string, string[]> = new Map()
+  const connectedNodesByCluster: Map<string, string[]> = new Map()
 
   const handlers: Record<string, Handler> = {
     [VALKEY.CONNECTION.connectPending]: connectPending,
@@ -198,7 +227,13 @@ wss.on("connection", (ws: AliveWebSocket) => {
 
     try {
       const handler = handlers[action.type] ?? unknownHandler
-      await handler({ ws, clients, connectionId: connectionId!, metricsServerMap, clusterNodesMap })(action as ReduxAction)
+      await handler(
+        { ws, 
+          clients, 
+          connectionId: connectionId!, 
+          metricsServerMap, 
+          connectedNodesByCluster, 
+          clusterNodesRegistry })(action as ReduxAction)
     } catch (error) {
       console.error(`Error handling action ${action.type}:`, error)
     }
@@ -208,7 +243,7 @@ wss.on("connection", (ws: AliveWebSocket) => {
   })
   ws.on("close", (code, reason) => {
     const removedIds = unsubscribeAll(ws)
-    clusterNodesMap.clear()
+    connectedNodesByCluster.clear()
     console.log("Client disconnected. Reason:", code, reason.toString())
 
     for (const connectionId of removedIds) {

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -163,18 +163,18 @@ async function createClusterClient(connectionDetails: ConnectionDetails) {
   return await createOrchestratorValkeyClient({ addresses, credentials, useTLS: tls, verifyTlsCertificate })
 }
 
-async function getClusterTopology(client: GlideClusterClient | null, node: ConnectionDetails) {
+async function getClusterTopology(client: GlideClusterClient | GlideClient | null, node: ConnectionDetails) {
   if (!client) client = await createClusterClient(node)
 
-  const { clusterNodes, clusterId } = await discoverCluster(client, { connectionDetails: node })
+  const { discoveredClusterNodes, clusterId } = await discoverCluster(client, { connectionDetails: node })
 
-  return { clusterNodes, clusterId }
+  return { discoveredClusterNodes, clusterId }
 }
 
-async function updateClusterNodeRegistry(client: GlideClusterClient | null) {
+export async function updateClusterNodeRegistry(client: GlideClusterClient | GlideClient | null, connectionDetails = initialConnectionDetails) {
   try {
-    const { clusterNodes, clusterId } = await getClusterTopology(client, initialConnectionDetails)
-    if (clusterId && clusterNodes) clusterNodesRegistry[clusterId] = clusterNodes 
+    const { discoveredClusterNodes, clusterId } = await getClusterTopology(client, connectionDetails)
+    if (clusterId && discoveredClusterNodes) clusterNodesRegistry[clusterId] = discoveredClusterNodes 
   }
   catch (err) {
     if (err instanceof ConnectionError) {
@@ -333,13 +333,13 @@ export async function reconcileClusterMetricsServers(
   clusterNodesRegistry: ClusterRegistry, 
   metricsServerMap: MetricsServerMap, 
   connectionDetails: ConnectionDetails, 
-  client: GlideClusterClient | null,
 ) {
   let clusterIds = Object.keys(clusterNodesRegistry) 
   if (clusterIds.length === 0) {
     try {
-      const { clusterNodes, clusterId } = await internals.getClusterTopology(client, connectionDetails)
-      if (clusterId && clusterNodes) clusterNodesRegistry[clusterId] = clusterNodes 
+      const client = await getInitialClient()
+      const { discoveredClusterNodes, clusterId } = await internals.getClusterTopology(client, connectionDetails)
+      if (clusterId && discoveredClusterNodes) clusterNodesRegistry[clusterId] = discoveredClusterNodes 
       clusterIds = Object.keys(clusterNodesRegistry)
     } catch (err) {
       console.error(err)
@@ -348,8 +348,7 @@ export async function reconcileClusterMetricsServers(
   await Promise.all(
     clusterIds.map(async (clusterId) => {
       try {
-        const updatedClusterNodeRegistry = await internals.updateClusterNodeRegistry(client)
-        const { nodesToAdd, nodesToRemove } = await internals.findDiff(metricsServerMap, updatedClusterNodeRegistry[clusterId])
+        const { nodesToAdd, nodesToRemove } = await internals.findDiff(metricsServerMap, clusterNodesRegistry[clusterId])
         // Early return if nothing has changed
         if (Object.keys(nodesToAdd).length === 0 && nodesToRemove.length === 0) {
           console.debug("Cluster nodes and metrics servers are in sync")

--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -160,11 +160,11 @@ function isClusterClientEntry(
 }
 
 export async function clusterClientExists(
-  clusterNodes: ClusterNodeMap, 
+  discoveredClusterNodes: ClusterNodeMap, 
   clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId?: string}>,
 ) {
   // Check if we've already connected to this cluster before 
-  const existingKey = Object.keys(clusterNodes).find(
+  const existingKey = Object.keys(discoveredClusterNodes).find(
     (key) => isClusterClientEntry(clients.get(key)),
   )
 

--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -10,7 +10,7 @@ import * as R from "ramda"
 import { lookup, reverse } from "node:dns/promises"
 import { KEY_EVICTION_POLICY, KeyEvictionPolicy, sanitizeUrl, VALKEY } from "valkey-common"
 import WebSocket from "ws"
-import { ClusterNodeMap, metricsServerMap } from "./metrics-orchestrator"
+import { ClusterNodeMap, ClusterRegistry, metricsServerMap } from "./metrics-orchestrator"
 import { connectToCluster } from "./connection"
 import { subscribe } from "./node-watchers"
 import type { ConnectionDetails } from "./actions/connection"
@@ -146,11 +146,11 @@ export async function resolveHostnameOrIpAddress(hostnameOrIP: string) {
 export async function isLastConnectedClusterNode(
   connectionId: string, 
   clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId? :string }>,
-  clusterNodesMap: Map<string, string[]>) 
+  connectedNodesByCluster: Map<string, string[]>) 
 {
   const connection = clients.get(connectionId)
   const currentClusterId = connection?.clusterId
-  return clusterNodesMap.get(currentClusterId!)?.length === 1
+  return connectedNodesByCluster.get(currentClusterId!)?.length === 1
 }
 
 function isClusterClientEntry(
@@ -179,19 +179,21 @@ export async function returnExistingClusterClient(
   existingClusterConnection: {client: GlideClusterClient, clusterId?: string},
   clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId?: string}>,
   connectionId: string,
-  clusterNodesMap: Map<string, string[]>,
+  connectedNodesByCluster: Map<string, string[]>,
+  clusterNodesRegistry: ClusterRegistry,
   ws: WebSocket,
-  clusterNodes: ClusterNodeMap,
+  discoveredClusterNodes: ClusterNodeMap,
 ) {
   const { client: existingClusterClient, clusterId: existingClusterId } = existingClusterConnection
   clients.set(connectionId, { client: existingClusterClient, clusterId: existingClusterId })
-      
-  if (!clusterNodesMap.get(existingClusterId!)?.includes(connectionId)) clusterNodesMap.get(existingClusterId!)?.push(connectionId)
+  clusterNodesRegistry[existingClusterId!] = discoveredClusterNodes
+  if (!connectedNodesByCluster.get(existingClusterId!)?.includes(connectionId)) 
+    connectedNodesByCluster.get(existingClusterId!)?.push(connectionId)
   subscribe(connectionId, ws)
   ws.send(
     JSON.stringify({
       type: VALKEY.CLUSTER.updateClusterInfo,
-      payload: { clusterId: existingClusterId, clusterNodes },
+      payload: { clusterId: existingClusterId, clusterNodes: discoveredClusterNodes },
     }),
   )
   return existingClusterClient
@@ -201,8 +203,9 @@ export async function connectToFirstNode(
   clusterNodes: ClusterNodeMap, 
   ws: WebSocket, 
   clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId?: string}>,
-  clusterNodesMap: Map<string, string[]>,
+  connectedNodesByCluster: Map<string, string[]>,
   payload: { connectionDetails: ConnectionDetails, connectionId: string, isRetry?: boolean},
+  clusterNodesRegistry: ClusterRegistry,
 ) {
   const firstNode = Object.values(clusterNodes)[0]
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -246,8 +249,9 @@ export async function connectToFirstNode(
     newPayload,
     newAddresses,
     newCredentials,
-    clusterNodesMap,
+    connectedNodesByCluster,
     metricsServerMap,
+    clusterNodesRegistry,
     payload.connectionId,
   )
 }


### PR DESCRIPTION
## Description

### Hot keys fan-out & aggregation
- Hot key requests are fanned out to all nodes in clusterNodesRegistry when a clusterId is present
- Results are aggregated by summing access counts per key, with size and TTL preserved from the first node that has them 
- Hot keys state is keyed by clusterId for cluster connections

### Error handling
- A yellow warning banner is shown when partial data is returned alongside node errors
- Node-level errors are collected per node and returned alongside data in hotKeysFulfilled rather than firing individual hotKeysError messages 
- If all nodes fail or monitor isn't running, a fulfilled response with empty data is still sent so the UI displays the new banner

### Hot key calculation fix
- calculateHotKeysFromMonitor previously counted every command argument as a key. It now only counts args[0] for single-key commands, all args for mget/json.mget, and every other arg for mset

### Cluster topology fix
- Added refreshAllClusterRegistriesLoop to periodically broadcast updated cluster topology to all connected clients
- Simplified reconcileClusterMetricsServers — removed getInitialClient indirection, increased reconcile interval to 10s

### Misc
- Renamed clusterNodesMap → connectedNodesByCluster throughout for clarity
- Added clusterNodesRegistry to the Deps type so all action handlers have access to the full cluster node map

### Change Visualization

Include a screenshot/video of before and after the change.
