### PR TITLE
Fix password prompt when there is no password

### DIFF
--- a/apps/frontend/src/components/cluster-topology/cluster-node.tsx
+++ b/apps/frontend/src/components/cluster-topology/cluster-node.tsx
@@ -1,3 +1,4 @@
+import * as R from "ramda"
 import { useState } from "react"
 import { LayoutDashboard, Terminal, PowerIcon, Server, MemoryStick, Users } from "lucide-react"
 import { useNavigate, useParams } from "react-router"
@@ -92,7 +93,7 @@ export function ClusterNode({
           awsReplicationGroupId: primary.awsReplicationGroupId,
         },
       }))
-    } else if (encryptedPassword) {
+    } else if (R.isNotNil(encryptedPassword)) {
       // Password already encrypted from existing cluster connection — do NOT re-encrypt
       dispatch(connectPending({
         connectionId,

--- a/apps/frontend/src/state/valkey-features/connection/connectionSelectors.ts
+++ b/apps/frontend/src/state/valkey-features/connection/connectionSelectors.ts
@@ -22,7 +22,7 @@ export const selectEndpointType = (id: string) => (state: RootState) => atId(id,
 
 export const selectEncryptedPassword = (clusterId: string) => (state: RootState) =>
   Object.values(state.valkeyConnection?.connections ?? {}).find(
-    (c) => c.connectionDetails?.clusterId === clusterId && c.connectionDetails?.password,
+    (c) => c.connectionDetails?.clusterId === clusterId && R.isNotNil(c.connectionDetails?.password),
   )?.connectionDetails?.password
 
 export const selectConfigEndpointNode = (clusterId: string) => (state: RootState) => {


### PR DESCRIPTION
## Description

Previously an empty string was not an option, so I used truthy checks to determine if the password modal was needed. [This change allows for empty passwords to be unencrypted](https://github.com/valkey-io/valkey-admin/pull/271) which changes the assumption the password modal appearance was based on. This change fixes the remaining truthy checks.

