### PR TITLE
Build macos and linux only on main

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build:
+    name: build-linux-artifact
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -3,8 +3,7 @@ name: Build Linux
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -24,8 +23,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build:
+    name: build-macos-artifact
     runs-on: macos-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -3,8 +3,7 @@ name: Node.js CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -15,8 +14,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  app-build:
+    name: app-build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    - name: Use Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: 'latest'
+    - name: Install dependencies
+      run: npm ci
+    - name: Build application
+      run: npm run build:electron

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,9 +211,9 @@ We use **ESLint v9.0.0+** to maintain code quality.
 
 PR CI is optimized for functional feedback first: linting, tests, and integration checks should catch code regressions quickly.
 
-Docker image builds are treated as packaging/distribution work rather than a required PR signal, so the Docker publish workflow runs on pushes to `main` and release tags, not on every PR branch update.
+Docker image builds and desktop packaging builds are treated as distribution work rather than required PR signals, so those workflows run on pushes to `main` and release tags, not on every PR branch update.
 
-If the Docker workflow fails on `main`, fix it in a new branch. Validate the image build locally first, then open a PR with the packaging fix. For packaging-focused branch validation in GitHub Actions, trigger the Docker workflow manually via `workflow_dispatch`; on non-`main` branches this validates the build without publishing images.
+Before requesting review on any PR, trigger the Docker, Linux, and macOS distribution workflows manually on your branch via `workflow_dispatch` and include the successful workflow runs in the PR.
 
 ---
 


### PR DESCRIPTION
## Description

This change stops Docker, Linux, and macOS artifact workflows from running automatically on PR branch pushes. Those workflows now run automatically only on main and release tags where applicable, and remain available via workflow_dispatch for manual branch validation. A new lightweight app-build workflow was also added for PRs and main to preserve a real compile/build signal without running full packaging jobs.

CONTRIBUTING.md was updated to document the new policy: before requesting review, contributors must manually run the Docker, Linux, and macOS distribution workflows on their branch and include the successful runs in the PR. This keeps PR CI focused on fast functional checks like lint, tests, integration, and app-build, while still validating release artifacts before merge.

### Change Visualization

Include a screenshot/video of before and after the change.
