### PR TITLE
Fix to only use metrics orchestrator when deployment type is Web

### DIFF
--- a/apps/frontend/electron.main.js
+++ b/apps/frontend/electron.main.js
@@ -5,7 +5,7 @@ const { fork } = require("child_process")
 const { createApplicationMenu } = require("./menu")
 
 let serverProcess
-
+const ELECTRON = "Electron"
 function startServer() {
   if (app.isPackaged) {
     const serverPath = path.join(process.resourcesPath, "server-backend.cjs")
@@ -13,7 +13,7 @@ function startServer() {
     serverProcess = fork(serverPath, [], {
       env: {
         ...process.env,
-        ELECTRON_APP: "true",
+        DEPLOYMENT_MODE: ELECTRON,
         PROCESS_RESOURCES_PATH: process.resourcesPath,
         DATA_DIR: path.join(app.getPath("userData"), "metrics-data"),
       },

--- a/apps/server/src/__tests__/monitorAction.test.ts
+++ b/apps/server/src/__tests__/monitorAction.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert"
 import { VALKEY } from "valkey-common"
 import { monitorRequested, saveMonitorSettingsRequested } from "../actions/monitorAction"
 import { subscribe, _reset as resetNodeWatchers } from "../node-watchers"
+import { ClusterRegistry } from "../metrics-orchestrator"
 
 function createMockResponse(body: any, ok = true, status = 200) {
   return {
@@ -18,6 +19,7 @@ describe("monitorAction", () => {
   let messages: string[]
   let metricsServerMap: Map<string, any>
   let connectedNodesByCluster: Map<string, string[]>
+  let clusterNodesRegistry: ClusterRegistry 
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
@@ -27,6 +29,7 @@ describe("monitorAction", () => {
     }
     metricsServerMap = new Map()
     connectedNodesByCluster = new Map()
+    clusterNodesRegistry = {}
   })
 
   afterEach(() => {
@@ -47,7 +50,9 @@ describe("monitorAction", () => {
     globalThis.fetch = (async () => { throw error }) as any
   }
 
-  const deps = () => ({ ws: mockWs, metricsServerMap, connectedNodesByCluster, clients: new Map(), connectionId: "" } as any)
+  const deps = () => ({ 
+    ws: mockWs, metricsServerMap, connectedNodesByCluster, clients: new Map(), connectionId: "", clusterNodesRegistry, 
+  } as any)
 
   describe("status request", () => {
     it("should call GET /monitor?action=status and send monitorFulfilled", async () => {
@@ -171,7 +176,22 @@ describe("monitorAction", () => {
     it("should send requests to all cluster nodes", async () => {
       metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
       metricsServerMap.set("node-2", { metricsURI: "http://localhost:9002" })
-      connectedNodesByCluster.set("cluster-1", ["node-1", "node-2"])
+      clusterNodesRegistry = {
+        "cluster-1": {
+          "node-1": {
+            host: "127.0.0.1",
+            port: 7000,
+            tls: false,
+            verifyTlsCertificate: false,
+          },
+          "node-2": {
+            host: "127.0.0.1",
+            port: 7001,
+            tls: false,
+            verifyTlsCertificate: false,
+          },
+        },
+      }
 
       const fetchCalls = mockFetch({ monitorRunning: true, checkAt: 55555 })
 
@@ -299,6 +319,7 @@ describe("saveMonitorSettingsRequested", () => {
   let messages: string[]
   let metricsServerMap: Map<string, any>
   let connectedNodesByCluster: Map<string, string[]>
+  let clusterNodesRegistry: ClusterRegistry
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
@@ -308,6 +329,7 @@ describe("saveMonitorSettingsRequested", () => {
     }
     metricsServerMap = new Map()
     connectedNodesByCluster = new Map()
+    clusterNodesRegistry = {}
   })
 
   afterEach(() => {
@@ -330,7 +352,9 @@ describe("saveMonitorSettingsRequested", () => {
     return fetchCalls
   }
 
-  const deps = () => ({ ws: mockWs, metricsServerMap, connectedNodesByCluster, clients: new Map(), connectionId: "" } as any)
+  const deps = () => ({ 
+    ws: mockWs, metricsServerMap, connectedNodesByCluster, clients: new Map(), connectionId: "", clusterNodesRegistry, 
+  } as any)
 
   it("should call only updateConfig when config is present but monitorAction is absent", async () => {
     metricsServerMap.set("conn-1", { metricsURI: "http://localhost:9999" })
@@ -445,8 +469,22 @@ describe("saveMonitorSettingsRequested", () => {
   it("should fan out across cluster nodes for both config and monitor", async () => {
     metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
     metricsServerMap.set("node-2", { metricsURI: "http://localhost:9002" })
-    connectedNodesByCluster.set("cluster-1", ["node-1", "node-2"])
-
+    clusterNodesRegistry = {
+      "cluster-1": {
+        "node-1": {
+          host: "127.0.0.1",
+          port: 7000,
+          tls: false,
+          verifyTlsCertificate: false,
+        },
+        "node-2": {
+          host: "127.0.0.1",
+          port: 7001,
+          tls: false,
+          verifyTlsCertificate: false,
+        },
+      },
+    }
     const fetchCalls = mockFetchRouted({
       "/update-config": { body: { success: true, message: "", data: {} } },
       "/monitor": { body: { monitorRunning: true, checkAt: 55555 } },

--- a/apps/server/src/actions/config.ts
+++ b/apps/server/src/actions/config.ts
@@ -10,9 +10,11 @@ interface ParsedResponse  {
 }
 
 export const updateConfig = withDeps<Deps, void>(
-  async ({ ws, metricsServerMap, action, connectedNodesByCluster }) => {
+  async ({ ws, metricsServerMap, action, clusterNodesRegistry }) => {
     const { connectionId, clusterId, config } = action.payload
-    const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
+    const connectionIds = clusterId 
+      ? Object.keys(clusterNodesRegistry[clusterId as string] ?? {}).filter((id) => metricsServerMap.has(id))
+      : [connectionId]
 
     const promises = connectionIds.map(async (connectionId: string) => {
       const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI

--- a/apps/server/src/actions/monitorAction.ts
+++ b/apps/server/src/actions/monitorAction.ts
@@ -45,9 +45,11 @@ const sendMonitorError = (
 }
 
 export const monitorRequested = withDeps<Deps, void>(
-  async ({ ws, metricsServerMap, action, connectedNodesByCluster }) => {
+  async ({ ws, metricsServerMap, action, clusterNodesRegistry }) => {
     const { connectionId, clusterId, monitorAction } = action.payload
-    const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
+    const connectionIds = clusterId 
+      ? Object.keys(clusterNodesRegistry[clusterId as string] ?? {}).filter((id) => metricsServerMap.has(id))
+      : [connectionId]
 
     const promises = connectionIds.map(async (connectionId: string) => {
       const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
@@ -85,8 +87,8 @@ export const monitorRequested = withDeps<Deps, void>(
   })
 
 export const saveMonitorSettingsRequested = withDeps<Deps, void>(
-  async ({ ws, clients, connectionId, metricsServerMap, connectedNodesByCluster, action }) => {
-    const deps: Deps = { ws, clients, connectionId, metricsServerMap, connectedNodesByCluster }
+  async ({ ws, clients, connectionId, metricsServerMap, connectedNodesByCluster, clusterNodesRegistry, action }) => {
+    const deps: Deps = { ws, clients, connectionId, metricsServerMap, connectedNodesByCluster, clusterNodesRegistry }
     const { config, monitorAction } = action.payload
 
     if (config) {

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -12,7 +12,15 @@ import {
   returnExistingClusterClient } from "./utils"
 import { checkJsonModuleAvailability } from "./check-json-module"
 import { type ConnectionDetails } from "./actions/connection"
-import { ClusterRegistry, isElectron, isWebMode, MetricsServerMap, startMetricsServer, clusterCredentials, reconcileClusterMetricsServers, metricsServerMap } from "./metrics-orchestrator"
+import { 
+  ClusterRegistry, 
+  isElectron, 
+  isWebMode, 
+  MetricsServerMap, 
+  startMetricsServer, 
+  clusterCredentials, 
+  reconcileClusterMetricsServers, 
+  metricsServerMap } from "./metrics-orchestrator"
 import { subscribe } from "./node-watchers"
 import { createClusterValkeyClient, createStandaloneValkeyClient } from "./valkey-client"
 

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -12,7 +12,7 @@ import {
   returnExistingClusterClient } from "./utils"
 import { checkJsonModuleAvailability } from "./check-json-module"
 import { type ConnectionDetails } from "./actions/connection"
-import { ClusterRegistry, MetricsServerMap, startMetricsServer } from "./metrics-orchestrator"
+import { ClusterRegistry, isElectron, isWebMode, MetricsServerMap, startMetricsServer } from "./metrics-orchestrator"
 import { subscribe } from "./node-watchers"
 import { createClusterValkeyClient, createStandaloneValkeyClient } from "./valkey-client"
 
@@ -83,8 +83,8 @@ export async function connectToValkey(
     // Need to set for metrics server to be able to register
     clients.set(connectionId, { client: standaloneClient })
 
-    // In cluster-orchestrator mode, metrics sidecars register themselves.
-    if (process.env.USE_CLUSTER_ORCHESTRATOR !== "true" && !metricsServerMap.has(payload.connectionId)) {
+    // In K8s or Web, metrics servers register themselves.
+    if (isElectron && !metricsServerMap.has(payload.connectionId)) {
       await startMetricsServer(payload.connectionDetails, payload.connectionId)
     }
 
@@ -397,7 +397,8 @@ export function teardownConnection(
   metricsServerMap: MetricsServerMap,
   clusterNodesRegistry?: ClusterRegistry,
 ) {
-  if (process.env.USE_CLUSTER_ORCHESTRATOR !== "true") {
+  // In web mode, metrics servers are managed by the orchestrator
+  if (!isWebMode) {
     closeMetricsServer(connectionId, metricsServerMap).catch((err) =>
       console.error(`Error closing metrics server for ${connectionId}:`, err),
     )
@@ -413,7 +414,7 @@ export function teardownConnection(
       console.error(`Error closing connection ${connectionId}:`, error)
     }
 
-    if (clusterNodesRegistry && connection.clusterId && process.env.USE_CLUSTER_ORCHESTRATOR !== "true") {
+    if (clusterNodesRegistry && connection.clusterId && !isWebMode) {
       delete clusterNodesRegistry[connection.clusterId]
     }
   }

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -12,7 +12,7 @@ import {
   returnExistingClusterClient } from "./utils"
 import { checkJsonModuleAvailability } from "./check-json-module"
 import { type ConnectionDetails } from "./actions/connection"
-import { ClusterRegistry, isElectron, isWebMode, MetricsServerMap, startMetricsServer } from "./metrics-orchestrator"
+import { ClusterRegistry, isElectron, isWebMode, MetricsServerMap, startMetricsServer, clusterCredentials } from "./metrics-orchestrator"
 import { subscribe } from "./node-watchers"
 import { createClusterValkeyClient, createStandaloneValkeyClient } from "./valkey-client"
 
@@ -314,6 +314,7 @@ export async function connectToCluster(
         }),
       )
       clusterNodesRegistry[clusterId] = discoveredClusterNodes
+      clusterCredentials.set(clusterId, payload.connectionDetails.password) 
       clients.set(connectionId, { client: clusterClient, clusterId })
       connectedNodesByCluster.set(clusterId, [connectionId])
       subscribe(payload.connectionId, ws)
@@ -416,6 +417,7 @@ export function teardownConnection(
 
     if (clusterNodesRegistry && connection.clusterId && !isWebMode) {
       delete clusterNodesRegistry[connection.clusterId]
+      clusterCredentials.delete(connection.clusterId)
     }
   }
 }

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -12,7 +12,7 @@ import {
   returnExistingClusterClient } from "./utils"
 import { checkJsonModuleAvailability } from "./check-json-module"
 import { type ConnectionDetails } from "./actions/connection"
-import { ClusterRegistry, isElectron, isWebMode, MetricsServerMap, startMetricsServer, clusterCredentials } from "./metrics-orchestrator"
+import { ClusterRegistry, isElectron, isWebMode, MetricsServerMap, startMetricsServer, clusterCredentials, reconcileClusterMetricsServers, metricsServerMap } from "./metrics-orchestrator"
 import { subscribe } from "./node-watchers"
 import { createClusterValkeyClient, createStandaloneValkeyClient } from "./valkey-client"
 
@@ -314,7 +314,12 @@ export async function connectToCluster(
         }),
       )
       clusterNodesRegistry[clusterId] = discoveredClusterNodes
-      clusterCredentials.set(clusterId, payload.connectionDetails.password) 
+      clusterCredentials.set(clusterId, payload.connectionDetails.password)
+
+      if (isWebMode) {
+        reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap, payload.connectionDetails) 
+      } 
+
       clients.set(connectionId, { client: clusterClient, clusterId })
       connectedNodesByCluster.set(clusterId, [connectionId])
       subscribe(payload.connectionId, ws)

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -34,7 +34,10 @@ import {
   initialConnectionDetails,
   cleanupOrchestratorResources,
   clients,
-  isWebMode
+  isWebMode,
+  isKubernetes,
+  getInitialClient,
+  updateClusterNodeRegistry
 } from "./metrics-orchestrator"
 import type { Request, Response } from "express"
 
@@ -127,6 +130,11 @@ async function refreshAllClusterRegistriesLoop() {
   }
 }
 
+async function updateRegistryforK8() {
+  const client = await getInitialClient()
+  updateClusterNodeRegistry(client, initialConnectionDetails)
+}
+
 server.listen(port, () => {
   console.log(`Server running at http://localhost:${port}`)
   if (process.send) { // Check if process.send is available (i.e., if forked)
@@ -136,6 +144,9 @@ server.listen(port, () => {
 
   if (isWebMode) {
     runReconcileLoop()
+  }
+  else if (isKubernetes) {
+    updateRegistryforK8()
   }
 })
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -33,7 +33,8 @@ import {
   clusterNodesRegistry,
   initialConnectionDetails,
   cleanupOrchestratorResources,
-  clients
+  clients,
+  isWebMode
 } from "./metrics-orchestrator"
 import type { Request, Response } from "express"
 
@@ -82,10 +83,6 @@ const wss = new WebSocketServer({ server })
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
 async function runReconcileLoop() {
-  if (!initialConnectionDetails.host || !initialConnectionDetails.port) {
-    console.error("USE_CLUSTER_ORCHESTRATOR is enabled but VALKEY_HOST and VALKEY_PORT are not set. Orchestrator will not start.")
-    return
-  }
 
   let consecutiveFailures = 0
   const MAX_FAILURES = 5
@@ -146,7 +143,7 @@ server.listen(port, () => {
   }
   refreshAllClusterRegistriesLoop()
 
-  if (process.env.USE_CLUSTER_ORCHESTRATOR === "true") {
+  if (isWebMode) {
     runReconcileLoop()
   }
 })

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -84,21 +84,12 @@ const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
 async function runReconcileLoop() {
 
-  let consecutiveFailures = 0
-  const MAX_FAILURES = 5
-
   while (true) {
     try {
       await reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap, initialConnectionDetails)
-      consecutiveFailures = 0
       await delay(10000)
     } catch (err) {
       console.error("Failed to reconcile metrics servers", err)
-      consecutiveFailures++
-      if (consecutiveFailures >= MAX_FAILURES) {
-        console.error(`Orchestrator failed ${MAX_FAILURES} consecutive times. Stopping reconcile loop.`)
-        return
-      }
       await delay(10000)
     }
   }

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -3,7 +3,7 @@ import { ChildProcess, spawn } from "child_process"
 import { fileURLToPath } from "url"
 import { Router, type Request, type Response } from "express"
 import path from "path"
-import { sanitizeUrl } from "valkey-common"
+import { DEPLOYMENT_TYPE, sanitizeUrl } from "valkey-common"
 import { discoverCluster } from "./connection"
 import { ConnectionDetails } from "./actions/connection"
 import { createOrchestratorValkeyClient } from "./valkey-client"
@@ -41,6 +41,10 @@ export const clients: Map<string, {client: GlideClient | GlideClusterClient, clu
 export const clusterNodesRegistry: ClusterRegistry = {}
 
 export const metricsServerMap: MetricsServerMap = new Map()
+
+export const isWebMode = process.env.DEPLOYMENT_MODE === DEPLOYMENT_TYPE.WEB
+export const isKubernetes = process.env.DEPLOYMENT_MODE === DEPLOYMENT_TYPE.K8
+export const isElectron = process.env.DEPLOYMENT_MODE === DEPLOYMENT_TYPE.ELECTRON
 
 // Validate env variable so it matches EndpointType
 const endpointType = process.env.VALKEY_ENDPOINT_TYPE === "node" ? "node" : "cluster-endpoint"
@@ -205,9 +209,7 @@ async function findDiff(metricsServerMap: MetricsServerMap, clusterNodeMap: Clus
 }
 
 async function updateMetricsServers(nodesToAdd: ClusterNodeMap, nodesToRemove: string[]) {
-  if (process.env.USE_CLUSTER_ORCHESTRATOR !== "true") {
-    await startMetricsServers(nodesToAdd)
-  }
+  await startMetricsServers(nodesToAdd)
   await stopMetricsServers(nodesToRemove)
 }
 
@@ -236,20 +238,21 @@ async function stopMetricsServers(nodesToStop: string[]) {
 }
 
 export async function stopAllMetricsServers(metricsMap: MetricsServerMap) {
-  const useClusterOrchestrator = process.env.USE_CLUSTER_ORCHESTRATOR === "true"
-  metricsMap.forEach((metricsServer, nodeId) => {
-    try {
-      if (!useClusterOrchestrator && metricsServer.pid)
-        process.kill(metricsServer.pid)
-    } catch (e) {
-      console.warn(`Failed to kill metrics server ${nodeId}:`, e)
-    }
-  })
+  if (!isKubernetes) {
+    metricsMap.forEach((metricsServer, nodeId) => {
+      try {
+        if (metricsServer.pid)
+          process.kill(metricsServer.pid)
+      } catch (e) {
+        console.warn(`Failed to kill metrics server ${nodeId}:`, e)
+      }
+    })
+  }
   metricsMap.clear()
 }
 
 export async function startMetricsServer(nodeToStart: ClusterNodeInfo, nodeId: string) {
-  const isElectron = process.env.ELECTRON_APP === "true"
+  const isElectron = process.env.DEPLOYMENT_MODE === DEPLOYMENT_TYPE.ELECTRON
   const processResourcesPath = process.env.PROCESS_RESOURCES_PATH  ?? ""
   const metricsServerPath = isElectron
     ? path.join(processResourcesPath, "server-metrics.js")
@@ -314,7 +317,7 @@ async function stopMetricsServer(nodeToStop: string) {
   try {
     console.log("Killing metrics server for ", nodeToStop)
     const entry = metricsServerMap.get(nodeToStop)
-    if (process.env.USE_CLUSTER_ORCHESTRATOR === "true") {
+    if (isKubernetes) {
       metricsServerMap.delete(nodeToStop)
       return
     }

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -252,7 +252,6 @@ export async function stopAllMetricsServers(metricsMap: MetricsServerMap) {
 }
 
 export async function startMetricsServer(nodeToStart: ClusterNodeInfo, nodeId: string) {
-  const isElectron = process.env.DEPLOYMENT_MODE === DEPLOYMENT_TYPE.ELECTRON
   const processResourcesPath = process.env.PROCESS_RESOURCES_PATH  ?? ""
   const metricsServerPath = isElectron
     ? path.join(processResourcesPath, "server-metrics.js")

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -40,6 +40,8 @@ export const clients: Map<string, {client: GlideClient | GlideClusterClient, clu
 
 export const clusterNodesRegistry: ClusterRegistry = {}
 
+export const clusterCredentials: Map<string, string | undefined> = new Map()
+
 export const metricsServerMap: MetricsServerMap = new Map()
 
 export const isWebMode = process.env.DEPLOYMENT_MODE === DEPLOYMENT_TYPE.WEB
@@ -208,20 +210,17 @@ async function findDiff(metricsServerMap: MetricsServerMap, clusterNodeMap: Clus
   return { nodesToAdd, nodesToRemove }
 }
 
-async function updateMetricsServers(nodesToAdd: ClusterNodeMap, nodesToRemove: string[]) {
-  await startMetricsServers(nodesToAdd)
+async function updateMetricsServers(nodesToAdd: ClusterNodeMap, nodesToRemove: string[], clusterId: string) {
+  await startMetricsServers(nodesToAdd, clusterId)
   await stopMetricsServers(nodesToRemove)
 }
 
-async function startMetricsServers(nodesToStart: ClusterNodeMap) {
+async function startMetricsServers(nodesToStart: ClusterNodeMap, clusterId: string) {
+  const password = clusterCredentials.get(clusterId)
   await Promise.all(
     Object.entries(nodesToStart).map(async ([nodeId, nodeInfo]) => {
       if (!metricsServerMap.has(nodeId)) {
-        await startMetricsServer({
-          ...nodeInfo,
-          username: initialConnectionDetails.username,
-          password: initialConnectionDetails.password,
-        }, nodeId)
+        await startMetricsServer({ ...nodeInfo, password }, nodeId)
       }
     }),
   )
@@ -340,7 +339,10 @@ export async function reconcileClusterMetricsServers(
     try {
       const client = await getInitialClient()
       const { discoveredClusterNodes, clusterId } = await internals.getClusterTopology(client, connectionDetails)
-      if (clusterId && discoveredClusterNodes) clusterNodesRegistry[clusterId] = discoveredClusterNodes 
+      if (clusterId && discoveredClusterNodes) {
+        clusterNodesRegistry[clusterId] = discoveredClusterNodes 
+        if (!clusterCredentials.has(clusterId)) clusterCredentials.set(clusterId, initialConnectionDetails.password)
+      } 
       clusterIds = Object.keys(clusterNodesRegistry)
     } catch (err) {
       console.error(err)
@@ -355,7 +357,7 @@ export async function reconcileClusterMetricsServers(
           console.debug("Cluster nodes and metrics servers are in sync")
           return
         }
-        await internals.updateMetricsServers(nodesToAdd, nodesToRemove)
+        await internals.updateMetricsServers(nodesToAdd, nodesToRemove, clusterId)
       } catch (err) {
         console.error(`Failed to reconcile metrics servers for cluster ${clusterId}:`, err)
       }

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -188,6 +188,7 @@ export const KEY_EVICTION_POLICY = {
 
 export type KeyEvictionPolicy =
   typeof KEY_EVICTION_POLICY[keyof typeof KEY_EVICTION_POLICY]
+
 export const KEY_TYPES = {
   STRING: "String",
   LIST: "List",
@@ -208,3 +209,8 @@ export type EndpointType = "node" | "cluster-endpoint"
 
 export const CONNECTION_TEARDOWN_DELAY_MS = Number(process.env.CONNECTION_TEARDOWN_DELAY_MS ?? 10000)
 
+export const DEPLOYMENT_TYPE = {
+  ELECTRON: "Electron",
+  WEB: "Web",
+  K8: "K8",
+}

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificat
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV DEPLOYMENT_MODE=Web
 
 # Copy root workspace files
 COPY package.json package-lock.json ./

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -327,7 +327,6 @@ services:
       VALKEY_PASSWORD: ${VALKEY_PASSWORD}
       VALKEY_TLS: ${VALKEY_TLS}
       VALKEY_VERIFY_CERT: ${VALKEY_VERIFY_CERT}
-      USE_CLUSTER_ORCHESTRATOR: true
     ports:
       - "8080:8080"
     networks:

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -22,8 +22,8 @@ spec:
               value: production
             - name: PORT
               value: "8080"
-            - name: USE_CLUSTER_ORCHESTRATOR
-              value: "true"
+            - name: DEPLOYMENT_MODE
+              value: "K8"
             - name: VALKEY_HOST
               value: valkey-0.valkey-headless.valkey.svc.cluster.local
             - name: VALKEY_PORT


### PR DESCRIPTION
## Description

 We now check for a `DEPLOYMENT_MODE` environment variable that's set automatically for web and electron deployments. If the env var is set to "Web", then we use our app's metrics orchestrator to synchronize metrics servers with the cluster registry. For Electron, the metrics server for a node is only started when we successfully connect to that node. For K8s, we defer the orchestration. 

In order to connect to all metrics servers without the user specifying credentials, I created a new clusterCredentials map that stores these in the backend. This map is used by metrics-orchestrator  to connect to the respective valkey instance.

For the Active Monitors warning, we now show nodes with metrics servers started, rather than just connected nodes:

<img width="353" height="328" alt="image" src="https://github.com/user-attachments/assets/0e946c68-baab-4cb7-8008-a3c74a6080b1" />