### PR TITLE
Change total system memory to maxmemory

### DIFF
--- a/apps/frontend/src/components/dashboard/Dashboard.tsx
+++ b/apps/frontend/src/components/dashboard/Dashboard.tsx
@@ -48,11 +48,12 @@ export function Dashboard() {
     used_memory_vm_eval: infoData.used_memory_vm_eval,
     used_memory_peak: infoData.used_memory_peak,
     used_memory_scripts: infoData.used_memory_scripts,
-    total_system_memory: infoData.total_system_memory,
-    maxmemory: infoData.maxmemory,
+    ...(Number(infoData.maxmemory) > 0
+      ? { max_memory: infoData.maxmemory }
+      : { total_system_memory: infoData.total_system_memory }),
   }
 
-  const maxmem = Number(memoryUsageMetrics.maxmemory)
+  const maxmem = Number(memoryUsageMetrics.max_memory)
   const sysmem = Number(memoryUsageMetrics.total_system_memory)
   const totalMemoryDisplay = maxmem > 0
     ? formatBytes(maxmem)

--- a/apps/frontend/src/components/dashboard/Dashboard.tsx
+++ b/apps/frontend/src/components/dashboard/Dashboard.tsx
@@ -53,8 +53,8 @@ export function Dashboard() {
       : { total_system_memory: infoData.total_system_memory }),
   }
 
-  const maxmem = Number(memoryUsageMetrics.max_memory)
-  const sysmem = Number(memoryUsageMetrics.total_system_memory)
+  const maxmem = Number(infoData.maxmemory)
+  const sysmem = Number(infoData.total_system_memory)
   const totalMemoryDisplay = maxmem > 0
     ? formatBytes(maxmem)
     : maxmem === 0 && sysmem > 0

--- a/apps/frontend/src/components/dashboard/Dashboard.tsx
+++ b/apps/frontend/src/components/dashboard/Dashboard.tsx
@@ -52,6 +52,16 @@ export function Dashboard() {
     maxmemory: infoData.maxmemory,
   }
 
+  const maxmem = Number(memoryUsageMetrics.maxmemory)
+  const sysmem = Number(memoryUsageMetrics.total_system_memory)
+  const totalMemoryDisplay = maxmem > 0
+    ? formatBytes(maxmem)
+    : maxmem === 0 && sysmem > 0
+      ? formatBytes(sysmem)
+      : maxmem === 0
+        ? "∞"
+        : "—"
+
   const upTimeMetrics = {
     evicted_scripts: infoData.evicted_scripts,
     uptime_in_seconds: infoData.uptime_in_seconds,
@@ -133,13 +143,7 @@ export function Dashboard() {
               className="flex-1"
               icon={<Database className="text-primary" size={24} />}
               label="Total Memory"
-              value={(() => {
-                const maxmem = Number(memoryUsageMetrics.maxmemory)
-                if (maxmem > 0) return formatBytes(maxmem)
-                const sysmem = Number(memoryUsageMetrics.total_system_memory)
-                if (sysmem > 0) return formatBytes(sysmem)
-                return "∞"
-              })()}
+              value={totalMemoryDisplay}
             />
             <StatCard
               className="flex-1"

--- a/apps/frontend/src/components/dashboard/Dashboard.tsx
+++ b/apps/frontend/src/components/dashboard/Dashboard.tsx
@@ -48,7 +48,7 @@ export function Dashboard() {
     used_memory_vm_eval: infoData.used_memory_vm_eval,
     used_memory_peak: infoData.used_memory_peak,
     used_memory_scripts: infoData.used_memory_scripts,
-    total_system_memory: infoData.total_system_memory,
+    maxmemory: infoData.maxmemory,
   }
 
   const upTimeMetrics = {
@@ -132,7 +132,7 @@ export function Dashboard() {
               className="flex-1"
               icon={<Database className="text-primary" size={24} />}
               label="Total Memory"
-              value={formatBytes(memoryUsageMetrics.total_system_memory || 0)}
+              value={formatBytes(memoryUsageMetrics.maxmemory || 0)}
             />
             <StatCard
               className="flex-1"

--- a/apps/frontend/src/components/dashboard/Dashboard.tsx
+++ b/apps/frontend/src/components/dashboard/Dashboard.tsx
@@ -48,6 +48,7 @@ export function Dashboard() {
     used_memory_vm_eval: infoData.used_memory_vm_eval,
     used_memory_peak: infoData.used_memory_peak,
     used_memory_scripts: infoData.used_memory_scripts,
+    total_system_memory: infoData.total_system_memory,
     maxmemory: infoData.maxmemory,
   }
 
@@ -132,7 +133,13 @@ export function Dashboard() {
               className="flex-1"
               icon={<Database className="text-primary" size={24} />}
               label="Total Memory"
-              value={formatBytes(memoryUsageMetrics.maxmemory || 0)}
+              value={(() => {
+                const maxmem = Number(memoryUsageMetrics.maxmemory)
+                if (maxmem > 0) return formatBytes(maxmem)
+                const sysmem = Number(memoryUsageMetrics.total_system_memory)
+                if (sysmem > 0) return formatBytes(sysmem)
+                return "∞"
+              })()}
             />
             <StatCard
               className="flex-1"

--- a/apps/frontend/src/state/valkey-features/info/infoSlice.ts
+++ b/apps/frontend/src/state/valkey-features/info/infoSlice.ts
@@ -10,7 +10,7 @@ interface ConnectionData {
   bytes_per_key: number | null
   server_name: string | null
   tcp_port: number | null
-  total_system_memory: number | null
+  maxmemory: number | null
   used_memory: number | null
   used_memory_dataset : number | null
   used_memory_functions : number | null
@@ -75,7 +75,7 @@ const createInitialConnectionState = (): ConnectionState => ({
     bytes_per_key: null,
     server_name: null,
     tcp_port: null,
-    total_system_memory: null,
+    maxmemory: null,
     used_memory: null,
     used_memory_dataset : null,
     used_memory_functions : null,
@@ -146,7 +146,7 @@ const infoSlice = createSlice({
         tcp_port: R.path(["info", "tcp_port"]),
         total_commands_processed: R.path(["info", "total_commands_processed"]),
         connected_clients: R.path(["info", "connected_clients"]),
-        total_system_memory: R.path(["info", "total_system_memory"]),
+        maxmemory: R.path(["info", "maxmemory"]),
         used_memory: R.path(["info", "used_memory"]),
         used_memory_dataset : R.path(["info", "used_memory_dataset"]),
         used_memory_functions : R.path(["info", "used_memory_functions"]),

--- a/apps/frontend/src/state/valkey-features/info/infoSlice.ts
+++ b/apps/frontend/src/state/valkey-features/info/infoSlice.ts
@@ -10,6 +10,7 @@ interface ConnectionData {
   bytes_per_key: number | null
   server_name: string | null
   tcp_port: number | null
+  total_system_memory: number | null
   maxmemory: number | null
   used_memory: number | null
   used_memory_dataset : number | null
@@ -75,6 +76,7 @@ const createInitialConnectionState = (): ConnectionState => ({
     bytes_per_key: null,
     server_name: null,
     tcp_port: null,
+    total_system_memory: null,
     maxmemory: null,
     used_memory: null,
     used_memory_dataset : null,
@@ -146,6 +148,7 @@ const infoSlice = createSlice({
         tcp_port: R.path(["info", "tcp_port"]),
         total_commands_processed: R.path(["info", "total_commands_processed"]),
         connected_clients: R.path(["info", "connected_clients"]),
+        total_system_memory: R.path(["info", "total_system_memory"]),
         maxmemory: R.path(["info", "maxmemory"]),
         used_memory: R.path(["info", "used_memory"]),
         used_memory_dataset : R.path(["info", "used_memory_dataset"]),

--- a/common/src/dashboard-metrics.ts
+++ b/common/src/dashboard-metrics.ts
@@ -40,8 +40,12 @@ export const singleMetricDescriptions = {
     description: "Number of bytes overhead by the EVAL scripts + Number of bytes overhead by Function scripts (part of used_memory).",
     unit: "Unit: Bytes",
   },
-  maxmemory: {
+  max_memory: {
     description: "Maximum amount of memory allocated for the Valkey instance.",
+    unit: "Unit: Bytes",
+  },
+  total_system_memory: {
+    description: "Total amount of memory that the Valkey instance has available.",
     unit: "Unit: Bytes",
   },
 

--- a/common/src/dashboard-metrics.ts
+++ b/common/src/dashboard-metrics.ts
@@ -40,8 +40,8 @@ export const singleMetricDescriptions = {
     description: "Number of bytes overhead by the EVAL scripts + Number of bytes overhead by Function scripts (part of used_memory).",
     unit: "Unit: Bytes",
   },
-  total_system_memory: {
-    description: "Total amount of memory that the Valkey instance has available.",
+  maxmemory: {
+    description: "Maximum amount of memory allocated for the Valkey instance.",
     unit: "Unit: Bytes",
   },
 


### PR DESCRIPTION
## Description

In ElastiCache, total_system_memory isn't exposed. To keep things consistent we can list total allocated memory for the node we're connected to. 

If maxmemory isn't available we fall back to total system memory. 

In the future this can be aggregated for clusters to show total allocated memory for all nodes. 