### PR TITLE
Remove await on send command and rate limiting on orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ When you start monitoring, two settings control the sampling behavior:
 
 - **Duration:** How long each sampling run captures commands (default: 10 seconds). During this window, the `MONITOR` command streams every command executed on the server, and the metrics server counts key access frequency.
 - **Interval:** How long to wait between sampling runs (default: 10 seconds). After each duration completes, the metrics server pauses for the interval before starting the next run.
+- **Max Commands Per Run:** Maximum number of commands captured during each monitoring cycle (default: 1,000,000). If the limit is reached before the duration expires, the cycle ends early. Lower values reduce memory usage on busy clusters.
+- **Cutoff Frequency:** Minimum number of times a key must be accessed during a monitoring cycle to be considered hot (default: 100). Keys accessed fewer times are filtered out. Lower values show more keys; higher values surface only the most active keys.
 
 This creates a repeating cycle: capture for *duration*, pause for *interval*, capture again. The hot keys displayed are from the most recent sampling run.
 

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-toolbar.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-toolbar.tsx
@@ -74,7 +74,7 @@ export function HotKeysToolbar({
         border border-input bg-background">
         <Clock className="shrink-0" size={12} />
         <Typography variant="bodyXs">
-          Last collected at: {new Date(lastCollectedAt!).toLocaleString()}
+          {lastCollectedAt && <>Last collected at: {new Date(lastCollectedAt).toLocaleString()}</>}
         </Typography>
       </div>
     </div>

--- a/apps/server/src/actions/command.ts
+++ b/apps/server/src/actions/command.ts
@@ -12,7 +12,7 @@ export const sendRequested = withDeps<Deps, void>(
     const connection = clients.get(connectionId!)
 
     if (connection) {
-      await sendValkeyRunCommand(connection.client, ws, action.payload as CommandAction)
+      sendValkeyRunCommand(connection.client, ws, action.payload as CommandAction)
       return
     }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -71,7 +71,10 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const frontendDist = path.join(__dirname, "../../frontend/dist")
 
-app.use(limiter)
+app.use((req, res, next) => {
+  if (req.path.startsWith("/orchestrator")) return next()
+  return limiter(req, res, next)
+})
 app.use(express.static(frontendDist))
 app.use(express.json())
 const metricsRouter = createMetricsOrchestratorRouter()

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -321,7 +321,7 @@ async function stopMetricsServer(nodeToStop: string) {
       return
     }
     if (entry?.pid) {
-      process?.kill(entry.pid,"SIGTERM")
+      try { process?.kill(entry.pid, "SIGTERM") } catch { /* already dead */ }
       metricsServerMap.delete(nodeToStop)
     }
   }


### PR DESCRIPTION
## Description

- Removed await from send command, so other operations aren't blocked for long running commands like INFO on a large cluster. 
- Removed rate limiting so 150 metrics servers could start at once for a large cluster without errors.
- Made sure to delete metrics server when it's already dead instead of trying to repeatedly kill it
- Fixed lastCollectedAtBug
