### PR TITLE
Update frontend and common to use proper env access

### DIFF
--- a/apps/frontend/src/state/epics/wsEpics.ts
+++ b/apps/frontend/src/state/epics/wsEpics.ts
@@ -30,7 +30,7 @@ const isElectron = window.location.protocol === "file:"
 const isHttps = window.location.protocol === "https:"
 
 const url =
-  process.env.VALKEY_ADMIN_WS_URL ||
+  import.meta.env.VITE_VALKEY_ADMIN_WS_URL ||
   (isElectron
     ? "ws://localhost:8080"
     : `${isHttps ? "wss" : "ws"}://${window.location.host}`)

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_VALKEY_ADMIN_WS_URL?: string
   readonly VITE_LOCAL_VALKEY_HOST?: string
   readonly VITE_LOCAL_VALKEY_PORT?: string
   readonly VITE_LOCAL_VALKEY_NAME?: string

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -104,6 +104,9 @@ export const VALKEY = {
   }),
 } as const
 
+// check truthyness in case process doesn't have env
+const nodeEnv = typeof process !== "undefined" && process.env ? process.env : {}
+
 export const CONNECTED = "Connected"
 export const CONNECTING = "Connecting"
 export const ERROR = "Error"
@@ -111,8 +114,8 @@ export const NOT_CONNECTED = "Not Connected"
 export const DISCONNECTED = "Disconnected"
 export const RECONNECTING = "Reconnecting"
 export const DISCONNECTING = "Disconnecting"
-export const MAX_CONNECTIONS = process?.env?.MAX_CONNECTIONS
-  ? Number(process.env.MAX_CONNECTIONS)
+export const MAX_CONNECTIONS = nodeEnv.MAX_CONNECTIONS
+  ? Number(nodeEnv.MAX_CONNECTIONS)
   : Infinity
 
 export const PENDING = "Pending"
@@ -207,7 +210,7 @@ export const METRICS_EVICTION_POLICY = {
 
 export type EndpointType = "node" | "cluster-endpoint"
 
-export const CONNECTION_TEARDOWN_DELAY_MS = Number(process.env.CONNECTION_TEARDOWN_DELAY_MS ?? 10000)
+export const CONNECTION_TEARDOWN_DELAY_MS = Number(nodeEnv.CONNECTION_TEARDOWN_DELAY_MS ?? 10000)
 
 export const DEPLOYMENT_TYPE = {
   ELECTRON: "Electron",


### PR DESCRIPTION
## Description

Previously `npm run dev` would lead to an error due to process not being defined.

This PR correctly guards process.
