### PR TITLE
Revise readme to include website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,209 +2,52 @@
 
 Valkey Admin is a web-based administration tool for [Valkey](https://valkey.io) clusters and standalone instances. It provides an intuitive interface to monitor, manage, and interact with your Valkey deployments.
 
-> **Compatibility:** Valkey Admin works with all versions of Valkey. Some features require newer versions:
-> - **Command Logs** (slow commands, large requests/replies): Valkey 8.1+
-> - **Hot Slots Detection** (via `CLUSTER SLOT-STATS`): Valkey 8.0+ with `cluster-slot-stats-enabled` set to `yes`
+Full documentation lives at **[valkey-admin.valkey.io](https://valkey-admin.valkey.io)**.
 
-## Features
+## Key Features
 
-- **Dashboard:** real-time metrics including memory usage, CPU, connected clients, hit ratio, and command throughput
+- **[Dashboard](https://valkey-admin.valkey.io/features/dashboard/)** — Real-time metrics for memory, CPU, connected clients, hit ratio, and command throughput.
+- **[Key Browser](https://valkey-admin.valkey.io/features/key-browser/)** — Browse, search, inspect, and edit keys across all data types (String, Hash, List, Set, Sorted Set, Stream, JSON).
+- **[Send Command](https://valkey-admin.valkey.io/features/send-command/)** — Execute Valkey commands with response formatting and command history.
+- **[Cluster Topology](https://valkey-admin.valkey.io/features/cluster-topology/)** — Visual map of shards, primaries, and replicas with per-node metrics.
+- **[Activity](https://valkey-admin.valkey.io/features/activity/)** — Hot Keys monitoring plus Command Logs (slow commands, large requests, large replies) aggregated across the cluster.
 
-![Dashboard](screenshots/dashboard.png)
-![DashboardMetrics](screenshots/dashboard2.png)
+## Compatibility
 
-- **Cluster Topology:** visual map of shards, primaries, and replicas with per-node metrics
+Valkey Admin works with all supported Valkey versions. Some features are version-gated:
 
-![Cluster Topology](screenshots/cluster_topology.png)
+- **Command Logs** (slow commands, large requests/replies) require Valkey 8.1+.
+- **Hot Slots detection** requires Valkey 8.0+ with `cluster-slot-stats-enabled` set to `yes`.
 
-- **Key Browser:** browse, search, inspect, and edit keys across all data types (String, Hash, List, Set, Sorted Set, Stream, JSON)
+## Getting Started
 
-![Key Browser](screenshots/key_browser.png)
+**Documentation:** [valkey-admin.valkey.io](https://valkey-admin.valkey.io/introduction/)
 
-- **Send Command:** execute Valkey commands with response formatting and command history
+**Install:**
 
-![Send Command](screenshots/send_command.png)
+- **Desktop (macOS / Linux)** — Download from [GitHub Releases](https://github.com/valkey-io/valkey-admin/releases). See the [Desktop deployment guide](https://valkey-admin.valkey.io/deployment/desktop/).
+- **Docker** — Images published to GHCR, Docker Hub, and ECR Public. See the [Docker deployment guide](https://valkey-admin.valkey.io/deployment/docker/).
+- **Kubernetes** — Sidecar-based deployment for cluster-scale collection. See the [Kubernetes deployment guide](https://valkey-admin.valkey.io/deployment/kubernetes/).
+- **AWS ElastiCache** — See the [AWS ElastiCache guide](https://valkey-admin.valkey.io/deployment/aws-elasticache/).
 
-- **Hot Keys Monitoring:** identify frequently accessed keys across all cluster nodes
+## Releases
 
-![Monitoring Hot Keys](screenshots/monitoring_hotkeys.png)
+Latest: **v1.0.1**. See [GitHub Releases](https://github.com/valkey-io/valkey-admin/releases) for the full changelog.
 
-- **Command Logs:** view slow commands, large requests, and large replies aggregated across the cluster
+## Getting Help
 
-![Monitoring Slow Logs](screenshots/monitoring_slowlogs.png)
+If you run into issues or have questions, open a [GitHub issue](https://github.com/valkey-io/valkey-admin/issues). Before filing a new issue, please check the existing ones to see if your question has already been addressed. When reporting a bug, please include:
 
-## Platform Support
-
-- **macOS** (native desktop app)
-- **Linux** (native desktop app — AppImage and deb)
-- **Docker** (web deployment)
-- **Kubernetes** (web deployment with metrics sidecars)
-
-## Installation
-
-### Desktop App
-
-Download the latest release from [GitHub Releases](https://github.com/valkey-io/valkey-admin/releases):
-
-- **macOS:** Download the `.dmg` file, open it, and drag Valkey Admin to Applications
-- **Linux:** Download the `.AppImage` or `.deb` package
-
-### Docker
-
-Docker images are published to the following registries:
-
-| Registry | Image |
-|----------|-------|
-| GitHub Container Registry | `ghcr.io/valkey-io/valkey-admin` |
-| Docker Hub | `valkey/valkey-admin` |
-| Amazon ECR Public Gallery | `public.ecr.aws/valkey/valkey-admin` |
-
-**Example:** 
-```bash
-docker pull valkey/valkey-admin:latest
-```
-
-See [examples/](./examples/) for deployment guides including Docker, Kubernetes, and AWS ElastiCache.
-
-
-## Resource Sizing
-
-In Web and Docker deployment modes, Valkey Admin spawns a metrics server process for each primary node in the cluster. Plan resources accordingly.
-
-**Formulas:**
-- **RAM:** `(primary nodes × 150 MB) + 1 GB`
-- **Disk:** `(primary nodes × 50 MB) + 1 GB`
-
-### Approximate Resource Recommendations
-
-| Cluster Size | Recommended Spec |
-|---|---|
-| 1–5 primaries | 2 vCPU, 2 GB RAM |
-| 5–50 primaries | 4 vCPU, 8 GB RAM |
-| 50–100 primaries | 8 vCPU, 16 GB RAM |
-| 100–200 primaries | 16 vCPU, 32 GB RAM |
-| 200–400+ primaries | 32 vCPU, 64 GB RAM |
-
-> **Warning:** These recommendations are based on the default retention settings in [config.yml](./apps/metrics/config.yml). If you increase `data_retention_mb` or `data_retention_days`, adjust your resource allocation accordingly. Disk usage scales at approximately `(primary nodes × 50 MB) + 1 GB` with default retention settings.
-
-For Kubernetes deployments, metrics servers run as sidecars on each Valkey pod, so the main Valkey Admin deployment only needs ~1 GB RAM.
-
-> **Note:** The desktop app (Electron) spawns a metrics server for each node you connect to. For large clusters, connecting to many nodes individually will increase local RAM and disk usage. Refer to the [formulas above](#resource-sizing) to ensure your machine can handle the load.
-
-## Configuration
-
-Valkey Admin is configured through environment variables. All variables are optional. 
-
-### Backend Server
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `PORT` | Server listen port | `8080` |
-| `DEPLOYMENT_MODE` | Controls metrics server orchestration. If `Web`, all metrics servers for cluster nodes start on any successful connection. If `Electron`, the metrics server only starts when you've successfully connected to a particular node. | `Electron` for Desktop and `Web` for Docker |
-| `TTL` | Metrics server health check timeout (ms) | `60000` |
-| `TOPOLOGY_REFRESH_INTERVAL` | Cluster topology refresh interval (ms) | `30000` |
-| `HOT_KEYS_COUNT` | Maximum number of hot keys returned per query | `50` |
-| `COMMAND_LOGS_COUNT` | Maximum number of command log entries returned per query | `100` |
-
-### Pre-configured Metrics Collection
-
-Set these to start all metrics servers for your cluster on startup, before manually connecting via UI (Web and K8 modes):
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `VALKEY_HOST` | Valkey host or cluster endpoint | — |
-| `VALKEY_PORT` | Valkey port | `6379` |
-| `VALKEY_TLS` | Enable TLS | `false` |
-| `VALKEY_VERIFY_CERT` | Verify TLS certificate | `false` |
-| `VALKEY_ENDPOINT_TYPE` | `node` or `cluster-endpoint` | `cluster-endpoint` |
-| `VALKEY_AUTH_TYPE` | `password` or `iam` | `password` |
-| `VALKEY_USERNAME` | Authentication username | — |
-| `VALKEY_PASSWORD` | Authentication password | — |
-| `VALKEY_AWS_REGION` | AWS region (IAM auth only) | — |
-| `VALKEY_REPLICATION_GROUP_ID` | ElastiCache replication group ID (IAM auth only) | — |
-
-### Metrics Server
-
-These are set automatically when the server spawns metrics processes. 
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `CONFIG_PATH` | Path to metrics config YAML. Mount a custom file to override collection and retention settings. | `config.yml` |
-| `DATA_DIR` | Metrics data storage directory | `./data` |
-| `SERVER_HOST` | Main server host for registration. Default is localhost, as metrics servers are forked from the main process. | `localhost` |
-| `SERVER_PORT` | Main server port for registration | `8080` |
-
-### Metrics Config (`config.yml`)
-
-The metrics config file controls collection intervals and data retention. Override it by mounting a custom file and setting `CONFIG_PATH`.
-
-See [apps/metrics/config.yml](./apps/metrics/config.yml) for the default epic configuration.
-
-**Global settings:**
-
-| Setting | Description | Default |
-|---------|-------------|---------|
-| `backend.ping_interval` | How often each metrics server pings the main server (ms) | `10000` |
-| `collector.batch_ms` | Batch write interval for metric data (ms) | `60000` |
-| `collector.batch_max` | Max records per batch write | `500` |
-
-**Per-epic settings:**
-
-Each metric collector (epic) supports the following options:
-
-| Setting | Description | Default |
-|---------|-------------|---------|
-| `poll_ms` | Collection interval (ms) | varies by epic |
-| `data_retention_mb` | Max disk space per epic (MB). Oldest files evicted when exceeded. | `10` |
-| `data_retention_days` | Files older than this are deleted during daily cleanup. | `30` |
-
-## Hot Keys Detection
-
-Valkey Admin supports two methods for detecting hot keys across your cluster:
-
-### Hot Slots (Recommended)
-
-Uses the `CLUSTER SLOT-STATS` command to identify hot slots by CPU usage, network ingress, and network egress. This is the preferred method as it has no performance impact on your cluster.
-
-**Requirements:**
-- Valkey 8.0+ (the `CLUSTER SLOT-STATS` command was introduced in Valkey 8.0)
-- `cluster-slot-stats-enabled` set to `yes`
-- LFU eviction policy (`allkeys-lfu` or `volatile-lfu`) configured on the cluster
-- Cluster mode (not available for standalone instances)
-
-When both conditions are met, Valkey Admin queries each shard's slot statistics and identifies the hottest slots by `cpu-usec`. It then resolves the keys within those slots to surface the hottest keys in those slots.
-
-> **Note:** The access count shown for hot slots keys is the LFU logarithmic frequency (0–255), not a raw access count. A key accessed millions of times may show a frequency of ~70. 
-
-### Monitor-based Detection
-
-Uses the Valkey `MONITOR` command to capture all commands in real time, then aggregates key access frequency from the command stream. Works with any Valkey or Redis version, in both standalone and cluster modes.
-
-**How it works:**
-
-When you start monitoring, two settings control the sampling behavior:
-
-- **Duration:** How long each sampling run captures commands (default: 10 seconds). During this window, the `MONITOR` command streams every command executed on the server, and the metrics server counts key access frequency.
-- **Interval:** How long to wait between sampling runs (default: 10 seconds). After each duration completes, the metrics server pauses for the interval before starting the next run.
-- **Max Commands Per Run:** Maximum number of commands captured during each monitoring cycle (default: 1,000,000). If the limit is reached before the duration expires, the cycle ends early. Lower values reduce memory usage on busy clusters.
-- **Cutoff Frequency:** Minimum number of times a key must be accessed during a monitoring cycle to be considered hot (default: 100). Keys accessed fewer times are filtered out. Lower values show more keys; higher values surface only the most active keys.
-
-This creates a repeating cycle: capture for *duration*, pause for *interval*, capture again. The hot keys displayed are from the most recent sampling run.
-
-![Monitoring](screenshots/monitoring.png)
-
-**Cluster behavior:**
-
-- **Web/Docker mode:** Monitoring starts on all primary nodes in the cluster simultaneously, regardless of which node you connected to. The reconcile loop ensures every primary has a metrics server, and the monitor command is sent to all of them.
-- **Desktop (Electron) mode:** Monitoring only starts on nodes you have explicitly connected to. If you connected to one node in a 20-shard cluster, only that node is monitored. Connect to additional nodes individually to monitor them.
-
-In both modes, hot keys are aggregated across all monitored nodes and sorted by access count.
-
-**Trade-offs:**
-- `MONITOR` has a performance impact on the server — it streams every command to the monitoring client
-- Best suited for short diagnostic sessions, not continuous monitoring
-
-When hot slots requirements are not met, Valkey Admin prompts you to start monitoring to calculate hot keys.
+1. A clear and concise title
+2. Detailed description of the problem or question
+3. Reproducible test case or step-by-step instructions
+4. Valkey Admin version in use
+5. Operating system details
+6. Valkey server version
+7. Cluster or standalone setup details (topology, shard/replica counts, data types in use)
+8. Any relevant modifications you've made
+9. Unusual aspects of your environment or deployment
+10. Log files
 
 ## Troubleshooting & Known Limitations
 
@@ -212,10 +55,13 @@ Before deploying, review the project's known limitations and operational caveats
 
 See [Troubleshooting & Known Limitations](https://valkey-admin.valkey.io/reference/troubleshooting/) for the full list and recommended workarounds.
 
-
 ## Contributing
 
-Interested in improving Valkey Admin? See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, architecture guidelines, and the contribution process.
+Interested in improving Valkey Admin? See [CONTRIBUTING.md](./CONTRIBUTING.md) for the RFC process, development setup, architectural guidelines, and the contribution workflow.
+
+## Community
+
+Join the conversation on the Valkey OSS Developer Slack: [Join Valkey Slack](https://join.slack.com/t/valkey-oss-developer/shared_invite/zt-2nxs51chx-EB9hu9Qdch3GMfRcztTSkQ).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ If you run into issues or have questions, open a [GitHub issue](https://github.c
 9. Unusual aspects of your environment or deployment
 10. Log files
 
-## Troubleshooting & Known Limitations
+## Known Limitations
 
-Before deploying, review the project's known limitations and operational caveats — including authentication, ACL/RBAC, replica monitoring, key-browser sampling, mTLS, and ElastiCache Serverless support.
+Before deploying, review the project's [Known Limitations](https://valkey-admin.valkey.io/reference/limitations/) covering authentication, ACL/RBAC, replica monitoring, key-browser sampling, mTLS, and ElastiCache Serverless support.
 
-See [Troubleshooting & Known Limitations](https://valkey-admin.valkey.io/reference/troubleshooting/) for the full list and recommended workarounds.
+## Troubleshooting
+
+For common issues and fixes, see the [Troubleshooting guide](https://valkey-admin.valkey.io/reference/troubleshooting/).
 
 ## Contributing
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,5 +1,4 @@
 # Troubleshooting
 
-Troubleshooting guides and known limitations now live on the docs site so we keep a single source of truth.
-
-See **[Troubleshooting & Known Limitations](https://valkey-admin.valkey.io/reference/troubleshooting/)** on the Valkey Admin docs site.
+- [Troubleshooting](https://valkey-admin.valkey.io/reference/troubleshooting/) — common issues and fixes.
+- [Known Limitations](https://valkey-admin.valkey.io/reference/limitations/) — capabilities and operational caveats.

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -44,6 +44,7 @@ export default defineConfig({
 						{ label: 'Docker', slug: 'deployment/docker' },
 						{ label: 'Kubernetes', slug: 'deployment/kubernetes' },
 						{ label: 'AWS ElastiCache', slug: 'deployment/aws-elasticache' },
+						{ label: 'Resource Sizing', slug: 'deployment/resource-sizing' },
 					],
 				},
 				{
@@ -74,6 +75,7 @@ export default defineConfig({
 					items: [
 						{ label: 'License', slug: 'reference/license' },
 						{ label: 'Troubleshooting', slug: 'reference/troubleshooting' },
+						{ label: 'Limitations', slug: 'reference/limitations' },
 						{ label: 'Security', slug: 'reference/security' },
 					],
 				},

--- a/docs-site/src/content/docs/configuration/metrics.md
+++ b/docs-site/src/content/docs/configuration/metrics.md
@@ -32,6 +32,34 @@ Each entry in `epics` is also merged with per-epic defaults of `data_retention_m
 
 After the YAML is parsed, a small set of environment variables is allowed to override specific fields — see "YAML Overrides" below. Everything else in the YAML stays as written.
 
+## Per-Epic Settings
+
+Each entry in the `epics` array describes one collector. The fields below apply to every epic; the `monitor` epic adds a few extras for sampling behavior.
+
+### Common fields
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `name` | Identifier used in logs and the orchestrator registry. | required |
+| `type` | Collector implementation. One of `memory_stats`, `info_cpu`, `commandlog_slow`, `commandlog_large_request`, `commandlog_large_reply`, `slowlog_len`, `monitor`. | required |
+| `poll_ms` | How often (ms) the collector runs. | varies per epic |
+| `file_prefix` | Filename prefix for the NDJSON output written under `DATA_DIR`. | required |
+| `data_retention_mb` | Max disk space (MB) this epic's NDJSON files may use. Oldest files are evicted when the budget is exceeded. | `10` |
+| `data_retention_days` | Files older than this (by birthtime) are deleted during the daily cleanup sweep. | `30` |
+
+The `Default` column shows the **fallback defaults applied by the YAML merge**. `apps/metrics/config.yml` overrides these with lower values per epic (3–15 MB, 5 days). See the file itself for the full per-epic configuration.
+
+### Monitor-only fields
+
+These apply only when `type: monitor` and control the `MONITOR`-based hot keys sampling cycle:
+
+| Field | Description | Default |
+|-------|-------------|---------------------------|
+| `monitoringDuration` | How long each sampling run captures commands (ms). | `10000` |
+| `monitoringInterval` | Pause between sampling runs (ms). | `10000` |
+| `maxCommandsPerRun` | Hard cap on commands captured per cycle. Cycle ends early when reached. | `1000000` |
+| `cutoffFrequency` | Minimum access count for a key to appear in results. | `100` |
+
 ## Connecting to Valkey
 
 Connection details come **only** from environment variables. The YAML never carries them, because in the default deployment the server injects them when it spawns a metrics child.

--- a/docs-site/src/content/docs/deployment/aws-elasticache.md
+++ b/docs-site/src/content/docs/deployment/aws-elasticache.md
@@ -80,7 +80,7 @@ Parameters:
   InstanceType:
     Type: String
     Default: t3.medium
-    Description: EC2 instance type (see Resource Sizing in Docker deployment docs)
+    Description: EC2 instance type (see Resource Sizing docs at https://valkey-admin.valkey.io/deployment/resource-sizing/)
   LatestAmiId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64

--- a/docs-site/src/content/docs/deployment/docker.md
+++ b/docs-site/src/content/docs/deployment/docker.md
@@ -85,27 +85,7 @@ See the [Metrics Configuration](/configuration/metrics/) page for available opti
 
 ## Resource Sizing
 
-In Docker (Web) mode, Valkey Admin spawns a metrics server process for each primary node in the cluster. Plan resources accordingly.
-
-**Formulas:**
-- **RAM:** `(primary nodes × 150 MB) + 1 GB`
-- **Disk:** `(primary nodes × 50 MB) + 1 GB`
-
-### Approximate Resource Recommendations
-
-| Cluster Size | Recommended Spec |
-|---|---|
-| 1–5 primaries | 2 vCPU, 2 GB RAM |
-| 5–50 primaries | 4 vCPU, 8 GB RAM |
-| 50–100 primaries | 8 vCPU, 16 GB RAM |
-| 100–200 primaries | 16 vCPU, 32 GB RAM |
-| 200–400+ primaries | 32 vCPU, 64 GB RAM |
-
-:::note
-These recommendations are based on default retention settings. If you increase `data_retention_mb` or `data_retention_days`, adjust your resource allocation accordingly.
-:::
-
-For large clusters, consider [Kubernetes deployment](/deployment/kubernetes/) where metrics servers run as sidecars on each Valkey pod, eliminating the memory burden on the main Valkey Admin instance.
+In Docker (Web) mode, Valkey Admin spawns a metrics server process per primary node. See [Resource Sizing](/deployment/resource-sizing/) for formulas, recommendations, and retention guidance.
 
 ## Configuration Reference
 

--- a/docs-site/src/content/docs/deployment/resource-sizing.md
+++ b/docs-site/src/content/docs/deployment/resource-sizing.md
@@ -1,0 +1,76 @@
+---
+title: Resource Sizing
+description: How to size Valkey Admin deployments across Web, Kubernetes, and Desktop modes.
+---
+
+Valkey Admin's resource footprint depends on **how** metrics collectors are spawned, which differs by deployment mode. This page walks through each mode so you can size the right host (or pod, or laptop).
+
+## Overview
+
+| Mode | Where metrics collectors run | Where sizing matters |
+|------|------------------------------|----------------------|
+| Web / Docker | Child processes of the main app | The Valkey Admin instance |
+| Kubernetes | Sidecar inside each Valkey pod | The Valkey pods (main app stays small) |
+| Desktop (Electron) | Child processes on the user's machine | The user's machine |
+
+The common factor: each primary node being monitored adds roughly **150 MB RAM** and **50 MB disk** for its metrics collector.
+
+## Web / Docker mode
+
+In Docker (Web) mode, Valkey Admin spawns a metrics server process for each primary node in the cluster. All collectors run on the same host as the main app, so plan resources for the entire cluster up front.
+
+**Formulas:**
+
+- **RAM:** `(primary nodes × 150 MB) + 1 GB`
+- **Disk:** `(primary nodes × 50 MB) + 1 GB`
+
+### Approximate recommendations
+
+| Cluster Size | Recommended Spec |
+|---|---|
+| 1–5 primaries | 2 vCPU, 2 GB RAM |
+| 5–50 primaries | 4 vCPU, 8 GB RAM |
+| 50–100 primaries | 8 vCPU, 16 GB RAM |
+| 100–200 primaries | 16 vCPU, 32 GB RAM |
+| 200–400+ primaries | 32 vCPU, 64 GB RAM |
+
+:::note
+These recommendations are based on default retention settings. If you increase `data_retention_mb` or `data_retention_days` for any epic, adjust your resource allocation accordingly. See [Per-Epic Settings](/configuration/metrics/#per-epic-settings) for tuning options.
+:::
+
+For large clusters, consider [Kubernetes deployment](/deployment/kubernetes/) where metrics collectors move out of the main process tree and onto the Valkey pods themselves.
+
+## Kubernetes
+
+Kubernetes flips the sizing story: instead of the main app spawning children, each Valkey pod runs its own metrics **sidecar**. The main `valkey-admin-app` deployment only orchestrates registrations and serves the UI, so it stays small regardless of cluster size.
+
+**Main `valkey-admin-app` deployment:**
+
+- ~1 GB RAM is enough for most clusters.
+- No per-node scaling — the deployment never spawns metrics children in K8s mode.
+
+**Per Valkey pod (with sidecar):**
+
+- Add ~150 MB RAM and ~50 MB disk to the pod's existing requests/limits for the metrics sidecar.
+- Sidecar shares the pod's lifecycle, so sizing folds into the StatefulSet's pod spec.
+
+See the [Kubernetes deployment guide](/deployment/kubernetes/) for the manifest layout and sidecar patch.
+
+## Desktop (Electron)
+
+The desktop app spawns a metrics child for each node you explicitly connect to. For large clusters, connecting to many nodes individually can blow up local RAM and disk usage on your laptop.
+
+**Rule of thumb:** apply the Web/Docker formulas to your local machine, but count only the nodes you have actively connected — not the full cluster size.
+
+For example, if you open desktop connections to 20 nodes in a 50-shard cluster:
+
+- **RAM:** `(20 × 150 MB) + 1 GB` ≈ 4 GB
+- **Disk:** `(20 × 50 MB) + 1 GB` ≈ 2 GB
+
+If your laptop can't host that comfortably, use the [Docker](/deployment/docker/) or [Kubernetes](/deployment/kubernetes/) deployment instead — both move the metrics workload off your machine.
+
+## Retention tuning
+
+Disk usage scales linearly with how long each epic keeps NDJSON files. The two relevant fields are `data_retention_mb` (per-epic disk budget) and `data_retention_days` (age-based cleanup). Both are documented under [Per-Epic Settings](/configuration/metrics/#per-epic-settings).
+
+The shipped `apps/metrics/config.yml` uses conservative defaults (3–15 MB per epic, 5 days). Raising either field on busy clusters shifts the disk recommendations above proportionally.

--- a/docs-site/src/content/docs/reference/limitations.md
+++ b/docs-site/src/content/docs/reference/limitations.md
@@ -1,0 +1,26 @@
+---
+title: Known Limitations
+description: Capabilities and behaviors Valkey Admin doesn't currently support.
+---
+
+This page lists the capabilities and operational caveats you should know about **before deploying** Valkey Admin. Items are grouped by category so you can scan to the area that matters for your environment.
+
+For runtime issues and fixes, see the [Troubleshooting guide](/reference/troubleshooting/).
+
+## Authentication & access control
+
+- **No built-in authentication.** Valkey Admin does not provide its own login layer. Web deployments rely on an external auth proxy — for example, AWS Cognito in front of an Application Load Balancer, or a reverse proxy such as nginx or oauth2-proxy.
+- **No RBAC within the app.** Any user who can reach the UI can run any command the connected Valkey ACL allows. Scope what the connecting Valkey user is permitted to do, not who can use the app.
+
+## TLS
+
+- **mTLS is not currently supported.** Standard TLS with password authentication or AWS ElastiCache IAM authentication is available.
+
+## Managed services
+
+- **ElastiCache Serverless is not supported.** Only ElastiCache node-based (non-serverless) clusters can be connected.
+
+## Architecture
+
+- **Metrics servers are per-primary only.** Each primary node gets its own metrics collector; replica nodes are not independently monitored.
+- **Key browser sample size.** The key browser scans up to approximately 1,000 keys across the cluster. Keys beyond this limit are not listed but can still be found using the search function, which performs a targeted lookup.

--- a/docs-site/src/content/docs/reference/troubleshooting.md
+++ b/docs-site/src/content/docs/reference/troubleshooting.md
@@ -7,7 +7,7 @@ description: Common issues and solutions for Valkey Admin
 
 In Web/Docker mode, Valkey Admin spawns a metrics server process for each primary node in the cluster. Each process uses approximately 150 MB of RAM. If your instance doesn't have enough memory, the app will OOM and become unresponsive.
 
-**Fix:** Refer to the [Resource Sizing](/deployment/docker/#resource-sizing) section and ensure your instance meets the recommended spec for your cluster size. Alternatively, deploy with [Kubernetes](/deployment/kubernetes/) where metrics servers run as sidecars on each Valkey pod, eliminating the memory burden on the main Valkey Admin instance.
+**Fix:** Refer to the [Resource Sizing](/deployment/resource-sizing/) page and ensure your instance meets the recommended spec for your cluster size. Alternatively, deploy with [Kubernetes](/deployment/kubernetes/) where metrics servers run as sidecars on each Valkey pod, eliminating the memory burden on the main Valkey Admin instance.
 
 ---
 
@@ -41,12 +41,10 @@ When connecting to an ElastiCache cluster configuration endpoint (`clustercfg.*`
 
 ---
 
-## Known Limitations
+## Key sampling numbers differ between views
 
-- **mTLS** is not currently supported. Standard TLS with password or IAM authentication is available.
-- **ElastiCache Serverless** is not supported. Only ElastiCache node-based (non-serverless) clusters are supported.
-- **Key sampling numbers** may differ between views. The key browser and distribution chart use separate sampling passes, so counts may not match exactly — this is expected behavior with sampled data.
-- **No RBAC within the app** — any connected user can run any command the Valkey ACL allows.
-- **No built-in authentication** — relies on external auth (Cognito, reverse proxy) for web deployments.
-- **Metrics servers are per-primary only** — replica nodes are not independently monitored.
-- **Key browser sample size:** The key browser scans up to approximately 1,000 keys across the cluster. Keys beyond this limit are not displayed but can still be found using the search function, which performs a targeted lookup.
+The key browser and the distribution chart use separate sampling passes, so their counts won't always match exactly. This is expected behavior with sampled data — each view samples independently and may pick up a slightly different cross-section of the keyspace.
+
+---
+
+For a list of capabilities and operational caveats that aren't bugs (no built-in auth, no RBAC, mTLS, ElastiCache Serverless, etc.), see [Known Limitations](/reference/limitations/).

--- a/examples/aws/aws-elasticache.md
+++ b/examples/aws/aws-elasticache.md
@@ -76,7 +76,7 @@ Parameters:
   InstanceType:
     Type: String
     Default: t3.medium
-    Description: EC2 instance type (see Resource Sizing in README)
+    Description: EC2 instance type (see Resource Sizing docs at https://valkey-admin.valkey.io/deployment/resource-sizing/)
   LatestAmiId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64


### PR DESCRIPTION
## Description

The doc site contains most information previously included in the README. Revise the Readme to pare down information while linking to the site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewritten, short README with single-docs pointer, streamlined Key Features, updated Getting Started and Releases (v1.0.1), and Community Slack invite
  * New Resource Sizing page with sizing formulas, retention guidance, and deployment recommendations
  * Added Limitations reference and expanded troubleshooting guidance (large-cluster guidance, key-sampling explanation)
  * Condensed Docker/AWS deployment docs and updated examples
  * Added Per‑Epic metrics configuration docs and improved bug-report checklist

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey-admin/pull/352)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->