### PR TITLE
Check for preconfigured connection details before reconciling

### DIFF
--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -337,7 +337,8 @@ export async function reconcileClusterMetricsServers(
   metricsServerMap: MetricsServerMap, 
   connectionDetails: ConnectionDetails, 
 ) {
-  let clusterIds = Object.keys(clusterNodesRegistry) 
+  let clusterIds = Object.keys(clusterNodesRegistry)
+  // Start metrics server for all nodes if it is preconfigured before manual connection
   if (clusterIds.length === 0 && preConfiguredConnection) {
     try {
       const client = await getInitialClient()

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -48,6 +48,8 @@ export const isWebMode = process.env.DEPLOYMENT_MODE === DEPLOYMENT_TYPE.WEB
 export const isKubernetes = process.env.DEPLOYMENT_MODE === DEPLOYMENT_TYPE.K8
 export const isElectron = process.env.DEPLOYMENT_MODE === DEPLOYMENT_TYPE.ELECTRON
 
+export const preConfiguredConnection = process.env.VALKEY_HOST && process.env.VALKEY_PORT
+
 // Validate env variable so it matches EndpointType
 const endpointType = process.env.VALKEY_ENDPOINT_TYPE === "node" ? "node" : "cluster-endpoint"
 
@@ -336,7 +338,7 @@ export async function reconcileClusterMetricsServers(
   connectionDetails: ConnectionDetails, 
 ) {
   let clusterIds = Object.keys(clusterNodesRegistry) 
-  if (clusterIds.length === 0) {
+  if (clusterIds.length === 0 && preConfiguredConnection) {
     try {
       const client = await getInitialClient()
       const { discoveredClusterNodes, clusterId } = await internals.getClusterTopology(client, connectionDetails)
@@ -349,21 +351,23 @@ export async function reconcileClusterMetricsServers(
       console.error(err)
     }
   }
-  await Promise.all(
-    clusterIds.map(async (clusterId) => {
-      try {
-        const { nodesToAdd, nodesToRemove } = await internals.findDiff(metricsServerMap, clusterNodesRegistry[clusterId])
-        // Early return if nothing has changed
-        if (Object.keys(nodesToAdd).length === 0 && nodesToRemove.length === 0) {
-          console.debug("Cluster nodes and metrics servers are in sync")
-          return
+  else if (clusterIds.length > 0) {
+    await Promise.all(
+      clusterIds.map(async (clusterId) => {
+        try {
+          const { nodesToAdd, nodesToRemove } = await internals.findDiff(metricsServerMap, clusterNodesRegistry[clusterId])
+          // Early return if nothing has changed
+          if (Object.keys(nodesToAdd).length === 0 && nodesToRemove.length === 0) {
+            console.debug("Cluster nodes and metrics servers are in sync")
+            return
+          }
+          await internals.updateMetricsServers(nodesToAdd, nodesToRemove, clusterId)
+        } catch (err) {
+          console.error(`Failed to reconcile metrics servers for cluster ${clusterId}:`, err)
         }
-        await internals.updateMetricsServers(nodesToAdd, nodesToRemove, clusterId)
-      } catch (err) {
-        console.error(`Failed to reconcile metrics servers for cluster ${clusterId}:`, err)
-      }
-    }),
-  )
+      }),
+    )
+  }
 }
 
 export function cleanupOrchestratorResources() {


### PR DESCRIPTION
## Description
Prior to this change, our metrics orchestrator would try to reconcile metrics servers with cluster topology even if a user is connecting to a standalone instance. The fix is to see if a user provided preconfigured cluster connection details before trying to reconcile. We also check if cluster registries has any entries before orchestrating.

