### PR TITLE
Add higher concurrency limit for getting keys

### DIFF
--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -272,7 +272,7 @@ async function scanCluster(
   return allKeys
 }
 
-const limit = pLimit(100) 
+const limit = pLimit(20) 
 export async function getKeys(
   client: GlideClient | GlideClusterClient,
   ws: WebSocket,

--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -272,7 +272,7 @@ async function scanCluster(
   return allKeys
 }
 
-const limit = pLimit(10) 
+const limit = pLimit(100) 
 export async function getKeys(
   client: GlideClient | GlideClusterClient,
   ws: WebSocket,

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -147,7 +147,7 @@ export const retryDelay = (retryCount: number): number => {
 export const VALKEY_CLIENT = {
   SCAN: {
     defaultPayloadPattern: "*",
-    defaultCount: 50,
+    defaultCount: 500,
   } ,
   KEY_VALUE_SIZE_LIMIT: 2048, // 2KiB
   MESSAGES: {

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -147,7 +147,7 @@ export const retryDelay = (retryCount: number): number => {
 export const VALKEY_CLIENT = {
   SCAN: {
     defaultPayloadPattern: "*",
-    defaultCount: 500,
+    defaultCount: 100,
   } ,
   KEY_VALUE_SIZE_LIMIT: 2048, // 2KiB
   MESSAGES: {


### PR DESCRIPTION
## Description

Currently, we have pLimit(10), which means only 10 getKeyInfo calls run at a time. Each call does 3 commands in parallel (Promise.all for TYPE, TTL, MEMORY USAGE), so effectively 30 commands in flight. Glide handles thousands of concurrent commands. Therefore, bumping would cut enrichment time significantly with no risk, since these are read-only commands on different keys.

## Perf Testing

 COUNT | pLimit | Scan | Enrich | Total |
|-------|--------|------|--------|-------|
| 50 | 10 | 9ms | 212ms | 220ms |
| 50 | 50 | 8ms | 82ms | 90ms |
| 50 | 100 | 8ms | 73ms | 80ms |
| 50 | 200 | 7ms | 71ms | 78ms |
| 100 | 10 | 5ms | 185ms | 190ms |
| 100 | 50 | 5ms | 83ms | 88ms |
| 100 | 100 | 5ms | 74ms | 79ms |
| 100 | 200 | 5ms | 71ms | 77ms |
| 500 | 10 | 4ms | 238ms | 242ms |
| 500 | 50 | 9ms | 79ms | 88ms |
| 500 | 100 | 8ms | 72ms | 80ms |
| 500 | 200 | 8ms | 68ms | 76ms |

Takeaways:
- Beyond pLimit=100, gains are marginal (<5ms)
- Best choice: COUNT=100, pLimit=100
