### PR TITLE
use cluster alias in views instead of cluster id if available

### DIFF
--- a/apps/frontend/src/components/activity-view/ActivityView.tsx
+++ b/apps/frontend/src/components/activity-view/ActivityView.tsx
@@ -23,7 +23,7 @@ import {
   selectHotKeysNodeErrors, selectHotKeysLastCollectedAt
 } from "@/state/valkey-features/hotkeys/hotKeysSlice"
 import { monitorRequested, selectMonitorRunning } from "@/state/valkey-features/monitor/monitorSlice"
-import { selectConnectionDetails } from "@/state/valkey-features/connection/connectionSelectors"
+import { selectConnectionDetails, selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
 import { getKeyTypeRequested } from "@/state/valkey-features/keys/keyBrowserSlice"
 import { selectKeys } from "@/state/valkey-features/keys/keyBrowserSelectors"
 
@@ -61,6 +61,7 @@ export const ActivityView = () => {
   const hotKeysLastCollectedAt = useSelector((state: RootState) => selectHotKeysLastCollectedAt(hotKeysId)(state))
   const monitorRunning = useSelector(selectMonitorRunning(id!))
   const connectionDetails = useSelector((state: RootState) => selectConnectionDetails(id!)(state))
+  const clusterAlias = useSelector(selectClusterAlias(id!))
   const useHotSlots = connectionDetails?.keyEvictionPolicy?.includes("lfu") && connectionDetails?.clusterSlotStatsEnabled
   const keys: KeyInfo[] = useSelector(selectKeys(id!))
 
@@ -140,7 +141,7 @@ export const ActivityView = () => {
             Monitor Hot Keys and Command Logs of{" "}
             {clusterId ? (
               <>
-                cluster {" "} <span className="font-semibold text-primary">{truncateText(clusterId!)}</span>
+                cluster {" "} <span className="font-semibold text-primary">{truncateText(clusterAlias || clusterId!)}</span>
               </>
             ) : (
               <>instance <span className="font-semibold text-primary">{truncateText(id!)}</span></>

--- a/apps/frontend/src/components/cluster-topology/Cluster.tsx
+++ b/apps/frontend/src/components/cluster-topology/Cluster.tsx
@@ -14,6 +14,7 @@ import type { RootState } from "@/store.ts"
 import { selectCluster } from "@/state/valkey-features/cluster/clusterSelectors"
 import { useAppDispatch } from "@/hooks/hooks"
 import { updateClusterData } from "@/state/valkey-features/cluster/clusterSlice"
+import { selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
 
 export function Cluster() {
   const { id, clusterId } = useParams()
@@ -27,6 +28,7 @@ export function Cluster() {
   const connectionStatuses = useSelector((state: RootState) =>
     state.valkeyConnection?.connections || {},
   )
+  const clusterAlias = useSelector(selectClusterAlias(id!))
 
   if (!clusterData?.clusterNodes || !clusterData?.data) {
     return (
@@ -77,7 +79,7 @@ export function Cluster() {
         description={
           <>
             Topology of cluster{" "}
-            <span className="font-semibold text-primary">{truncateText(clusterId!)}</span>
+            <span className="font-semibold text-primary">{truncateText(clusterAlias || clusterId!)}</span>
           </>
         }
         icon={<Server size={20} />}

--- a/apps/frontend/src/components/key-browser/KeyBrowser.tsx
+++ b/apps/frontend/src/components/key-browser/KeyBrowser.tsx
@@ -38,6 +38,7 @@ import {
   getKeysRequested,
   getKeyTypeRequested
 } from "@/state/valkey-features/keys/keyBrowserSlice"
+import { selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
 
 interface KeyInfo {
   name: string;
@@ -57,6 +58,7 @@ export function KeyBrowser() {
   const [isDistributionOpen, setIsDistributionOpen] = useState(false)
   const [searchPattern, setSearchPattern] = useState("")
   const [selectedType, setSelectedType] = useState<string>("all")
+  const clusterAlias = useSelector(selectClusterAlias(id!))
   const keyTypes = [
     { value: "all", label: "All Key Types" },
     { value: "string", label: "String" },
@@ -137,7 +139,7 @@ export function KeyBrowser() {
             Add, View and Edit keys of{" "}
             {clusterId ? (
               <>
-                cluster{" "} <span className="font-semibold text-primary">{truncateText(clusterId!)}</span>
+                cluster{" "} <span className="font-semibold text-primary">{truncateText(clusterAlias || clusterId!)}</span>
               </>
             ) : (
               <>instance <span className="font-semibold text-primary">{truncateText(id!)}</span></>

--- a/apps/frontend/src/components/send-command/SendCommand.tsx
+++ b/apps/frontend/src/components/send-command/SendCommand.tsx
@@ -20,6 +20,7 @@ import DiffCommands from "@/components/send-command/DiffCommands.tsx"
 import Response from "@/components/send-command/Response.tsx"
 import { useAppDispatch } from "@/hooks/hooks.ts"
 import { Typography } from "@/components/ui/typography.tsx"
+import { selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
 
 export function SendCommand() {
   const dispatch = useAppDispatch()
@@ -31,6 +32,7 @@ export function SendCommand() {
   const [historyFilter, setHistoryFilter] = useState("")
 
   const { id, clusterId } = useParams()
+  const clusterAlias = useSelector(selectClusterAlias(id!))
   const allCommands = useSelector(selectAllCommands(id as string)) || []
   const { error, response } = useSelector(getNth(commandIndex, id as string)) as CommandMetadata
 
@@ -68,7 +70,7 @@ export function SendCommand() {
             Send commands and view responses for{" "}
             {clusterId ? (
               <>
-                cluster{" "} <span className="font-semibold text-primary">{truncateText(clusterId!)}</span>
+                cluster{" "} <span className="font-semibold text-primary">{truncateText(clusterAlias || clusterId!)}</span>
               </>
             ) : (
               <>instance <span className="font-semibold text-primary">{truncateText(id!)}</span></>

--- a/apps/frontend/src/components/ui/connection-form.tsx
+++ b/apps/frontend/src/components/ui/connection-form.tsx
@@ -67,7 +67,8 @@ function ConnectionForm({ onClose }: ConnectionFormProps) {
     const trimmed: ConnectionDetails = {
       ...connectionDetails,
       host: connectionDetails.host.trim(),
-      alias: connectionDetails.alias?.trim() ?? "",
+      // uses typed alias which falls back to awsReplicationGroupId for AWS IAM auth
+      alias: connectionDetails.alias?.trim() || (connectionDetails.authType === "iam" ? connectionDetails.awsReplicationGroupId : ""),
       username: connectionDetails.username?.trim() ?? "",
       awsRegion: connectionDetails.awsRegion?.trim(),
       awsReplicationGroupId: connectionDetails.awsReplicationGroupId?.trim(),

--- a/apps/frontend/src/state/valkey-features/connection/connectionSelectors.ts
+++ b/apps/frontend/src/state/valkey-features/connection/connectionSelectors.ts
@@ -23,3 +23,6 @@ export const selectEncryptedPassword = (clusterId: string) => (state: RootState)
     (c) => c.connectionDetails?.clusterId === clusterId && R.isNotNil(c.connectionDetails?.password),
   )?.connectionDetails?.password
 
+export const selectClusterAlias = (id: string) => (state: RootState) =>
+  atId(id, state)?.connectionDetails?.alias
+


### PR DESCRIPTION
## Description

Include a summary of the change.

1. use cluster alias instead of cluster id if available 
2. when auth type is AWS IAM use the aws replication ID as alias if no typed alias is provided

### Change Visualization

Include a screenshot/video of before and after the change.
