### PR TITLE
Aggregate command logs across cluster nodes and add node attribution

### DIFF
--- a/apps/frontend/src/components/monitoring/Monitoring.tsx
+++ b/apps/frontend/src/components/monitoring/Monitoring.tsx
@@ -15,7 +15,7 @@ import KeyDetails from "../key-browser/key-details/key-details"
 import RouteContainer from "../ui/route-container"
 import { Button } from "../ui/button"
 import type { RootState } from "@/store"
-import { commandLogsRequested, selectCommandLogs } from "@/state/valkey-features/commandlogs/commandLogsSlice"
+import { commandLogsRequested, selectCommandLogs, selectCommandLogsNodeErrors } from "@/state/valkey-features/commandlogs/commandLogsSlice"
 import { useAppDispatch } from "@/hooks/hooks"
 import {
   hotKeysRequested, selectHotKeys, selectHotKeysStatus, selectHotKeysError, selectHotKeysNodeErrors
@@ -45,9 +45,11 @@ export const Monitoring = () => {
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [configOpen, setConfigOpen] = useState(false)
 
-  const commandLogsSlowData = useSelector((state: RootState) => selectCommandLogs(id!, COMMANDLOG_TYPE.SLOW)(state))
-  const commandLogsLargeRequestData = useSelector((state: RootState) => selectCommandLogs(id!, COMMANDLOG_TYPE.LARGE_REQUEST)(state))
-  const commandLogsLargeReplyData = useSelector((state: RootState) => selectCommandLogs(id!, COMMANDLOG_TYPE.LARGE_REPLY)(state))
+  const commandLogsId = clusterId ?? id!
+  const commandLogsSlowData = useSelector((state: RootState) => selectCommandLogs(commandLogsId, COMMANDLOG_TYPE.SLOW)(state))
+  const commandLogsLargeRequestData = useSelector((state: RootState) => selectCommandLogs(commandLogsId, COMMANDLOG_TYPE.LARGE_REQUEST)(state))
+  const commandLogsLargeReplyData = useSelector((state: RootState) => selectCommandLogs(commandLogsId, COMMANDLOG_TYPE.LARGE_REPLY)(state))
+  const commandLogsNodeErrors = useSelector((state: RootState) => selectCommandLogsNodeErrors(commandLogsId)(state))
   const hotKeysId = clusterId ?? id!
   const hotKeysData = useSelector((state: RootState) => selectHotKeys(hotKeysId)(state))
   const hotKeysStatus = useSelector((state: RootState) => selectHotKeysStatus(hotKeysId)(state))
@@ -213,7 +215,7 @@ export const Monitoring = () => {
         </div>
       ) : (
         <div className="flex-1 h-full overflow-hidden border border-input rounded-md shadow-xs">
-          <CommandLogTable data={getCurrentCommandLogData()} logType={commandLogSubTab} />
+          <CommandLogTable data={getCurrentCommandLogData()} logType={commandLogSubTab} nodeErrors={commandLogsNodeErrors} />
         </div>
       )}
     </RouteContainer>

--- a/apps/frontend/src/components/monitoring/command-log-table.tsx
+++ b/apps/frontend/src/components/monitoring/command-log-table.tsx
@@ -33,6 +33,7 @@ interface LogGroup {
   ts: number
   metric: string
   values: (SlowLogEntry | LargeLogEntry)[]
+  nodeId: string,
 }
 
 type LogType = "slow" | "large-request" | "large-reply"
@@ -117,6 +118,7 @@ export function CommandLogTable({ data, logType, nodeErrors }: CommandLogTablePr
       logGroup.values.map((entry) => ({
         ...entry,
         groupTs: logGroup.ts,
+        nodeId: (logGroup).nodeId,
       })),
     )
     .sort((sortOrder === SORT_ORDER.ASC ? R.ascend : R.descend)(
@@ -129,81 +131,81 @@ export function CommandLogTable({ data, logType, nodeErrors }: CommandLogTablePr
     <>
       {nodeErrorsBanner}
       <TableContainer
-      header={
-        <>
-          <StaticTableHeader className="flex-1" label="Command" />
-          <SortableTableHeader
-            active={sortField === SORT_FIELD.METRIC}
-            className="text-center"
-            label={config.metricLabel}
-            onClick={() => toggleSort(SORT_FIELD.METRIC)}
-            sortOrder={sortOrder === SORT_ORDER.ASC ? "asc" : "desc"}
-            width="w-1/6"
-          />
-          <SortableTableHeader
-            active={sortField === SORT_FIELD.TIMESTAMP}
-            icon={<Clock className="text-primary" size={16} />}
-            label="Timestamp"
-            onClick={() => toggleSort(SORT_FIELD.TIMESTAMP)}
-            sortOrder={sortOrder === SORT_ORDER.ASC ? "asc" : "desc"}
-            width="w-1/6"
-          />
-          <StaticTableHeader className="text-center" label="Client Address" width="w-1/6" />
-          <StaticTableHeader className="text-center" label="Node" width="w-1/6" />
-        </>
-      }
-    >
-      {sortedLogs.map((entry, index) => {
-        const metricValue = config.metricKey in entry
-          ? entry[config.metricKey as keyof typeof entry] as number
-          : 0
+        header={
+          <>
+            <StaticTableHeader className="flex-1" label="Command" />
+            <SortableTableHeader
+              active={sortField === SORT_FIELD.METRIC}
+              className="text-center"
+              label={config.metricLabel}
+              onClick={() => toggleSort(SORT_FIELD.METRIC)}
+              sortOrder={sortOrder === SORT_ORDER.ASC ? "asc" : "desc"}
+              width="w-1/6"
+            />
+            <SortableTableHeader
+              active={sortField === SORT_FIELD.TIMESTAMP}
+              icon={<Clock className="text-primary" size={16} />}
+              label="Timestamp"
+              onClick={() => toggleSort(SORT_FIELD.TIMESTAMP)}
+              sortOrder={sortOrder === SORT_ORDER.ASC ? "asc" : "desc"}
+              width="w-1/6"
+            />
+            <StaticTableHeader className="text-center" label="Client Address" width="w-1/6" />
+            <StaticTableHeader className="text-center" label="Node" width="w-1/6" />
+          </>
+        }
+      >
+        {sortedLogs.map((entry, index) => {
+          const metricValue = config.metricKey in entry
+            ? entry[config.metricKey as keyof typeof entry] as number
+            : 0
 
-        return (
-          <tr
-            className="group border-b dark:border-tw-dark-border hover:bg-primary/10"
-            key={`${entry.groupTs}-${entry.id}-${index}`}
-          >
-            {/* command */}
-            <td className="px-4 py-2 flex-1">
-              <CustomTooltip content={entry.argv.join(" ")}>
-                <Typography
-                  className="bg-primary/30 py-1 px-2 rounded-full"
-                  variant="code"
-                >
-                  {truncateCommand(entry.argv)}
+          return (
+            <tr
+              className="group border-b dark:border-tw-dark-border hover:bg-primary/10"
+              key={`${entry.groupTs}-${entry.id}-${index}`}
+            >
+              {/* command */}
+              <td className="px-4 py-2 flex-1">
+                <CustomTooltip content={entry.argv.join(" ")}>
+                  <Typography
+                    className="bg-primary/30 py-1 px-2 rounded-full"
+                    variant="code"
+                  >
+                    {truncateCommand(entry.argv)}
+                  </Typography>
+                </CustomTooltip>
+              </td>
+
+              {/* metric (duration or size) */}
+              <td className="px-4 py-2 w-1/6 text-center">
+                <Typography className="" variant="bodySm">
+                  {config.metricFormat(metricValue)}
                 </Typography>
-              </CustomTooltip>
-            </td>
+              </td>
 
-            {/* metric (duration or size) */}
-            <td className="px-4 py-2 w-1/6 text-center">
-              <Typography className="" variant="bodySm">
-                {config.metricFormat(metricValue)}
-              </Typography>
-            </td>
+              {/* timestamp */}
+              <td className="px-4 py-2 w-1/6 text-center">
+                <Typography variant="bodySm">
+                  {new Date(entry.ts).toLocaleString()}
+                </Typography>
+              </td>
 
-            {/* timestamp */}
-            <td className="px-4 py-2 w-1/6 text-center">
-              <Typography variant="bodySm">
-                {new Date(entry.ts).toLocaleString()}
-              </Typography>
-            </td>
+              {/* client address */}
+              <td className="px-4 py-2 w-1/6 text-center">
+                <Typography variant="code">
+                  {entry.addr}
+                </Typography>
+              </td>
 
-            {/* client address */}
-            <td className="px-4 py-2 w-1/6 text-center">
-              <Typography variant="code">
-                {entry.addr}
-              </Typography>
-            </td>
-
-            {/* node */}
-            <td className="px-4 py-2 w-1/6 text-center">
-              <Typography variant="code">{(entry as any).nodeId ?? "—"}</Typography>
-            </td>
-          </tr>
-        )
-      })}
-    </TableContainer>
+              {/* node */}
+              <td className="px-4 py-2 w-1/6 text-center">
+                <Typography variant="code">{(entry).nodeId ?? "—"}</Typography>
+              </td>
+            </tr>
+          )
+        })}
+      </TableContainer>
     </>
   ) : (
     <>

--- a/apps/frontend/src/components/monitoring/command-log-table.tsx
+++ b/apps/frontend/src/components/monitoring/command-log-table.tsx
@@ -197,11 +197,9 @@ export function CommandLogTable({ data, logType, nodeErrors }: CommandLogTablePr
             </td>
 
             {/* node */}
-            {"nodeId" in entry && (
-              <td className="px-4 py-2 w-1/6 text-center">
-                <Typography variant="code">{(entry as any).nodeId}</Typography>
-              </td>
-            )}
+            <td className="px-4 py-2 w-1/6 text-center">
+              <Typography variant="code">{(entry as any).nodeId ?? "—"}</Typography>
+            </td>
           </tr>
         )
       })}

--- a/apps/frontend/src/components/monitoring/command-log-table.tsx
+++ b/apps/frontend/src/components/monitoring/command-log-table.tsx
@@ -146,10 +146,10 @@ export function CommandLogTable({ data, logType, nodeErrors }: CommandLogTablePr
             label="Timestamp"
             onClick={() => toggleSort(SORT_FIELD.TIMESTAMP)}
             sortOrder={sortOrder === SORT_ORDER.ASC ? "asc" : "desc"}
-            width="w-1/4"
+            width="w-1/6"
           />
-          <StaticTableHeader className="text-center" label="Client Address" width="w-1/5" />
-          <StaticTableHeader className="text-center" label="Node" width="w-1/5" />
+          <StaticTableHeader className="text-center" label="Client Address" width="w-1/6" />
+          <StaticTableHeader className="text-center" label="Node" width="w-1/6" />
         </>
       }
     >
@@ -183,14 +183,14 @@ export function CommandLogTable({ data, logType, nodeErrors }: CommandLogTablePr
             </td>
 
             {/* timestamp */}
-            <td className="px-4 py-2 w-1/4 text-center">
+            <td className="px-4 py-2 w-1/6 text-center">
               <Typography variant="bodySm">
                 {new Date(entry.ts).toLocaleString()}
               </Typography>
             </td>
 
             {/* client address */}
-            <td className="px-4 py-2 w-1/5 text-center">
+            <td className="px-4 py-2 w-1/6 text-center">
               <Typography variant="code">
                 {entry.addr}
               </Typography>
@@ -198,7 +198,7 @@ export function CommandLogTable({ data, logType, nodeErrors }: CommandLogTablePr
 
             {/* node */}
             {"nodeId" in entry && (
-              <td className="px-4 py-2 w-1/5 text-center">
+              <td className="px-4 py-2 w-1/6 text-center">
                 <Typography variant="code">{(entry as any).nodeId}</Typography>
               </td>
             )}

--- a/apps/frontend/src/components/monitoring/command-log-table.tsx
+++ b/apps/frontend/src/components/monitoring/command-log-table.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Clock } from "lucide-react"
+import { Clock, AlertCircle } from "lucide-react"
 import * as R from "ramda"
 import { SORT_ORDER, SORT_FIELD } from "@common/src/constants"
 import { EmptyState } from "../ui/empty-state"
@@ -40,6 +40,7 @@ type LogType = "slow" | "large-request" | "large-reply"
 interface CommandLogTableProps {
   data: LogGroup[] | null
   logType: LogType
+  nodeErrors?: { connectionId: string; error: string }[]
 }
 
 const logTypeConfig = {
@@ -69,10 +70,32 @@ const logTypeConfig = {
   },
 }
 
-export function CommandLogTable({ data, logType }: CommandLogTableProps) {
+export function CommandLogTable({ data, logType, nodeErrors }: CommandLogTableProps) {
   const [sortField, setSortField] = useState<SortField>(SORT_FIELD.TIMESTAMP)
   const [sortOrder, setSortOrder] = useState<SortOrder>(SORT_ORDER.DESC)
   const config = logTypeConfig[logType]
+
+  const nodeErrorsBanner = nodeErrors && nodeErrors.length > 0 && (
+    <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border
+      border-yellow-200 dark:border-yellow-700 flex items-start gap-2">
+      <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
+      <div>
+        <Typography variant="bodySm">
+          Command log data is partial —{" "}
+          {nodeErrors.length} metrics server{nodeErrors.length > 1 ? "s" : ""} failed to respond or are not connected:
+        </Typography>
+        <ul className="mt-1 space-y-0.5">
+          {nodeErrors.map(({ connectionId, error }) => (
+            <li key={connectionId}>
+              <Typography variant="bodySm">
+                <span className="font-mono">{connectionId}</span>: {error}
+              </Typography>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
 
   const toggleSort = (field: SortField) => {
     if (sortField === field) {
@@ -103,7 +126,9 @@ export function CommandLogTable({ data, logType }: CommandLogTableProps) {
     ))
 
   return sortedLogs.length > 0 ? (
-    <TableContainer
+    <>
+      {nodeErrorsBanner}
+      <TableContainer
       header={
         <>
           <StaticTableHeader className="flex-1" label="Command" />
@@ -124,6 +149,7 @@ export function CommandLogTable({ data, logType }: CommandLogTableProps) {
             width="w-1/4"
           />
           <StaticTableHeader className="text-center" label="Client Address" width="w-1/5" />
+          <StaticTableHeader className="text-center" label="Node" width="w-1/5" />
         </>
       }
     >
@@ -169,15 +195,26 @@ export function CommandLogTable({ data, logType }: CommandLogTableProps) {
                 {entry.addr}
               </Typography>
             </td>
+
+            {/* node */}
+            {"nodeId" in entry && (
+              <td className="px-4 py-2 w-1/5 text-center">
+                <Typography variant="code">{(entry as any).nodeId}</Typography>
+              </td>
+            )}
           </tr>
         )
       })}
     </TableContainer>
+    </>
   ) : (
-    <EmptyState
-      description={config.emptySubtext}
-      icon={<Clock size={48} />}
-      title={config.emptyMessage}
-    />
+    <>
+      {nodeErrorsBanner}
+      <EmptyState
+        description={config.emptySubtext}
+        icon={<Clock size={48} />}
+        title={config.emptyMessage}
+      />
+    </>
   )
 }

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -155,11 +155,9 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
               </td>
 
               {/* node */}
-              {nodeId && (
-                <td className="px-4 py-3 w-1/6 text-center">
-                  <Typography variant={"code"}>{nodeId}</Typography>
-                </td>
-              )}
+              <td className="px-4 py-3 w-1/6 text-center">
+                <Typography variant={"code"}>{nodeId ?? "—"}</Typography>
+              </td>
             </tr>
           )
         })}

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -75,7 +75,7 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
             <StaticTableHeader
               icon={<Flame className="text-primary" size={16} />}
               label="Key Name"
-              width="w-2/5"
+              width="w-1/3"
             />
             <SortableTableHeader
               active={true}
@@ -83,11 +83,11 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
               label="Access Count"
               onClick={toggleSortOrder}
               sortOrder={sortOrder}
-              width="w-1/5"
+              width="w-1/6"
             />
-            <StaticTableHeader className="text-center" label="Size" width="w-1/5" />
-            <StaticTableHeader className="text-center" label="TTL" width="w-1/5" />
-            <StaticTableHeader className="text-center" label="Node" width="w-1/5" />
+            <StaticTableHeader className="text-center" label="Size" width="w-1/6" />
+            <StaticTableHeader className="text-center" label="TTL" width="w-1/6" />
+            <StaticTableHeader className="text-center" label="Node" width="w-1/6" />
           </>
         }
       >
@@ -106,7 +106,7 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
               onClick={() => onKeyClick?.(keyName)}
             >
               {/* key name */}
-              <td className="px-4 py-3 w-2/5">
+              <td className="px-4 py-3 w-1/3">
                 <div className="flex items-center gap-2">
                   <Typography className={`truncate
                             ${isDeleted
@@ -134,21 +134,21 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
               </td>
 
               {/* access count */}
-              <td className="px-4 py-3 w-1/5 text-center">
+              <td className="px-4 py-3 w-1/6 text-center">
                 <Typography variant={"bodySm"}>
                   {count.toLocaleString()}
                 </Typography>
               </td>
 
               {/* size */}
-              <td className="px-4 py-3 w-1/5 text-center">
+              <td className="px-4 py-3 w-1/6 text-center">
                 <Typography variant={"bodySm"}>
                   {isDeleted ? "—" : formatBytes(size!)}
                 </Typography>
               </td>
 
               {/* ttl */}
-              <td className="px-4 py-3 w-1/5 text-center">
+              <td className="px-4 py-3 w-1/6 text-center">
                 <Typography variant={"bodySm"}>
                   {isDeleted ? "—" : convertTTL(ttl)}
                 </Typography>
@@ -156,7 +156,7 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
 
               {/* node */}
               {nodeId && (
-                <td className="px-4 py-3 w-1/5 text-center">
+                <td className="px-4 py-3 w-1/6 text-center">
                   <Typography variant={"code"}>{nodeId}</Typography>
                 </td>
               )}

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -12,7 +12,7 @@ import { Typography } from "../ui/typography"
 import { copyToClipboard } from "@/lib/utils"
 
 interface HotKeysProps {
-  data: [string, number, number | null, number][] | null
+  data: [string, number, number | null, number, string?][] | null
   errorMessage: string | null
   status?: string
   monitorRunning?: boolean
@@ -87,10 +87,11 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
             />
             <StaticTableHeader className="text-center" label="Size" width="w-1/5" />
             <StaticTableHeader className="text-center" label="TTL" width="w-1/5" />
+            <StaticTableHeader className="text-center" label="Node" width="w-1/5" />
           </>
         }
       >
-        {sortedHotKeys.map(([keyName, count, size, ttl], index) => {
+        {sortedHotKeys.map(([keyName, count, size, ttl, nodeId], index) => {
           const isDeleted = ttl === -2
           return (
             <tr
@@ -152,6 +153,13 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
                   {isDeleted ? "—" : convertTTL(ttl)}
                 </Typography>
               </td>
+
+              {/* node */}
+              {nodeId && (
+                <td className="px-4 py-3 w-1/5 text-center">
+                  <Typography variant={"code"}>{nodeId}</Typography>
+                </td>
+              )}
             </tr>
           )
         })}

--- a/apps/frontend/src/state/valkey-features/commandlogs/commandLogsSlice.ts
+++ b/apps/frontend/src/state/valkey-features/commandlogs/commandLogsSlice.ts
@@ -12,6 +12,11 @@ export const selectCommandLogs =
     (state: RootState) =>
       R.path([VALKEY.COMMANDLOGS.name, connectionId, "logs", type], state)
 
+export const selectCommandLogsNodeErrors =
+  (connectionId: string) =>
+    (state: RootState) =>
+      R.path([VALKEY.COMMANDLOGS.name, connectionId, "nodeErrors"], state) ?? []
+
 interface CommandLogSlowEntry {
   id: string
   ts: number
@@ -50,6 +55,7 @@ interface CommandLogState {
     count: number
     error?: JSONObject | null
     loading?: boolean
+    nodeErrors?: { connectionId: string; error: string }[]
   }
 }
 
@@ -60,9 +66,10 @@ const commandLogsSlice = createSlice({
   initialState: initialCommandLogsState,
   reducers: {
     commandLogsRequested: (state, action) => {
-      const { connectionId } = action.payload
-      if (!state[connectionId]) {
-        state[connectionId] = {
+      const { connectionId, clusterId } = action.payload
+      const id = clusterId ?? connectionId
+      if (!state[id]) {
+        state[id] = {
           logs: {
             slow: [],
             [COMMANDLOG_TYPE.LARGE_REQUEST]: [],
@@ -72,11 +79,11 @@ const commandLogsSlice = createSlice({
           loading: false,
         }
       }
-      state[connectionId].loading = true
+      state[id].loading = true
     },
     commandLogsFulfilled: (state, action) => {
-      const { connectionId, parsedResponse } = action.payload
-      const commandLogType : CommandLogType = action.payload.commandLogType
+      const { connectionId, parsedResponse, nodeErrors } = action.payload
+      const commandLogType: CommandLogType = action.payload.commandLogType
       const { rows, count } = parsedResponse
       if (!state[connectionId]) {
         state[connectionId] = {
@@ -92,6 +99,7 @@ const commandLogsSlice = createSlice({
       state[connectionId].logs[commandLogType] = rows
       state[connectionId].count = count
       state[connectionId].loading = false
+      state[connectionId].nodeErrors = nodeErrors ?? []
     },
     commandLogsError: (state, action) => {
       const { connectionId, error } = action.payload

--- a/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
+++ b/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
@@ -20,7 +20,7 @@ export const selectHotKeysNodeErrors = (id: string) => (state: RootState) =>
 
 interface HotKeysState {
   [connectionId: string]: {
-    hotKeys: [string, number, number | null, number][]
+    hotKeys: [string, number, number | null, number, string?][]
     checkAt: string | null,
     monitorRunning: boolean,
     nodeId: string | null,

--- a/apps/metrics/src/handlers/commandlog-handler.js
+++ b/apps/metrics/src/handlers/commandlog-handler.js
@@ -27,7 +27,7 @@ const getCommandLogRows = async (commandlogType) => {
   }
 }
 
-export const getCommandLogs = async (req, res) => {
+export const getCommandLogs = async (req, res, nodeId) => {
   try {
     const commandlogType = req.query.type
     const { lastUpdatedAt, nextCycleAt } = getCollectorMeta(commandlogType) || {}
@@ -35,7 +35,7 @@ export const getCommandLogs = async (req, res) => {
       const count = Number(req.query.count) || 50
       const rows = await getCommandLogRows(commandlogType, count)
       // Add minimum (1) and maximum (500) boundaries for rows requested
-      return res.json({ count: Math.max(1, Math.min(500, count)), rows, lastUpdatedAt })
+      return res.json({ count: Math.max(1, Math.min(500, count)), rows, lastUpdatedAt, nodeId })
     }
     else return res.json({ checkAt: nextCycleAt, lastUpdatedAt })
   } catch (e) {

--- a/apps/metrics/src/handlers/monitor-handler.js
+++ b/apps/metrics/src/handlers/monitor-handler.js
@@ -13,7 +13,7 @@ const toResponse = ({ isRunning, willCompleteAt, startedAt }) => ({
   startedAt: startedAt ?? null,
 })
 
-export const useMonitor = async (res, client) => {
+export const useMonitor = async (res, client, nodeId) => {
   const { isRunning, willCompleteAt: checkAt } = getCollectorMeta(MONITOR) 
   try {
     if (!isRunning) {
@@ -21,7 +21,7 @@ export const useMonitor = async (res, client) => {
     }
     if (Date.now() > checkAt) {
       const hotKeys = await Streamer.monitor().then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
-      return res.json({ hotKeys, ...toResponse(getCollectorMeta(MONITOR)) })
+      return res.json({ hotKeys, nodeId, ...toResponse(getCollectorMeta(MONITOR)) })
     }
     return res.json({ checkAt })
   } catch (e) {

--- a/apps/metrics/src/index.js
+++ b/apps/metrics/src/index.js
@@ -58,7 +58,7 @@ async function main() {
     }
   })
 
-  app.get("/commandlog", getCommandLogs)
+  app.get("/commandlog", (req, res) => getCommandLogs(req, res, ownConnectionId))
 
   app.get("/slowlog_len", async (req, res) => {
     try {

--- a/apps/metrics/src/index.js
+++ b/apps/metrics/src/index.js
@@ -78,9 +78,9 @@ async function main() {
   app.get("/hot-keys", async (req, res) => {
     if (req.query.useHotSlots === "true") {
       const hotKeys = await calculateHotKeysFromHotSlots(client, req.query.count).then(enrichHotKeys(client))
-      return res.json({ hotKeys })
+      return res.json({ hotKeys, nodeId: ownConnectionId })
     }
-    else useMonitor(res, client)
+    else useMonitor(res, client, ownConnectionId)
   })
 
   app.post("/update-config", async (req, res) => {

--- a/apps/server/src/actions/commandLogs.ts
+++ b/apps/server/src/actions/commandLogs.ts
@@ -1,5 +1,6 @@
 import { type WebSocket } from "ws"
 import { VALKEY, COMMANDLOG_TYPE } from "valkey-common"
+import * as R from "ramda"
 import { withDeps, Deps } from "./utils"
 
 type CommandLogType = typeof COMMANDLOG_TYPE.SLOW | typeof COMMANDLOG_TYPE.LARGE_REQUEST | typeof COMMANDLOG_TYPE.LARGE_REPLY
@@ -38,13 +39,16 @@ type CommandLogsLargeResponse = {
   checkAt: number
 }
 
-type CommandLogResponse = CommandLogsLargeResponse | CommandLogsSlowResponse
+type CommandLogResponse = (CommandLogsLargeResponse | CommandLogsSlowResponse) & { nodeId?: string }
+
+type NodeError = { connectionId: string; error: string }
 
 const sendCommandLogsFulfilled = (
   ws: WebSocket,
   connectionId: string,
   parsedResponse: CommandLogsSlowResponse | CommandLogsLargeResponse,
   commandLogType: CommandLogType,
+  nodeErrors?: NodeError[],
 ) => {
   ws.send(
     JSON.stringify({
@@ -53,6 +57,7 @@ const sendCommandLogsFulfilled = (
         connectionId,
         parsedResponse,
         commandLogType,
+        ...(nodeErrors?.length ? { nodeErrors } : {}),
       },
     }),
   )
@@ -75,47 +80,61 @@ const sendCommandLogsError = (
   )
 }
 
+const fetchCommandLogs = async (metricsServerURI: string, commandLogType: CommandLogType): Promise<CommandLogResponse> => {
+  const url = `${metricsServerURI}/commandlog?type=${commandLogType}`
+  const initialResponse = await fetch(url)
+  const parsed: CommandLogResponse = await initialResponse.json() as CommandLogResponse
+  if (parsed.checkAt) {
+    const delay = parsed.checkAt - Date.now()
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    const dataResponse = await fetch(url)
+    return await dataResponse.json() as CommandLogResponse
+  }
+  return parsed
+}
+
 export const commandLogsRequested = withDeps<Deps, void>(
-  async ({ ws, metricsServerMap, action, connectedNodesByCluster }) => {
+  async ({ ws, metricsServerMap, action, clusterNodesRegistry }) => {
     const { connectionId, clusterId } = action.payload
-    const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
     const commandLogType: CommandLogType = action.payload.commandLogType as CommandLogType
 
-    const promises = connectionIds.map(async (connectionId: string) => {
-      const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
+    const nodes = typeof clusterId === "string" ? clusterNodesRegistry[clusterId] : undefined
+    const connectionIds = nodes ? Object.keys(nodes) : [connectionId]
 
+    const promises = connectionIds.map(async (nodeId: string) => {
+      const metricsServerURI = metricsServerMap.get(nodeId)?.metricsURI
       if (!metricsServerURI) {
-        sendCommandLogsError(ws, connectionId, new Error("Metrics server URI not found"))
-        return
+        if (!nodes) sendCommandLogsError(ws, nodeId, new Error("Metrics server URI not found"))
+        return { connectionId: nodeId, error: "Metrics server not started" } as NodeError
       }
-
       try {
-        const url = `${metricsServerURI}/commandlog?type=${commandLogType}`
-        console.debug(`[Command Logs ${commandLogType}] Fetching from:`, url)
-
-        const initialResponse = await fetch(url)
-        const initialParsedResponse: CommandLogResponse = await initialResponse.json() as CommandLogResponse
-        if (initialParsedResponse.checkAt) {
-          const delay = initialParsedResponse.checkAt - Date.now()
-          // Schedule the follow-up request for when the monitor cycle finishes
-          setTimeout(async () => {
-            try {
-              const dataResponse = await fetch(`${metricsServerURI}/commandlog?type=${commandLogType}`)
-              const dataParsedResponse = await dataResponse.json() as CommandLogResponse
-              sendCommandLogsFulfilled(ws, connectionId, dataParsedResponse, commandLogType)
-            } catch (error) {
-              sendCommandLogsError(ws, connectionId, error)
-            }
-          }, delay)
-        }
-        else {
-          sendCommandLogsFulfilled(ws, connectionId, initialParsedResponse, commandLogType)
-        }
-
+        console.debug(`[Command Logs ${commandLogType}] Fetching from:`, metricsServerURI)
+        return await fetchCommandLogs(metricsServerURI, commandLogType)
       } catch (error) {
-        sendCommandLogsError(ws, connectionId, error)
+        if (!nodes) sendCommandLogsError(ws, nodeId, error)
+        return { connectionId: nodeId, error: error instanceof Error ? error.message : String(error) } as NodeError
       }
-
     })
-    await Promise.all(promises)
+
+    const settled = await Promise.all(promises)
+    const results = settled.filter((r): r is CommandLogResponse & { connectionId: string } => !!r && "rows" in r)
+    const nodeErrors = nodes ? settled.filter((r): r is NodeError => !!r && "error" in r) : []
+
+    if (!nodes) {
+      if (results[0]) sendCommandLogsFulfilled(ws, connectionId, results[0], commandLogType)
+      return
+    }
+
+    const aggregatedRows = R.sort(
+      R.descend(R.prop("ts")),
+      results.flatMap((r) => r.rows.map((row) => ({ ...row, nodeId: r.nodeId }))),
+    )
+    const count = results[0]?.count ?? 0
+    sendCommandLogsFulfilled(
+      ws,
+      clusterId as string,
+      { rows: aggregatedRows, count, checkAt: 0 } as CommandLogResponse,
+      commandLogType,
+      nodeErrors,
+    )
   })

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -122,14 +122,19 @@ export const hotKeysRequested = withDeps<Deps, void>(
       return
     }
 
+    type HotKeyTuple = [string, number, number | null, number, string]
     const aggregatedHotKeys = R.pipe(
-      R.chain(({ hotKeys }: HotKeysResponse) => hotKeys as unknown as [string, number, number | null, number][]),
-      R.reduce((acc, [key, count, size, ttl]: [string, number, number | null, number]) => ({
+      R.chain(({ hotKeys, nodeId: nId }: HotKeysResponse) =>
+        (hotKeys as unknown as [string, number, number | null, number][]).map(
+          ([key, count, size, ttl]) => [key, count, size, ttl, nId] as HotKeyTuple,
+        ),
+      ),
+      R.reduce((acc: Record<string, HotKeyTuple>, [key, count, size, ttl, nId]: HotKeyTuple) => ({
         ...acc,
-        [key]: [key, (acc[key]?.[1] ?? 0) + count, acc[key]?.[2] ?? size, acc[key]?.[3] ?? ttl],
-      }), {} as Record<string, [string, number, number | null, number]>),
+        [key]: [key, (acc[key]?.[1] ?? 0) + count, acc[key]?.[2] ?? size, acc[key]?.[3] ?? ttl, nId] as HotKeyTuple,
+      }), {}),
       R.values,
-      R.sort(R.descend(R.prop(1))),
+      R.sort(R.descend(R.nth(1) as (x: HotKeyTuple) => number)),
     )(results)
     const { monitorRunning, checkAt, nodeId } = results[0]
     const aggregatedResponse = { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId } as unknown as HotKeysResponse

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -223,7 +223,7 @@ export async function connectToCluster(
     const { discoveredClusterNodes, clusterId: initialClusterId } = await discoverCluster(discoveryClient, payload)
     discoveryClient.close()
     let clusterId = initialClusterId
-    if (Object.keys(discoveredClusterNodes).length < 3) {
+    if (Object.keys(discoveredClusterNodes).length < 1) {
       throw new Error("Unable to discover cluster")
     }
     const useClusterEndpoint = payload.connectionDetails.endpointType === "cluster-endpoint"


### PR DESCRIPTION
## Description

- Fan out command log requests to all nodes in clusterNodesRegistry when a clusterId is present
- Node-level errors collected and returned alongside data; yellow warning banner shown when partial data is returned
- Added nodeId to command log and hot key responses from the metrics server
- Both tables show a Node column attributing each entry to its cluster node
- Fixed column widths in both tables to accommodate the new column



