### PR TITLE
Change clientName to include valkey admin

### DIFF
--- a/apps/server/src/__tests__/connection.test.ts
+++ b/apps/server/src/__tests__/connection.test.ts
@@ -504,7 +504,7 @@ describe("connectToValkey", () => {
         port: Number(alternate_payload.connectionDetails.port),
       }])
       assert.strictEqual(config.requestTimeout, 5000)
-      assert.strictEqual(config.clientName, "valkey_server_standalone_client")
+      assert.strictEqual(config.clientName, "valkey_admin_standalone_client")
       return mockStandaloneClient as any
     })
 
@@ -537,7 +537,7 @@ describe("connectToValkey", () => {
         port: Number(alternate_payload.connectionDetails.port),
       }])
       assert.strictEqual(config.requestTimeout, 5000)
-      assert.strictEqual(config.clientName, "valkey_server_standalone_client")
+      assert.strictEqual(config.clientName, "valkey_admin_standalone_client")
     } finally {
       GlideClient.createClient = originalCreateClient
     }

--- a/apps/server/src/valkey-client.ts
+++ b/apps/server/src/valkey-client.ts
@@ -37,7 +37,7 @@ export const createStandaloneValkeyClient = ({
 }: ClientOptions) =>
   GlideClient.createClient({
     ...buildSharedOptions(options),
-    clientName: "valkey_server_standalone_client",
+    clientName: "valkey_admin_standalone_client",
   })
 
 export const createClusterValkeyClient = ({
@@ -45,7 +45,7 @@ export const createClusterValkeyClient = ({
 }: ClientOptions) =>
   GlideClusterClient.createClient({
     ...buildSharedOptions(options),
-    clientName: "valkey_server_cluster_client",
+    clientName: "valkey_admin_cluster_client",
   })
 
 export const createOrchestratorValkeyClient = ({
@@ -53,5 +53,5 @@ export const createOrchestratorValkeyClient = ({
 }: ClientOptions) =>
   GlideClient.createClient({
     ...buildSharedOptions(options),
-    clientName: "valkey_server_orchestrator_client",
+    clientName: "valkey_admin_orchestrator_client",
   })


### PR DESCRIPTION
## Description

Renames the GLIDE clientName on all main backend connections from valkey_server_*_client to valkey_admin_*_client, since the valkey_server_* prefix is misleading (it reads like a connection from the Valkey server itself rather than from the Valkey Admin application), making the client list output confusing.

### Change Visualization

N/A
