### PR TITLE
Enable numbered databases for Valkey Cluster (Valkey 9.0+)

### DIFF
--- a/tools/valkey-cluster/docker-compose.yml
+++ b/tools/valkey-cluster/docker-compose.yml
@@ -7,6 +7,7 @@ services:
             --port 7001
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7001
@@ -40,6 +41,7 @@ services:
             --port 7002
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7002
@@ -73,6 +75,7 @@ services:
             --port 7003
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7003
@@ -106,6 +109,7 @@ services:
             --port 7004
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7004
@@ -139,6 +143,7 @@ services:
             --port 7005
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7005
@@ -172,6 +177,7 @@ services:
             --port 7006
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7006


### PR DESCRIPTION
## Summary
Enable numbered databases (0-15) in Valkey Cluster by adding `--cluster-databases 16` flag to all cluster nodes.

## Why
Valkey 9.0+ supports numbered databases in cluster mode (previously cluster mode forced single database). This unlocks multi-database workflows for local dev/test clusters.

Reference: https://valkey.io/blog/numbered-databases/

## Changes
- Add `--cluster-databases 16` config to all 6 cluster nodes (7001-7006) in docker-compose.yml

## Test Plan
- [ ] Start cluster with `docker-compose up`
- [ ] Connect and verify `SELECT 1` works (should not error)
- [ ] Verify data isolated between databases

Change Visualization

docker-compose.yml (6 nodes)
  ├─ valkey-1 (7001)  → +--cluster-databases 16
  ├─ valkey-2 (7002)  → +--cluster-databases 16
  ├─ valkey-3 (7003)  → +--cluster-databases 16
  ├─ valkey-4 (7004)  → +--cluster-databases 16
  ├─ valkey-5 (7005)  → +--cluster-databases 16
  └─ valkey-6 (7006)  → +--cluster-databases 16

Impact: All cluster nodes now support 16 numbered databases (0-15)