### PR TITLE
feat: add key analysis page with big key and prefix memory features

### DIFF
--- a/apps/frontend/src/components/key-analysis/BigKeysTable.tsx
+++ b/apps/frontend/src/components/key-analysis/BigKeysTable.tsx
@@ -1,0 +1,198 @@
+import { useState, useMemo } from "react"
+import { BarChart3 } from "lucide-react"
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts"
+import { formatBytes } from "@common/src/bytes-conversion"
+import { convertTTL } from "@common/src/ttl-conversion"
+import { TableContainer } from "@/components/ui/table-container"
+import {
+  SortableTableHeader,
+  StaticTableHeader,
+  type SortOrder,
+} from "@/components/ui/sortable-table-header"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ChartModal } from "@/components/ui/chart-modal"
+import { Typography } from "@/components/ui/typography"
+import type { AnalyzedKeyInfo } from "@/state/valkey-features/key-analysis/keyAnalysisSlice"
+
+interface BigKeysTableProps {
+  keys: AnalyzedKeyInfo[]
+  loading: boolean
+}
+
+type SortField = "name" | "type" | "memoryUsage" | "collectionSize" | "ttl"
+
+export function BigKeysTable({ keys, loading }: BigKeysTableProps) {
+  const [sortField, setSortField] = useState<SortField>("memoryUsage")
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc")
+  const [chartOpen, setChartOpen] = useState(false)
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc")
+    } else {
+      setSortField(field)
+      setSortOrder("desc")
+    }
+  }
+
+  const sortedKeys = useMemo(() => {
+    const multiplier = sortOrder === "asc" ? 1 : -1
+    return [...keys].sort((a, b) => {
+      switch (sortField) {
+        case "name":
+          return multiplier * a.name.localeCompare(b.name)
+        case "type":
+          return multiplier * a.type.localeCompare(b.type)
+        case "memoryUsage":
+          return multiplier * (a.memoryUsage - b.memoryUsage)
+        case "collectionSize":
+          return multiplier * ((a.collectionSize ?? 0) - (b.collectionSize ?? 0))
+        case "ttl":
+          return multiplier * (a.ttl - b.ttl)
+        default:
+          return 0
+      }
+    })
+  }, [keys, sortField, sortOrder])
+
+  const chartData = useMemo(
+    () =>
+      keys.slice(0, 20).map((k) => ({
+        name: k.name.length > 20 ? k.name.slice(0, 20) + "..." : k.name,
+        fullName: k.name,
+        memory: k.memoryUsage,
+        type: k.type,
+      })),
+    [keys],
+  )
+
+  const header = (
+    <div className="flex items-center gap-4 w-full">
+      <SortableTableHeader
+        active={sortField === "name"}
+        label="Key Name"
+        onClick={() => handleSort("name")}
+        sortOrder={sortOrder}
+        width="flex-1 min-w-0"
+      />
+      <SortableTableHeader
+        active={sortField === "type"}
+        label="Type"
+        onClick={() => handleSort("type")}
+        sortOrder={sortOrder}
+        width="w-20"
+      />
+      <SortableTableHeader
+        active={sortField === "memoryUsage"}
+        label="Memory"
+        onClick={() => handleSort("memoryUsage")}
+        sortOrder={sortOrder}
+        width="w-28"
+      />
+      <SortableTableHeader
+        active={sortField === "collectionSize"}
+        label="Size"
+        onClick={() => handleSort("collectionSize")}
+        sortOrder={sortOrder}
+        width="w-20"
+      />
+      <SortableTableHeader
+        active={sortField === "ttl"}
+        label="TTL"
+        onClick={() => handleSort("ttl")}
+        sortOrder={sortOrder}
+        width="w-24"
+      />
+      <StaticTableHeader label="" width="w-10" />
+    </div>
+  )
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex justify-between items-center mb-2">
+        <Typography variant="bodySm" className="text-gray-500">
+          {keys.length} keys sorted by memory usage
+        </Typography>
+        <Button
+          disabled={keys.length === 0}
+          onClick={() => setChartOpen(true)}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          <BarChart3 size={16} className="mr-1" />
+          Chart
+        </Button>
+      </div>
+
+      <TableContainer header={header}>
+        {sortedKeys.map((key) => (
+          <tr
+            className="border-b dark:border-tw-dark-border hover:bg-primary/10"
+            key={key.name}
+          >
+            <td className="px-4 py-2 truncate max-w-0">
+              <Typography variant="bodySm" className="truncate">
+                {key.name}
+              </Typography>
+            </td>
+            <td className="px-4 py-2 w-20">
+              <Badge variant="secondary">{key.type}</Badge>
+            </td>
+            <td className="px-4 py-2 w-28">
+              <Typography variant="bodySm">{formatBytes(key.memoryUsage)}</Typography>
+            </td>
+            <td className="px-4 py-2 w-20">
+              <Typography variant="bodySm">
+                {key.collectionSize !== null ? key.collectionSize.toLocaleString() : "-"}
+              </Typography>
+            </td>
+            <td className="px-4 py-2 w-24">
+              <Typography variant="bodySm">{convertTTL(key.ttl)}</Typography>
+            </td>
+            <td className="px-4 py-2 w-10" />
+          </tr>
+        ))}
+      </TableContainer>
+
+      <ChartModal
+        onClose={() => setChartOpen(false)}
+        open={chartOpen}
+        subtitle="Memory usage of the top 20 keys"
+        title="Top Big Keys"
+      >
+        <ResponsiveContainer height={400} width="100%">
+          <BarChart data={chartData} layout="vertical">
+            <CartesianGrid horizontal={false} strokeDasharray="3 3" />
+            <XAxis
+              tickFormatter={(v: number) => formatBytes(v)}
+              type="number"
+            />
+            <YAxis
+              dataKey="name"
+              tick={{ fontSize: 11 }}
+              type="category"
+              width={140}
+            />
+            <Tooltip
+              formatter={(value: number) => [formatBytes(value), "Memory"]}
+              labelFormatter={(_label: string, payload: Array<{ payload?: { fullName?: string } }>) =>
+                payload?.[0]?.payload?.fullName ?? _label
+              }
+            />
+            <Bar dataKey="memory" fill="var(--chart-1)" radius={[0, 4, 4, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartModal>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/key-analysis/KeyAnalysis.tsx
+++ b/apps/frontend/src/components/key-analysis/KeyAnalysis.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react"
+import { useSelector, useDispatch } from "react-redux"
+import { useParams } from "react-router"
+import { BarChart3, Database, Hash, HardDrive, RefreshCw } from "lucide-react"
+import { formatBytes } from "@common/src/bytes-conversion"
+import RouteContainer from "@/components/ui/route-container"
+import { AppHeader } from "@/components/ui/app-header"
+import { StatCard } from "@/components/ui/stat-card"
+import { TabGroup } from "@/components/ui/tab-group"
+import { LoadingState } from "@/components/ui/loading-state"
+import { EmptyState } from "@/components/ui/empty-state"
+import { Button } from "@/components/ui/button"
+import {
+  analysisRequested,
+  selectAnalysisStatus,
+  selectAnalysisKeys,
+  selectAnalysisTotalKeys,
+  selectAnalysisScannedKeys,
+  selectAnalysisTotalMemory,
+  selectAnalysisProgress,
+  selectAnalysisError,
+} from "@/state/valkey-features/key-analysis/keyAnalysisSlice"
+import { BigKeysTable } from "./BigKeysTable"
+import { PrefixMemoryTable } from "./PrefixMemoryTable"
+import type { AppDispatch } from "@/store.ts"
+
+type TabId = "big-keys" | "prefix-memory"
+
+export function KeyAnalysis() {
+  const { id, clusterId } = useParams<{ id: string; clusterId: string }>()
+  const connectionId = clusterId ?? id ?? ""
+  const dispatch = useDispatch<AppDispatch>()
+
+  const status = useSelector(selectAnalysisStatus(connectionId))
+  const keys = useSelector(selectAnalysisKeys(connectionId))
+  const totalKeys = useSelector(selectAnalysisTotalKeys(connectionId))
+  const scannedKeys = useSelector(selectAnalysisScannedKeys(connectionId))
+  const totalMemory = useSelector(selectAnalysisTotalMemory(connectionId))
+  const progress = useSelector(selectAnalysisProgress(connectionId))
+  const error = useSelector(selectAnalysisError(connectionId))
+
+  const [activeTab, setActiveTab] = useState<TabId>("big-keys")
+
+  useEffect(() => {
+    if (id) {
+      dispatch(analysisRequested({ connectionId }))
+    }
+  }, [id, connectionId, dispatch])
+
+  const handleRefresh = () => {
+    if (id) {
+      dispatch(analysisRequested({ connectionId }))
+    }
+  }
+
+  const isLoading = status === "Pending"
+  const largestKey = keys.length > 0 ? keys[0] : null
+
+  const progressPercent =
+    progress.totalEstimated > 0
+      ? Math.round((progress.scannedCount / progress.totalEstimated) * 100)
+      : 0
+
+  return (
+    <RouteContainer>
+      <AppHeader
+        description="Analyze key memory usage and identify large keys"
+        icon={<BarChart3 size={24} />}
+        title="Key Analysis"
+      />
+
+      {/* Stat Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard
+          icon={<Database size={16} />}
+          label="Total Keys"
+          value={totalKeys.toLocaleString()}
+        />
+        <StatCard
+          icon={<Hash size={16} />}
+          label="Scanned"
+          value={scannedKeys.toLocaleString()}
+        />
+        <StatCard
+          icon={<HardDrive size={16} />}
+          label="Total Memory"
+          value={formatBytes(totalMemory)}
+        />
+        <StatCard
+          icon={<BarChart3 size={16} />}
+          label="Largest Key"
+          value={largestKey ? formatBytes(largestKey.memoryUsage) : "-"}
+        />
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center justify-between">
+        <TabGroup
+          activeTab={activeTab}
+          onChange={setActiveTab}
+          tabs={[
+            { id: "big-keys" as TabId, label: "Big Keys" },
+            { id: "prefix-memory" as TabId, label: "Prefix Memory" },
+          ]}
+        />
+        <Button
+          className="flex items-center gap-1"
+          disabled={isLoading}
+          onClick={handleRefresh}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          <RefreshCw
+            className={isLoading ? "animate-spin" : ""}
+            size={16}
+          />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Content */}
+      {isLoading && (
+        <div className="flex-1 flex flex-col items-center justify-center gap-4">
+          <LoadingState message={`Analyzing keys... ${progressPercent}% (${progress.phase})`} />
+          <div className="w-64 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+            <div
+              className="bg-primary h-2 rounded-full transition-all duration-300"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+          <p className="text-xs text-gray-500">
+            {progress.scannedCount.toLocaleString()} / {progress.totalEstimated.toLocaleString()} keys ({progress.phase})
+          </p>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-red-500">Error: {error}</p>
+        </div>
+      )}
+
+      {!isLoading && !error && keys.length === 0 && status !== "Idle" && (
+        <EmptyState
+          description="No keys found in the database"
+          icon={<Database size={48} />}
+          title="No Keys Found"
+        />
+      )}
+
+      {!isLoading && !error && keys.length > 0 && (
+        <div className="flex-1 min-h-0">
+          {activeTab === "big-keys" && (
+            <BigKeysTable keys={keys} loading={isLoading} />
+          )}
+          {activeTab === "prefix-memory" && (
+            <PrefixMemoryTable keys={keys} totalMemory={totalMemory} />
+          )}
+        </div>
+      )}
+    </RouteContainer>
+  )
+}

--- a/apps/frontend/src/components/key-analysis/PrefixMemoryTable.tsx
+++ b/apps/frontend/src/components/key-analysis/PrefixMemoryTable.tsx
@@ -1,0 +1,239 @@
+import { useState, useMemo } from "react"
+import { PieChart as RechartsPieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts"
+import { formatBytes } from "@common/src/bytes-conversion"
+import { TableContainer } from "@/components/ui/table-container"
+import {
+  SortableTableHeader,
+  type SortOrder,
+} from "@/components/ui/sortable-table-header"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ChartModal } from "@/components/ui/chart-modal"
+import { Typography } from "@/components/ui/typography"
+import type { AnalyzedKeyInfo } from "@/state/valkey-features/key-analysis/keyAnalysisSlice"
+
+interface PrefixAggregation {
+  prefix: string
+  totalMemory: number
+  keyCount: number
+  percentageOfTotal: number
+  typeBreakdown: Record<string, number>
+}
+
+interface PrefixMemoryTableProps {
+  keys: AnalyzedKeyInfo[]
+  totalMemory: number
+}
+
+type SortField = "prefix" | "totalMemory" | "keyCount" | "percentageOfTotal"
+
+const CHART_COLORS = [
+  "var(--chart-1)", "var(--chart-2)", "var(--chart-3)",
+  "var(--chart-4)", "var(--chart-5)", "var(--chart-6)", "var(--chart-7)",
+]
+
+function groupByPrefix(keys: AnalyzedKeyInfo[], segmentCount: number): PrefixAggregation[] {
+  const groups: Record<string, PrefixAggregation> = {}
+
+  for (const key of keys) {
+    const delimiter = key.name.includes(":") ? ":" : key.name.includes(".") ? "." : ":"
+    const segments = key.name.split(delimiter)
+    const prefix = segments.slice(0, Math.min(segmentCount, segments.length)).join(delimiter)
+
+    if (!groups[prefix]) {
+      groups[prefix] = { prefix, totalMemory: 0, keyCount: 0, percentageOfTotal: 0, typeBreakdown: {} }
+    }
+    groups[prefix].totalMemory += key.memoryUsage
+    groups[prefix].keyCount += 1
+    groups[prefix].typeBreakdown[key.type] = (groups[prefix].typeBreakdown[key.type] || 0) + 1
+  }
+
+  const grandTotal = Object.values(groups).reduce((sum, g) => sum + g.totalMemory, 0)
+  for (const g of Object.values(groups)) {
+    g.percentageOfTotal = grandTotal > 0 ? (g.totalMemory / grandTotal) * 100 : 0
+  }
+
+  return Object.values(groups).sort((a, b) => b.totalMemory - a.totalMemory)
+}
+
+export function PrefixMemoryTable({ keys, totalMemory }: PrefixMemoryTableProps) {
+  const [sortField, setSortField] = useState<SortField>("totalMemory")
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc")
+  const [segmentDepth, setSegmentDepth] = useState(1)
+  const [chartOpen, setChartOpen] = useState(false)
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc")
+    } else {
+      setSortField(field)
+      setSortOrder("desc")
+    }
+  }
+
+  const aggregated = useMemo(
+    () => groupByPrefix(keys, segmentDepth),
+    [keys, segmentDepth],
+  )
+
+  const sorted = useMemo(() => {
+    const multiplier = sortOrder === "asc" ? 1 : -1
+    return [...aggregated].sort((a, b) => {
+      switch (sortField) {
+        case "prefix":
+          return multiplier * a.prefix.localeCompare(b.prefix)
+        case "totalMemory":
+          return multiplier * (a.totalMemory - b.totalMemory)
+        case "keyCount":
+          return multiplier * (a.keyCount - b.keyCount)
+        case "percentageOfTotal":
+          return multiplier * (a.percentageOfTotal - b.percentageOfTotal)
+        default:
+          return 0
+      }
+    })
+  }, [aggregated, sortField, sortOrder])
+
+  const chartData = useMemo(
+    () => aggregated.slice(0, 15).map((g) => ({
+      name: g.prefix,
+      value: g.totalMemory,
+    })),
+    [aggregated],
+  )
+
+  const header = (
+    <div className="flex items-center gap-4 w-full">
+      <SortableTableHeader
+        active={sortField === "prefix"}
+        label="Prefix"
+        onClick={() => handleSort("prefix")}
+        sortOrder={sortOrder}
+        width="flex-1 min-w-0"
+      />
+      <SortableTableHeader
+        active={sortField === "totalMemory"}
+        label="Total Memory"
+        onClick={() => handleSort("totalMemory")}
+        sortOrder={sortOrder}
+        width="w-28"
+      />
+      <SortableTableHeader
+        active={sortField === "keyCount"}
+        label="Keys"
+        onClick={() => handleSort("keyCount")}
+        sortOrder={sortOrder}
+        width="w-20"
+      />
+      <SortableTableHeader
+        active={sortField === "percentageOfTotal"}
+        label="% Total"
+        onClick={() => handleSort("percentageOfTotal")}
+        sortOrder={sortOrder}
+        width="w-20"
+      />
+      <div className="w-40 text-xs font-bold">Types</div>
+    </div>
+  )
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex justify-between items-center mb-2">
+        <Typography variant="bodySm" className="text-gray-500">
+          {aggregated.length} prefixes found
+        </Typography>
+        <div className="flex items-center gap-2">
+          <Typography variant="bodySm" className="text-gray-500">
+            Depth:
+          </Typography>
+          {[1, 2, 3].map((d) => (
+            <Button
+              key={d}
+              onClick={() => setSegmentDepth(d)}
+              size="sm"
+              type="button"
+              variant={segmentDepth === d ? "default" : "outline"}
+            >
+              {d}
+            </Button>
+          ))}
+          <Button
+            disabled={aggregated.length === 0}
+            onClick={() => setChartOpen(true)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Chart
+          </Button>
+        </div>
+      </div>
+
+      <TableContainer header={header}>
+        {sorted.map((group) => (
+          <tr
+            className="border-b dark:border-tw-dark-border hover:bg-primary/10"
+            key={group.prefix}
+          >
+            <td className="px-4 py-2 truncate max-w-0">
+              <Typography variant="bodySm" className="truncate font-medium">
+                {group.prefix}
+              </Typography>
+            </td>
+            <td className="px-4 py-2 w-28">
+              <Typography variant="bodySm">{formatBytes(group.totalMemory)}</Typography>
+            </td>
+            <td className="px-4 py-2 w-20">
+              <Typography variant="bodySm">{group.keyCount.toLocaleString()}</Typography>
+            </td>
+            <td className="px-4 py-2 w-20">
+              <Typography variant="bodySm">{group.percentageOfTotal.toFixed(1)}%</Typography>
+            </td>
+            <td className="px-4 py-2 w-40">
+              <div className="flex flex-wrap gap-1">
+                {Object.entries(group.typeBreakdown).map(([type, count]) => (
+                  <Badge key={type} variant="secondary">
+                    {type}: {count}
+                  </Badge>
+                ))}
+              </div>
+            </td>
+          </tr>
+        ))}
+      </TableContainer>
+
+      <ChartModal
+        onClose={() => setChartOpen(false)}
+        open={chartOpen}
+        subtitle="Memory distribution by key prefix"
+        title="Prefix Memory Distribution"
+      >
+        <ResponsiveContainer height={400} width="100%">
+          <RechartsPieChart>
+            <Pie
+              data={chartData}
+              dataKey="value"
+              innerRadius={100}
+              label={({ name, percent }: { name: string; percent: number }) =>
+                `${name} (${(percent * 100).toFixed(0)}%)`
+              }
+              nameKey="name"
+              outerRadius={140}
+              paddingAngle={2}
+            >
+              {chartData.map((_entry, index) => (
+                <Cell
+                  fill={CHART_COLORS[index % CHART_COLORS.length]}
+                  key={`cell-${index}`}
+                />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(value: number) => [formatBytes(value), "Memory"]}
+            />
+          </RechartsPieChart>
+        </ResponsiveContainer>
+      </ChartModal>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/ui/app-sidebar.tsx
+++ b/apps/frontend/src/components/ui/app-sidebar.tsx
@@ -9,7 +9,8 @@ import {
   Github,
   KeyRound,
   Network,
-  Activity
+  Activity,
+  BarChart3
 } from "lucide-react"
 import { Link, useLocation, useParams } from "react-router"
 import { useState } from "react"
@@ -72,6 +73,11 @@ export function AppSidebar() {
                     to: (clusterId ? `/${clusterId}/${id}/activity` : `/${id}/activity`),
                     title: "Activity",
                     icon: Activity,
+                  },
+                  {
+                    to: (clusterId ? `/${clusterId}/${id}/key-analysis` : `/${id}/key-analysis`),
+                    title: "Key Analysis",
+                    icon: BarChart3,
                   },
                   { to: (clusterId ? `/${clusterId}/${id}/sendcommand` : `/${id}/sendcommand`), 
                     title: "Send Command", 

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -15,6 +15,7 @@ import { WebSocketReconnect } from "./components/WebSocketReconnect.tsx"
 import { ValkeyReconnect } from "./components/ValkeyReconnect.tsx"
 import { SendCommand } from "@/components/send-command/SendCommand.tsx"
 import { ActivityView } from "@/components/activity-view/ActivityView.tsx"
+import { KeyAnalysis } from "@/components/key-analysis/KeyAnalysis.tsx"
 import { Connection } from "@/components/connection/Connection.tsx"
 import "./css/index.css"
 
@@ -48,6 +49,7 @@ const AppWithHistory = () => {
           <Route element={<KeyBrowser />} path="/:clusterId/:id/browse" />
           <Route element={<Cluster />} path="/:clusterId/:id/cluster-topology" />
           <Route element={<ActivityView />} path="/:clusterId/:id/activity" />
+          <Route element={<KeyAnalysis />} path="/:clusterId/:id/key-analysis" />
           <Route element={<Settings />} path="/:clusterId/:id/settings" />
         </Route>
 
@@ -58,6 +60,7 @@ const AppWithHistory = () => {
           <Route element={<SendCommand />} path="/:id/sendcommand" />
           <Route element={<KeyBrowser />} path="/:id/browse" />
           <Route element={<ActivityView />} path="/:id/activity" />
+          <Route element={<KeyAnalysis />} path="/:id/key-analysis" />
           <Route element={<Settings />} path="/:id/settings" />
           <Route element={<LearnMore />} path="/:id/learnmore" />
         </Route>

--- a/apps/frontend/src/state/epics/keyAnalysisEpic.ts
+++ b/apps/frontend/src/state/epics/keyAnalysisEpic.ts
@@ -1,0 +1,17 @@
+import { tap } from "rxjs/operators"
+import { getSocket } from "./wsEpics"
+import { analysisRequested } from "../valkey-features/key-analysis/keyAnalysisSlice"
+import { action$, select } from "../middleware/rxjsMiddleware/rxjsMiddleware"
+
+export const keyAnalysisEpic = () =>
+  action$.pipe(
+    select(analysisRequested),
+    tap((action) => {
+      const socket = getSocket()
+      const { connectionId, limit, sampleCount } = action.payload
+      socket.next({
+        type: action.type,
+        payload: { connectionId, limit, sampleCount },
+      })
+    }),
+  )

--- a/apps/frontend/src/state/epics/rootEpic.ts
+++ b/apps/frontend/src/state/epics/rootEpic.ts
@@ -17,6 +17,7 @@ import {
   saveMonitorSettingsEpic
 } from "./valkeyEpics"
 import { keyBrowserEpic } from "./keyBrowserEpic"
+import { keyAnalysisEpic } from "./keyAnalysisEpic"
 import type { Store } from "@reduxjs/toolkit"
 
 export const registerEpics = (store: Store) => {
@@ -37,6 +38,7 @@ export const registerEpics = (store: Store) => {
     getMemoryUsageEpic(),
     monitorEpic(),
     saveMonitorSettingsEpic(),
+    keyAnalysisEpic(),
   ).subscribe({
     error: (err) => console.error("Epic error:", err),
   })

--- a/apps/frontend/src/state/valkey-features/key-analysis/keyAnalysisSlice.ts
+++ b/apps/frontend/src/state/valkey-features/key-analysis/keyAnalysisSlice.ts
@@ -1,0 +1,109 @@
+import { createSlice } from "@reduxjs/toolkit"
+import { ERROR, FULFILLED, PENDING, VALKEY } from "@common/src/constants.ts"
+import * as R from "ramda"
+import type { RootState } from "@/store.ts"
+
+export interface AnalyzedKeyInfo {
+  name: string
+  type: string
+  memoryUsage: number
+  collectionSize: number | null
+  ttl: number
+}
+
+type AnalysisStatus = "Idle" | typeof PENDING | typeof FULFILLED | typeof ERROR
+
+interface AnalysisProgress {
+  scannedCount: number
+  totalEstimated: number
+  phase: "idle" | "scanning" | "enriching"
+}
+
+interface AnalysisState {
+  [connectionId: string]: {
+    status: AnalysisStatus
+    keys: AnalyzedKeyInfo[]
+    totalKeys: number
+    scannedKeys: number
+    totalMemoryScanned: number
+    progress: AnalysisProgress
+    error: string | null
+  }
+}
+
+const initialState: AnalysisState = {}
+
+const keyAnalysisSlice = createSlice({
+  name: VALKEY.KEY_ANALYSIS.name,
+  initialState,
+  reducers: {
+    analysisRequested: (state, action) => {
+      const { connectionId } = action.payload
+      const id = connectionId
+      state[id] = {
+        status: PENDING,
+        keys: [],
+        totalKeys: 0,
+        scannedKeys: 0,
+        totalMemoryScanned: 0,
+        progress: { scannedCount: 0, totalEstimated: 0, phase: "idle" },
+        error: null,
+      }
+    },
+    analysisProgress: (state, action) => {
+      const { connectionId, scannedCount, totalEstimated, phase } = action.payload
+      if (state[connectionId]) {
+        state[connectionId].progress = { scannedCount, totalEstimated, phase }
+      }
+    },
+    analysisFulfilled: (state, action) => {
+      const { connectionId, keys, totalKeys, scannedKeys, totalMemoryScanned } = action.payload
+      state[connectionId] = {
+        status: FULFILLED,
+        keys,
+        totalKeys,
+        scannedKeys,
+        totalMemoryScanned,
+        progress: { scannedCount: scannedKeys, totalEstimated: totalKeys, phase: "idle" },
+        error: null,
+      }
+    },
+    analysisError: (state, action) => {
+      const { connectionId, error } = action.payload
+      if (state[connectionId]) {
+        state[connectionId].status = ERROR
+        state[connectionId].error = error
+      }
+    },
+  },
+})
+
+export default keyAnalysisSlice.reducer
+
+export const {
+  analysisRequested,
+  analysisProgress,
+  analysisFulfilled,
+  analysisError,
+} = keyAnalysisSlice.actions
+
+export const selectAnalysisStatus = (id: string) => (state: RootState) =>
+  R.path([VALKEY.KEY_ANALYSIS.name, id, "status"], state) ?? "Idle"
+
+export const selectAnalysisKeys = (id: string) => (state: RootState) =>
+  R.path<AnalyzedKeyInfo[]>([VALKEY.KEY_ANALYSIS.name, id, "keys"], state) ?? []
+
+export const selectAnalysisTotalKeys = (id: string) => (state: RootState) =>
+  R.path<number>([VALKEY.KEY_ANALYSIS.name, id, "totalKeys"], state) ?? 0
+
+export const selectAnalysisScannedKeys = (id: string) => (state: RootState) =>
+  R.path<number>([VALKEY.KEY_ANALYSIS.name, id, "scannedKeys"], state) ?? 0
+
+export const selectAnalysisTotalMemory = (id: string) => (state: RootState) =>
+  R.path<number>([VALKEY.KEY_ANALYSIS.name, id, "totalMemoryScanned"], state) ?? 0
+
+export const selectAnalysisProgress = (id: string) => (state: RootState) =>
+  R.path<AnalysisProgress>([VALKEY.KEY_ANALYSIS.name, id, "progress"], state) ?? { scannedCount: 0, totalEstimated: 0, phase: "idle" as const }
+
+export const selectAnalysisError = (id: string) => (state: RootState) =>
+  R.path<string>([VALKEY.KEY_ANALYSIS.name, id, "error"], state) ?? null

--- a/apps/frontend/src/store.ts
+++ b/apps/frontend/src/store.ts
@@ -15,6 +15,7 @@ import cpuReducer from "@/state/valkey-features/cpu/cpuSlice.ts"
 import memoryReducer from "@/state/valkey-features/memory/memorySlice.ts"
 import monitorReducer from "@/state/valkey-features/monitor/monitorSlice.ts"
 import topologyReducer from "@/state/valkey-features/topology/topologySlice.ts"
+import keyAnalysisReducer from "@/state/valkey-features/key-analysis/keyAnalysisSlice.ts"
 
 export const store = configureStore({
   reducer: {
@@ -31,6 +32,7 @@ export const store = configureStore({
     [VALKEY.MEMORY.name]: memoryReducer,
     [VALKEY.MONITOR.name]: monitorReducer,
     [VALKEY.TOPOLOGY.name]: topologyReducer,
+    [VALKEY.KEY_ANALYSIS.name]: keyAnalysisReducer,
   },
   middleware: (getDefaultMiddleware) => {
     return getDefaultMiddleware({

--- a/apps/server/src/actions/key-analysis.ts
+++ b/apps/server/src/actions/key-analysis.ts
@@ -1,0 +1,23 @@
+import { WebSocket } from "ws"
+import { VALKEY } from "valkey-common"
+import { analyzeKeys } from "../key-analysis"
+import { type Deps, withDeps } from "./utils"
+
+export const analysisRequested = withDeps<Deps, void>(
+  async ({ ws, clients, connectionId, action }) => {
+    const connection = clients.get(connectionId)
+    if (connection) {
+      await analyzeKeys(connection.client, ws, action.payload)
+    } else {
+      ws.send(
+        JSON.stringify({
+          type: VALKEY.KEY_ANALYSIS.analysisError,
+          payload: {
+            connectionId,
+            error: "Invalid connection Id",
+          },
+        }),
+      )
+    }
+  },
+)

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -23,6 +23,7 @@ import { updateConfig, enableClusterSlotStats } from "./actions/config"
 import { cpuUsageRequested } from "./actions/cpuUsage"
 import { memoryUsageRequested } from "./actions/memoryUsage"
 import { monitorRequested, saveMonitorSettingsRequested } from "./actions/monitorAction"
+import { analysisRequested } from "./actions/key-analysis"
 import { unsubscribeAll, getWatcherCount } from "./node-watchers"
 import { teardownConnection } from "./connection"
 import { Handler, ReduxAction, unknownHandler, type WsActionMessage } from "./actions/utils"
@@ -203,6 +204,7 @@ wss.on("connection", (ws: AliveWebSocket) => {
     [VALKEY.MEMORY.memoryUsageRequested]: memoryUsageRequested,
     [VALKEY.MONITOR.monitorRequested]: monitorRequested,
     [VALKEY.MONITOR.saveMonitorSettingsRequested]: saveMonitorSettingsRequested,
+    [VALKEY.KEY_ANALYSIS.analysisRequested]: analysisRequested,
   }
 
   process.on("message", (message: MetricsServerMessage) => {

--- a/apps/server/src/key-analysis.ts
+++ b/apps/server/src/key-analysis.ts
@@ -1,0 +1,222 @@
+import { WebSocket } from "ws"
+import {
+  GlideClient,
+  GlideClusterClient,
+  ConnectionError,
+  TimeoutError,
+  ClosingError,
+  RouteOption,
+} from "@valkey/valkey-glide"
+import pLimit from "p-limit"
+import { VALKEY } from "valkey-common"
+import { buildScanCommandArgs } from "./valkey-client-commands"
+
+interface AnalyzedKeyInfo {
+  name: string
+  type: string
+  memoryUsage: number
+  collectionSize: number | null
+  ttl: number
+}
+
+type ClusterScanResult = {
+  key: string
+  value: [string, string[]]
+}
+
+const COLLECTION_SIZE_COMMANDS: Record<string, string> = {
+  hash: "HLEN",
+  list: "LLEN",
+  set: "SCARD",
+  zset: "ZCARD",
+  stream: "XLEN",
+}
+
+async function analyzeKey(
+  client: GlideClient | GlideClusterClient,
+  key: string,
+): Promise<AnalyzedKeyInfo> {
+  try {
+    const [keyType, memoryUsage, ttl] = await Promise.all([
+      client.customCommand(["TYPE", key]) as Promise<string>,
+      client.customCommand(["MEMORY", "USAGE", key]).catch(() => null) as Promise<number | null>,
+      client.customCommand(["TTL", key]).catch(() => -1) as Promise<number>,
+    ])
+
+    const type = keyType.toLowerCase()
+    const sizeCmd = COLLECTION_SIZE_COMMANDS[type]
+    let collectionSize: number | null = null
+
+    if (sizeCmd) {
+      collectionSize = await (client.customCommand([sizeCmd, key]).catch(() => null)) as number | null
+    }
+
+    return {
+      name: key,
+      type: keyType,
+      memoryUsage: memoryUsage || 0,
+      collectionSize,
+      ttl,
+    }
+  } catch {
+    return { name: key, type: "unknown", memoryUsage: 0, collectionSize: null, ttl: -1 }
+  }
+}
+
+async function scanStandaloneForAnalysis(
+  client: GlideClient,
+  limit: number,
+  count: number,
+): Promise<Set<string>> {
+  const allKeys = new Set<string>()
+  let cursor = "0"
+
+  do {
+    const scanResult = (await client.customCommand(
+      buildScanCommandArgs({ cursor, count }),
+    )) as [string, string[]]
+    const [newCursor, keys] = scanResult
+    cursor = newCursor
+    keys.forEach((key) => {
+      if (allKeys.size < limit) allKeys.add(key)
+    })
+  } while (allKeys.size < limit && cursor !== "0")
+
+  return allKeys
+}
+
+async function scanClusterForAnalysis(
+  client: GlideClusterClient,
+  limit: number,
+  count: number,
+): Promise<Set<string>> {
+  const routeOption: RouteOption = { route: "allPrimaries" }
+  const allKeys = new Set<string>()
+
+  const scanClusterResult = await client.customCommand(
+    buildScanCommandArgs({ cursor: "0", count }),
+    routeOption,
+  ) as ClusterScanResult[]
+
+  await Promise.all(
+    scanClusterResult.map(async ({ key: nodeAddress, value }) => {
+      let cursor = value[0]
+      const keys = value[1]
+
+      keys.forEach((k) => {
+        if (allKeys.size < limit) allKeys.add(k)
+      })
+
+      const [host, portStr] = nodeAddress.split(/:(?=[^:]+$)/)
+      const nodeRouteOption: RouteOption = {
+        route: { type: "routeByAddress", host, port: Number(portStr) },
+      }
+
+      while (cursor !== "0" && allKeys.size < limit) {
+        const [nextCursor, newKeys] = await client.customCommand(
+          buildScanCommandArgs({ cursor, count }),
+          nodeRouteOption,
+        ) as [string, string[]]
+
+        cursor = nextCursor
+        newKeys.forEach((k) => {
+          if (allKeys.size < limit) allKeys.add(k)
+        })
+      }
+    }),
+  )
+
+  return allKeys
+}
+
+const concurrencyLimit = pLimit(20)
+
+export async function analyzeKeys(
+  client: GlideClient | GlideClusterClient,
+  ws: WebSocket,
+  payload: {
+    connectionId: string
+    limit?: number
+    sampleCount?: number
+  },
+) {
+  const { connectionId } = payload
+  const scanLimit = payload.limit ?? 10000
+  const sampleCount = payload.sampleCount ?? 200
+
+  const sendProgress = (scannedCount: number, totalEstimated: number, phase: "scanning" | "enriching") => {
+    ws.send(JSON.stringify({
+      type: VALKEY.KEY_ANALYSIS.analysisProgress,
+      payload: { connectionId, scannedCount, totalEstimated, phase },
+    }))
+  }
+
+  const sendError = (err: unknown) => {
+    ws.send(JSON.stringify({
+      type: VALKEY.KEY_ANALYSIS.analysisError,
+      payload: {
+        connectionId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    }))
+  }
+
+  try {
+    const totalKeys = (await client.customCommand(["DBSIZE"])) as number
+
+    sendProgress(0, totalKeys, "scanning")
+
+    const allKeys = client instanceof GlideClusterClient
+      ? await scanClusterForAnalysis(client, scanLimit, sampleCount)
+      : await scanStandaloneForAnalysis(client, scanLimit, sampleCount)
+
+    sendProgress(allKeys.size, totalKeys, "enriching")
+
+    const keysArray = [...allKeys]
+    let enrichedCount = 0
+
+    const analyzedKeys = await Promise.all(
+      keysArray.map((key) =>
+        concurrencyLimit(async () => {
+          const result = await analyzeKey(client, key)
+          enrichedCount++
+          if (enrichedCount % 500 === 0) {
+            sendProgress(enrichedCount, keysArray.length, "enriching")
+          }
+          return result
+        }),
+      ),
+    )
+
+    analyzedKeys.sort((a, b) => b.memoryUsage - a.memoryUsage)
+
+    const totalMemoryScanned = analyzedKeys.reduce((sum, k) => sum + k.memoryUsage, 0)
+
+    ws.send(JSON.stringify({
+      type: VALKEY.KEY_ANALYSIS.analysisFulfilled,
+      payload: {
+        connectionId,
+        keys: analyzedKeys,
+        totalKeys,
+        scannedKeys: analyzedKeys.length,
+        totalMemoryScanned,
+      },
+    }))
+  } catch (err) {
+    console.error(`Key analysis error for ${connectionId}:`, err)
+    sendError(err)
+
+    if (
+      err instanceof ConnectionError || err instanceof TimeoutError || err instanceof ClosingError
+    ) {
+      ws.send(JSON.stringify({
+        type: VALKEY.CONNECTION.connectRejected,
+        payload: {
+          connectionId,
+          errorMessage: "Error during key analysis - Valkey instance could be down",
+          shouldRetry: true,
+        },
+      }))
+    }
+  }
+}

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -102,6 +102,12 @@ export const VALKEY = {
     monitorError: "monitorError",
     saveMonitorSettingsRequested: "saveMonitorSettingsRequested",
   }),
+  KEY_ANALYSIS: makeNamespace("keyAnalysis", {
+    analysisRequested: "analysisRequested",
+    analysisProgress: "analysisProgress",
+    analysisFulfilled: "analysisFulfilled",
+    analysisError: "analysisError",
+  }),
 } as const
 
 // check truthyness in case process doesn't have env


### PR DESCRIPTION
Add a new Key Analysis page with two diagnostic tools for identifying memory-heavy keys and understanding memory distribution by key prefix.

Server-side changes:
- Add key-analysis.ts: core scanning logic using SCAN command to iterate keys, collecting MEMORY USAGE, TYPE, TTL, and collection size (HLEN, LLEN, SCARD, ZCARD, XLEN) for each key. Uses pLimit(20) for concurrent enrichment with configurable scan limit (default 10,000 keys).
- Add actions/key-analysis.ts: WebSocket action handler using withDeps pattern, registered in server index.ts handlers map.
- Add KEY_ANALYSIS namespace to common/src/constants.ts with four action types: analysisRequested, analysisProgress, analysisFulfilled, analysisError.
- Supports both GlideClient (standalone) and GlideClusterClient (cluster) with per-node cursor tracking for cluster deployments.
- Sends real-time progress updates during scanning and enriching phases.
- Error handling follows existing pattern: send analysisError then check for ConnectionError/TimeoutError/ClosingError.

Frontend state management:
- Add keyAnalysisSlice.ts: Redux slice with connectionId-keyed state, four reducers (requested/progress/fulfilled/error), and eight selectors for status, keys, totals, progress, and error.
- Add keyAnalysisEpic.ts: RxJS epic forwarding analysisRequested actions via WebSocket. Registered in rootEpic.ts and store.ts.

Frontend UI:
- Add KeyAnalysis.tsx: main page component with AppHeader, four StatCards (Total Keys, Scanned, Total Memory, Largest Key), TabGroup toolbar for switching between Big Keys and Prefix Memory tabs, progress bar with percentage during scanning, and refresh button.
- Add BigKeysTable.tsx: sortable table (Key Name, Type, Memory, Size, TTL) with click-to-sort headers, default sorted by memory desc. Includes a ChartModal with Recharts horizontal BarChart showing top 20 keys.
- Add PrefixMemoryTable.tsx: client-side prefix aggregation by colon delimiter with configurable segment depth (1/2/3). Columns: Prefix, Total Memory, Key Count, % of Total, Type Breakdown. Includes donut chart (Recharts PieChart with innerRadius) for memory distribution.
- Add sidebar navigation item (BarChart3 icon) and routes for both standalone (/:id/key-analysis) and cluster (/:clusterId/:id/key-analysis).

Files changed: 13 files, +994 lines (7 new, 6 modified)

## Description

Include a summary of the change.

### Change Visualization

Include a screenshot/video of before and after the change.
