### PR TITLE
Improve hot keys UX when monitor is not running

### DIFF
--- a/apps/frontend/src/components/monitoring/Monitoring.tsx
+++ b/apps/frontend/src/components/monitoring/Monitoring.tsx
@@ -18,7 +18,8 @@ import type { RootState } from "@/store"
 import { commandLogsRequested, selectCommandLogs } from "@/state/valkey-features/commandlogs/commandLogsSlice"
 import { useAppDispatch } from "@/hooks/hooks"
 import {
-  hotKeysRequested, selectHotKeys, selectHotKeysStatus, selectHotKeysError, selectHotKeysNodeErrors
+  hotKeysRequested, selectHotKeys, selectHotKeysStatus, selectHotKeysError,
+  selectHotKeysNodeErrors, selectHotKeysLastCollectedAt
 } from "@/state/valkey-features/hotkeys/hotKeysSlice"
 import { selectMonitorRunning } from "@/state/valkey-features/monitor/monitorSlice"
 import { getKeyTypeRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
@@ -53,6 +54,7 @@ export const Monitoring = () => {
   const hotKeysStatus = useSelector((state: RootState) => selectHotKeysStatus(hotKeysId)(state))
   const hotKeysErrorMessage = useSelector((state: RootState) => selectHotKeysError(hotKeysId)(state))
   const hotKeysNodeErrors = useSelector((state: RootState) => selectHotKeysNodeErrors(hotKeysId)(state))
+  const hotKeysLastCollectedAt = useSelector((state: RootState) => selectHotKeysLastCollectedAt(hotKeysId)(state))
   const monitorRunning = useSelector(selectMonitorRunning(id!))
   const keys: KeyInfo[] = useSelector(selectKeys(id!))
 
@@ -189,6 +191,7 @@ export const Monitoring = () => {
               <HotKeys
                 data={hotKeysData}
                 errorMessage={hotKeysErrorMessage as string | null}
+                lastCollectedAt={hotKeysLastCollectedAt}
                 monitorRunning={monitorRunning}
                 nodeErrors={hotKeysNodeErrors}
                 onKeyClick={handleKeyClick}

--- a/apps/frontend/src/components/monitoring/Monitoring.tsx
+++ b/apps/frontend/src/components/monitoring/Monitoring.tsx
@@ -22,6 +22,7 @@ import {
   selectHotKeysNodeErrors, selectHotKeysLastCollectedAt
 } from "@/state/valkey-features/hotkeys/hotKeysSlice"
 import { selectMonitorRunning } from "@/state/valkey-features/monitor/monitorSlice"
+import { selectConnectionDetails } from "@/state/valkey-features/connection/connectionSelectors"
 import { getKeyTypeRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
 import { selectKeys } from "@/state/valkey-features/keys/keyBrowserSelectors"
 
@@ -56,6 +57,8 @@ export const Monitoring = () => {
   const hotKeysNodeErrors = useSelector((state: RootState) => selectHotKeysNodeErrors(hotKeysId)(state))
   const hotKeysLastCollectedAt = useSelector((state: RootState) => selectHotKeysLastCollectedAt(hotKeysId)(state))
   const monitorRunning = useSelector(selectMonitorRunning(id!))
+  const connectionDetails = useSelector((state: RootState) => selectConnectionDetails(id!)(state))
+  const useHotSlots = connectionDetails?.keyEvictionPolicy?.includes("lfu") && connectionDetails?.clusterSlotStatsEnabled
   const keys: KeyInfo[] = useSelector(selectKeys(id!))
 
   useEffect(() => {
@@ -195,7 +198,7 @@ export const Monitoring = () => {
                 monitorRunning={monitorRunning}
                 nodeErrors={hotKeysNodeErrors}
                 onKeyClick={handleKeyClick}
-                onStartMonitoring={() => setConfigOpen(true)}
+                onStartMonitoring={useHotSlots ? undefined : () => setConfigOpen(true)}
                 selectedKey={selectedKey}
                 status={hotKeysStatus}
               />

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -47,46 +47,48 @@ export function HotKeys({
     return <LoadingState message="Loading hot keys..." />
   }
 
-  const nodeErrorsBanner = (nodeErrors && nodeErrors.length > 0 || (!monitorRunning && onStartMonitoring)) && (
+  const nodeErrorsBanner = nodeErrors && nodeErrors.length > 0 && (
     <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border
       border-yellow-200 dark:border-yellow-700 flex items-start gap-2">
       <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
       <div>
-        {!monitorRunning && onStartMonitoring && (
-          <Typography variant="bodySm">
-            Monitor is not running. Showing last known data.{" "}
-            <button
-              className="text-primary underline hover:opacity-80"
-              onClick={onStartMonitoring}
-              type="button"
-            >
-              Start Monitoring
-            </button>
-          </Typography>
-        )}
-        {nodeErrors && nodeErrors.length > 0 && (
-          <>
-            <Typography variant="bodySm">
-              Hot keys data is partial:
-            </Typography>
-            <ul className="mt-1 space-y-0.5">
-              {nodeErrors.map(({ connectionId, error }) => (
-                <li key={connectionId}>
-                  <Typography variant="bodySm">
-                    <span className="font-mono">{connectionId}</span>: {error}
-                  </Typography>
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
+        <Typography variant="bodySm">
+          Hot keys data is partial:
+        </Typography>
+        <ul className="mt-1 space-y-0.5">
+          {nodeErrors.map(({ connectionId, error }) => (
+            <li key={connectionId}>
+              <Typography variant="bodySm">
+                <span className="font-mono">{connectionId}</span>: {error}
+              </Typography>
+            </li>
+          ))}
+        </ul>
       </div>
+    </div>
+  )
+
+  const monitorNotRunningBanner = !monitorRunning && onStartMonitoring && (
+    <div className="m-3 p-3 bg-red-50 dark:bg-red-900/20 rounded-md border
+      border-red-200 dark:border-red-700 flex items-start gap-2">
+      <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
+      <Typography variant="bodySm">
+        Monitor is not running. Showing last known data.{" "}
+        <button
+          className="text-primary underline hover:opacity-80"
+          onClick={onStartMonitoring}
+          type="button"
+        >
+          Start Monitoring
+        </button>
+      </Typography>
     </div>
   )
 
   return sortedHotKeys.length > 0 ? (
     <>
       {nodeErrorsBanner}
+      {monitorNotRunningBanner}
       {lastCollectedAt && (
         <div className="px-4 py-2 text-right">
           <Typography className="text-muted-foreground" variant="bodySm">
@@ -185,6 +187,7 @@ export function HotKeys({
   ) : (
     <>
       {nodeErrorsBanner}
+      {monitorNotRunningBanner}
       <EmptyState
         action={
           (errorMessage || !monitorRunning) && (

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -17,12 +17,15 @@ interface HotKeysProps {
   status?: string
   monitorRunning?: boolean
   nodeErrors?: { connectionId: string; error: string }[]
+  lastCollectedAt?: number | null
   onKeyClick?: (keyName: string) => void
   onStartMonitoring?: () => void
   selectedKey?: string | null
 }
 
-export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors, onKeyClick, onStartMonitoring, selectedKey }: HotKeysProps) {
+export function HotKeys({ 
+  data, errorMessage, status, monitorRunning, nodeErrors, lastCollectedAt, onKeyClick, onStartMonitoring, selectedKey, 
+}: HotKeysProps) {
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc")
 
   const toggleSortOrder = () => {
@@ -44,24 +47,39 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
     return <LoadingState message="Loading hot keys..." />
   }
 
-  const nodeErrorsBanner = nodeErrors && nodeErrors.length > 0 && (
+  const nodeErrorsBanner = (nodeErrors && nodeErrors.length > 0 || (!monitorRunning && onStartMonitoring)) && (
     <div className="m-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border
       border-yellow-200 dark:border-yellow-700 flex items-start gap-2">
       <AlertCircle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
       <div>
-        <Typography variant="bodySm">
-          Hot keys data is partial —{" "}
-          {nodeErrors.length} metrics server{nodeErrors.length > 1 ? "s" : ""} failed to respond or are not connected:
-        </Typography>
-        <ul className="mt-1 space-y-0.5">
-          {nodeErrors.map(({ connectionId, error }) => (
-            <li key={connectionId}>
-              <Typography variant="bodySm">
-                <span className="font-mono">{connectionId}</span>: {error}
-              </Typography>
-            </li>
-          ))}
-        </ul>
+        {!monitorRunning && onStartMonitoring && (
+          <Typography variant="bodySm">
+            Monitor is not running. Showing last known data.{" "}
+            <button
+              className="text-primary underline hover:opacity-80"
+              onClick={onStartMonitoring}
+              type="button"
+            >
+              Start Monitoring
+            </button>
+          </Typography>
+        )}
+        {nodeErrors && nodeErrors.length > 0 && (
+          <>
+            <Typography variant="bodySm">
+              Hot keys data is partial:
+            </Typography>
+            <ul className="mt-1 space-y-0.5">
+              {nodeErrors.map(({ connectionId, error }) => (
+                <li key={connectionId}>
+                  <Typography variant="bodySm">
+                    <span className="font-mono">{connectionId}</span>: {error}
+                  </Typography>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
       </div>
     </div>
   )
@@ -69,6 +87,13 @@ export function HotKeys({ data, errorMessage, status, monitorRunning, nodeErrors
   return sortedHotKeys.length > 0 ? (
     <>
       {nodeErrorsBanner}
+      {lastCollectedAt && (
+        <div className="px-4 py-2 text-right">
+          <Typography className="text-muted-foreground" variant="bodySm">
+            Hot Keys last collected at: {new Date(lastCollectedAt).toLocaleString()}
+          </Typography>
+        </div>
+      )}
       <TableContainer
         header={
           <>

--- a/apps/frontend/src/components/monitoring/hot-keys.tsx
+++ b/apps/frontend/src/components/monitoring/hot-keys.tsx
@@ -39,7 +39,7 @@ export function HotKeys({
   }
 
   const sortedHotKeys = R.sort<[string, number, number | null, number]>(
-    (sortOrder === "asc" ? R.ascend : R.descend)(R.nth(1) as (tuple: [string, number, number | null, number]) => number),
+    (sortOrder === "asc" ? R.ascend : R.descend)(R.nth(1) as (tuple: [string, number, number | null, number,]) => number),
     R.defaultTo([], data),
   )
 

--- a/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
+++ b/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
@@ -18,12 +18,16 @@ export const selectHotKeysError = (id: string) => (state: RootState) =>
 export const selectHotKeysNodeErrors = (id: string) => (state: RootState) =>
   R.path([VALKEY.HOTKEYS.name, id, "nodeErrors"], state) ?? []
 
+export const selectHotKeysLastCollectedAt = (id: string) => (state: RootState) =>
+  R.path([VALKEY.HOTKEYS.name, id, "lastCollectedAt"], state) ?? null
+
 interface HotKeysState {
   [connectionId: string]: {
     hotKeys: [string, number, number | null, number][]
     checkAt: string | null,
     monitorRunning: boolean,
     nodeId: string | null,
+    lastCollectedAt?: number | null,
     error?: JSONObject | null,
     nodeErrors?: { connectionId: string; error: string }[],
     status: HotKeysStatus,
@@ -54,7 +58,7 @@ const hotKeysSlice = createSlice({
       }
     },
     hotKeysFulfilled: (state, action) => {
-      const { hotKeys, monitorRunning, checkAt, nodeId } = action.payload.parsedResponse
+      const { hotKeys, monitorRunning, checkAt, nodeId, lastCollectedAt } = action.payload.parsedResponse
       const connectionId = action.payload.connectionId
       const nodeErrors = action.payload.nodeErrors ?? []
       if (!state[connectionId]) {
@@ -71,6 +75,7 @@ const hotKeysSlice = createSlice({
         checkAt,
         monitorRunning,
         nodeId,
+        lastCollectedAt,
         nodeErrors,
         status: FULFILLED,
       }

--- a/apps/metrics/src/handlers/monitor-handler.js
+++ b/apps/metrics/src/handlers/monitor-handler.js
@@ -16,16 +16,17 @@ const toResponse = ({ isRunning, willCompleteAt, startedAt }) => ({
 export const useMonitor = async (res, client, nodeId) => {
   const { isRunning, willCompleteAt: checkAt } = getCollectorMeta(MONITOR) 
   try {
-    const toLastCollectedAt = (rows) => rows.at(-1)?.ts ? rows.at(-1).ts * 1000 : null
     if (!isRunning) {
       const rows = await Streamer.monitor()
+      const lastCollectedAt = rows.at(-1)?.ts ? rows.at(-1).ts * 1000 : null
       const hotKeys = await Promise.resolve(rows).then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
-      return res.json({ hotKeys, nodeId, monitorRunning: false, checkAt: null, startedAt: null, lastCollectedAt: toLastCollectedAt(rows) })
+      return res.json({ hotKeys, nodeId, monitorRunning: false, checkAt: null, startedAt: null, lastCollectedAt })
     }
     if (Date.now() > checkAt) {
       const rows = await Streamer.monitor()
+      const lastCollectedAt = rows.at(-1)?.ts ? rows.at(-1).ts * 1000 : null
       const hotKeys = await Promise.resolve(rows).then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
-      return res.json({ hotKeys, nodeId, lastCollectedAt: toLastCollectedAt(rows), ...toResponse(getCollectorMeta(MONITOR)) })
+      return res.json({ hotKeys, nodeId, lastCollectedAt, ...toResponse(getCollectorMeta(MONITOR)) })
     }
     return res.json({ checkAt })
   } catch (e) {

--- a/apps/metrics/src/handlers/monitor-handler.js
+++ b/apps/metrics/src/handlers/monitor-handler.js
@@ -13,15 +13,20 @@ const toResponse = ({ isRunning, willCompleteAt, startedAt }) => ({
   startedAt: startedAt ?? null,
 })
 
-export const useMonitor = async (res, client) => {
+export const useMonitor = async (res, client, nodeId) => {
   const { isRunning, willCompleteAt: checkAt } = getCollectorMeta(MONITOR) 
   try {
     if (!isRunning) {
-      return res.status(400).json({ error: "Monitor is not running" })
+      const rows = await Streamer.monitor()
+      const lastCollectedAt = rows.at(-1)?.ts ?? null
+      const hotKeys = await Promise.resolve(rows).then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
+      return res.json({ hotKeys, nodeId, monitorRunning: false, checkAt: null, startedAt: null, lastCollectedAt })
     }
     if (Date.now() > checkAt) {
-      const hotKeys = await Streamer.monitor().then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
-      return res.json({ hotKeys, ...toResponse(getCollectorMeta(MONITOR)) })
+      const rows = await Streamer.monitor()
+      const lastCollectedAt = rows.at(-1)?.ts ?? null
+      const hotKeys = await Promise.resolve(rows).then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
+      return res.json({ hotKeys, nodeId, lastCollectedAt, ...toResponse(getCollectorMeta(MONITOR)) })
     }
     return res.json({ checkAt })
   } catch (e) {

--- a/apps/metrics/src/handlers/monitor-handler.js
+++ b/apps/metrics/src/handlers/monitor-handler.js
@@ -16,17 +16,16 @@ const toResponse = ({ isRunning, willCompleteAt, startedAt }) => ({
 export const useMonitor = async (res, client, nodeId) => {
   const { isRunning, willCompleteAt: checkAt } = getCollectorMeta(MONITOR) 
   try {
+    const toLastCollectedAt = (rows) => rows.at(-1)?.ts ? rows.at(-1).ts * 1000 : null
     if (!isRunning) {
       const rows = await Streamer.monitor()
-      const lastCollectedAt = rows.at(-1)?.ts ?? null
       const hotKeys = await Promise.resolve(rows).then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
-      return res.json({ hotKeys, nodeId, monitorRunning: false, checkAt: null, startedAt: null, lastCollectedAt })
+      return res.json({ hotKeys, nodeId, monitorRunning: false, checkAt: null, startedAt: null, lastCollectedAt: toLastCollectedAt(rows) })
     }
     if (Date.now() > checkAt) {
       const rows = await Streamer.monitor()
-      const lastCollectedAt = rows.at(-1)?.ts ?? null
       const hotKeys = await Promise.resolve(rows).then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
-      return res.json({ hotKeys, nodeId, lastCollectedAt, ...toResponse(getCollectorMeta(MONITOR)) })
+      return res.json({ hotKeys, nodeId, lastCollectedAt: toLastCollectedAt(rows), ...toResponse(getCollectorMeta(MONITOR)) })
     }
     return res.json({ checkAt })
   } catch (e) {

--- a/apps/metrics/src/handlers/monitor-handler.js
+++ b/apps/metrics/src/handlers/monitor-handler.js
@@ -14,21 +14,15 @@ const toResponse = ({ isRunning, willCompleteAt, startedAt }) => ({
 })
 
 export const useMonitor = async (res, client, nodeId) => {
-  const { isRunning, willCompleteAt: checkAt } = getCollectorMeta(MONITOR) 
+  const { isRunning, willCompleteAt: checkAt } = getCollectorMeta(MONITOR)
   try {
-    if (!isRunning) {
-      const rows = await Streamer.monitor()
-      const lastCollectedAt = rows.at(-1)?.ts ? rows.at(-1).ts * 1000 : null
-      const hotKeys = await Promise.resolve(rows).then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
-      return res.json({ hotKeys, nodeId, monitorRunning: false, checkAt: null, startedAt: null, lastCollectedAt })
-    }
-    if (Date.now() > checkAt) {
-      const rows = await Streamer.monitor()
-      const lastCollectedAt = rows.at(-1)?.ts ? rows.at(-1).ts * 1000 : null
-      const hotKeys = await Promise.resolve(rows).then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
-      return res.json({ hotKeys, nodeId, lastCollectedAt, ...toResponse(getCollectorMeta(MONITOR)) })
-    }
-    return res.json({ checkAt })
+    if (isRunning && Date.now() <= checkAt) return res.json({ checkAt })
+
+    const rows = await Streamer.monitor()
+    const lastCollectedAt = rows.at(-1)?.ts ? rows.at(-1).ts * 1000 : null
+    const hotKeys = await Promise.resolve(rows).then(calculateHotKeysFromMonitor).then(enrichHotKeys(client))
+    const monitorMeta = isRunning ? toResponse(getCollectorMeta(MONITOR)) : { monitorRunning: false, checkAt: null, startedAt: null }
+    return res.json({ hotKeys, nodeId, lastCollectedAt, ...monitorMeta })
   } catch (e) {
     res.status(500).json({ error: e.message })
   }

--- a/apps/metrics/src/index.js
+++ b/apps/metrics/src/index.js
@@ -180,7 +180,18 @@ async function main() {
     }
 
     console.debug(`listening on http://${metricsBindHost}:${assignedPort}`)
-    await registerWithServer()
+
+    const registerWithRetry = async () => {
+      const maxAttempts = 30
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const success = await registerWithServer()
+        if (success) return
+        if (attempt < maxAttempts) await new Promise((resolve) => setTimeout(resolve, 1000))
+      }
+      console.error("Failed to register with server after 30 attempts. Shutting down.")
+      shutdown()
+    }
+    await registerWithRetry()
     // Base interval ±10% jitter
     const pingIntervalMs = cfg.backend.ping_interval * (1 + (Math.random() * 2 - 1) * 0.1)
     setInterval(async () => {

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -8,6 +8,7 @@ type HotKeysResponse = {
   hotKeys: [[]]
   checkAt: number
   monitorRunning: boolean
+  lastCollectedAt: number | null
 }
 
 type NodeError = {
@@ -131,7 +132,9 @@ export const hotKeysRequested = withDeps<Deps, void>(
       R.values,
       R.sort(R.descend(R.prop(1))),
     )(results)
-    const { monitorRunning, checkAt, nodeId } = results[0]
-    const aggregatedResponse = { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId } as unknown as HotKeysResponse
+    const { checkAt, nodeId } = results[0]
+    const monitorRunning = results.every((r) => r.monitorRunning)
+    const lastCollectedAt = results.reduce((max, r) => Math.max(max, r.lastCollectedAt ?? 0), 0) || null
+    const aggregatedResponse = { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId, lastCollectedAt } as unknown as HotKeysResponse
     sendHotKeysFulfilled(ws, clusterId as string, aggregatedResponse, nodeErrors)
   })


### PR DESCRIPTION
## Description
- Metrics server now returns existing hot key data (with monitorRunning: false) instead of a 400 error when monitor is off, so users see last known data rather than an empty state

- Added lastCollectedAt timestamp to the hot keys response, derived from the most recent monitor log row's timestamp, displayed above the table as "Hot Keys last collected at:..."

- Added a red warning banner when monitor is not running that includes a "Start Monitoring" button — shown both above the table (when data exists) and in the empty state

- The start monitoring button is suppressed when LFU + cluster slot stats are enabled, since that path doesn't use the monitor

- Metrics server retries registration with the backend every second for up to 30 seconds before shutting down

