### PR TITLE
Build docker images only on main

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,17 +2,16 @@ name: Docker Build
 
 on:
   push:
+    branches:
+      - 'main'
     tags:
       - 'v*'
-  pull_request:
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 env:
-  PUBLISH_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' && (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v')) }}
-  PUBLISH_GHCR: ${{ github.repository == 'valkey-io/valkey-admin' && (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v')) }}
-  PUBLISH_ECR: ${{ secrets.AWS_ROLE_TO_ASSUME != '' && (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v')) }}
+  PUBLISH_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+  PUBLISH_GHCR: ${{ github.repository == 'valkey-io/valkey-admin' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+  PUBLISH_ECR: ${{ secrets.AWS_ROLE_TO_ASSUME != '' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
 
 defaults:
   run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,14 @@ We use **ESLint v9.0.0+** to maintain code quality.
 4. **Submit PR:** Open a Pull Request against the `main` branch.
 5. **Approval:** All Pull Requests require at least one approval from a project contributor before they can be merged.
 
+### CI Notes
+
+PR CI is optimized for functional feedback first: linting, tests, and integration checks should catch code regressions quickly.
+
+Docker image builds are treated as packaging/distribution work rather than a required PR signal, so the Docker publish workflow runs on pushes to `main` and release tags, not on every PR branch update.
+
+If the Docker workflow fails on `main`, fix it in a new branch. Validate the image build locally first, then open a PR with the packaging fix. For packaging-focused branch validation in GitHub Actions, trigger the Docker workflow manually via `workflow_dispatch`; on non-`main` branches this validates the build without publishing images.
+
 ---
 
 ## License


### PR DESCRIPTION
## Description

This change updates the Docker GitHub Actions workflow to align CI cost with its purpose. Docker image builds are treated as packaging/distribution work, not a required signal for everyday feature PRs, so the workflow no longer runs automatically on pull requests or on a schedule. It now runs on pushes to main, on release tags, and can still be triggered manually with workflow_dispatch for packaging-focused branch validation.

Publishing behavior was updated to match the new trigger policy: images are pushed only from main and version tags. Manual runs on non-main branches still validate the Docker build path without publishing images.

The contributor guidance in CONTRIBUTING.md was also updated to document the reasoning behind this setup and the expected recovery path when a Docker build fails on main: fix it in a new branch, validate locally, and open a PR.


### Change Visualization

N/A