### PR TITLE
Fix cluster state on WebSocket reconnect with shared backend

### DIFF
--- a/apps/server/src/actions/connection.ts
+++ b/apps/server/src/actions/connection.ts
@@ -81,6 +81,6 @@ export const closeConnection = withDeps<Deps, void>(
         }
       }
     }
-    teardownConnection(connectionId, clients, metricsServerMap)
+    teardownConnection(connectionId, clients, metricsServerMap, clusterNodesRegistry)
   },
 )

--- a/apps/server/src/actions/connection.ts
+++ b/apps/server/src/actions/connection.ts
@@ -52,7 +52,7 @@ export const resetConnection = withDeps<Deps, void>(
 )
 
 export const closeConnection = withDeps<Deps, void>(
-  async ({ ws, clients, action, metricsServerMap, connectedNodesByCluster }) => {
+  async ({ ws, clients, action, metricsServerMap, connectedNodesByCluster, clusterNodesRegistry }) => {
     const { connectionId } = action.payload
     const connection = clients.get(connectionId)
     const clusterId = connection?.clusterId

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -395,6 +395,7 @@ export function teardownConnection(
   connectionId: string,
   clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId?: string}>,
   metricsServerMap: MetricsServerMap,
+  clusterNodesRegistry?: ClusterRegistry,
 ) {
   if (process.env.USE_CLUSTER_ORCHESTRATOR !== "true") {
     closeMetricsServer(connectionId, metricsServerMap).catch((err) =>
@@ -410,6 +411,10 @@ export function teardownConnection(
       connection.client.close()
     } catch (error) {
       console.error(`Error closing connection ${connectionId}:`, error)
+    }
+
+    if (clusterNodesRegistry && connection.clusterId && process.env.USE_CLUSTER_ORCHESTRATOR !== "true") {
+      delete clusterNodesRegistry[connection.clusterId]
     }
   }
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -248,12 +248,12 @@ wss.on("connection", (ws: AliveWebSocket) => {
     console.log("Client disconnected. Reason:", code, reason.toString())
 
     for (const connectionId of removedIds) {
-      if (getWatcherCount(connectionId) === 0) teardownConnection(connectionId, clients, metricsServerMap)
+      if (getWatcherCount(connectionId) === 0) teardownConnection(connectionId, clients, metricsServerMap, clusterNodesRegistry)
     }
 
     // Clean up any side-entries (e.g., node entries from config endpoint connections)
     for (const [id] of clients) {
-      if (getWatcherCount(id) === 0) teardownConnection(id, clients, metricsServerMap)
+      if (getWatcherCount(id) === 0) teardownConnection(id, clients, metricsServerMap, clusterNodesRegistry)
     }
   })
 })

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -2,7 +2,7 @@ import { WebSocket, WebSocketServer } from "ws"
 import express from "express"
 import path from "path"
 import http from "http"
-import { VALKEY } from "valkey-common"
+import { VALKEY, CONNECTION_TEARDOWN_DELAY_MS } from "valkey-common"
 import { fileURLToPath } from "url"
 import rateLimit from "express-rate-limit"
 import { connectPending, resetConnection, closeConnection } from "./actions/connection"
@@ -159,6 +159,7 @@ const interval = setInterval(() => {
     ws.ping()
   })
 }, 30000)
+
 wss.on("connection", (ws: AliveWebSocket) => {
   console.log("Client connected.")
   ws.isAlive = true
@@ -248,7 +249,11 @@ wss.on("connection", (ws: AliveWebSocket) => {
     console.log("Client disconnected. Reason:", code, reason.toString())
 
     for (const connectionId of removedIds) {
-      if (getWatcherCount(connectionId) === 0) teardownConnection(connectionId, clients, metricsServerMap, clusterNodesRegistry)
+      setTimeout(() => {
+        if (getWatcherCount(connectionId) === 0) {
+          teardownConnection(connectionId, clients, metricsServerMap, clusterNodesRegistry)
+        }
+      }, CONNECTION_TEARDOWN_DELAY_MS)
     }
 
     // Clean up any side-entries (e.g., node entries from config endpoint connections)

--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -189,7 +189,7 @@ export async function returnExistingClusterClient(
   subscribe(connectionId, ws)
   ws.send(
     JSON.stringify({
-      type: VALKEY.CLUSTER.updateClusterInfo,
+      type: VALKEY.CLUSTER.addCluster,
       payload: { clusterId: existingClusterId, clusterNodes: discoveredClusterNodes },
     }),
   )

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -205,3 +205,6 @@ export const METRICS_EVICTION_POLICY = {
 }
 
 export type EndpointType = "node" | "cluster-endpoint"
+
+export const CONNECTION_TEARDOWN_DELAY_MS = Number(process.env.CONNECTION_TEARDOWN_DELAY_MS ?? 10000)
+


### PR DESCRIPTION
## Description

When multiple users share the same backend, a reconnecting user would receive updateClusterInfo instead of addCluster because the global clients map still held the existing  GlideClusterClient. Since updateClusterInfo is a no-op on an empty frontend state, the cluster topology would never populate after reconnect.

In addition, clusterNodesRegistry was not cleaned up properly, this fix addresses that.

Changes:
- returnExistingClusterClient now sends addCluster instead of updateClusterInfo, so a reconnecting client always rebuilds its cluster state from scratch

- teardownConnection now accepts an optional clusterNodesRegistry and deletes the cluster entry when the last client for that cluster is closed — preventing stale entries 
from causing fan-out to disconnected nodes. This cleanup is skipped when USE_CLUSTER_ORCHESTRATOR=true since the registry is managed by the reconcile loop in that mode
- closeConnection and the WebSocket close handler both pass clusterNodesRegistry to teardownConnection


### Change Visualization

Include a screenshot/video of before and after the change.
