### PR TITLE
restricting destructive commands that cause server issues

### DIFF
--- a/apps/frontend/src/components/send-command/CommandConfirmDialog.tsx
+++ b/apps/frontend/src/components/send-command/CommandConfirmDialog.tsx
@@ -1,6 +1,8 @@
 import * as Dialog from "@radix-ui/react-dialog"
 import { AlertTriangle, X } from "lucide-react"
+import { useState } from "react"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { Typography } from "@/components/ui/typography"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 
@@ -12,13 +14,16 @@ interface CommandConfirmDialogProps {
 }
 
 export function CommandConfirmDialog({ command, reason, onConfirm, onCancel }: CommandConfirmDialogProps) {
+  const [typed, setTyped] = useState("")
+  const confirmed = typed.trim().toUpperCase() === command.trim().toUpperCase()
+
   return (
     <Dialog.Root onOpenChange={(open) => !open && onCancel()} open>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-30 bg-black/50" />
         <Dialog.Content asChild>
           <div className="fixed inset-0 z-40 flex items-center justify-center">
-            <div className="w-full max-w-md bg-white dark:bg-tw-dark-primary dark:border-tw-dark-border 
+            <div className="w-full max-w-md bg-white dark:bg-tw-dark-primary dark:border-tw-dark-border
             rounded-lg shadow-lg border p-4 flex flex-col gap-4">
               <div className="flex justify-between items-start">
                 <Dialog.Title asChild>
@@ -36,14 +41,22 @@ export function CommandConfirmDialog({ command, reason, onConfirm, onCancel }: C
                 <AlertDescription>{reason}</AlertDescription>
               </Alert>
 
-              <div>
-                <Typography variant="bodySm">Are you sure you want to run:</Typography>
-                <Typography className="mt-1" variant="code">{command}</Typography>
+              <div className="flex flex-col gap-2">
+                <Typography variant="bodySm">
+                  Type <Typography variant="code">{command}</Typography> to confirm:
+                </Typography>
+                <Input
+                  autoFocus
+                  onChange={(e) => setTyped(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && confirmed && onConfirm()}
+                  placeholder={command}
+                  value={typed}
+                />
               </div>
 
               <div className="flex justify-end gap-2">
                 <Button onClick={onCancel} variant="outline">Cancel</Button>
-                <Button onClick={onConfirm} variant="destructive">Run anyway</Button>
+                <Button disabled={!confirmed} onClick={onConfirm} variant="destructive">Run anyway</Button>
               </div>
             </div>
           </div>

--- a/apps/frontend/src/components/send-command/CommandConfirmDialog.tsx
+++ b/apps/frontend/src/components/send-command/CommandConfirmDialog.tsx
@@ -1,0 +1,54 @@
+import * as Dialog from "@radix-ui/react-dialog"
+import { AlertTriangle, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Typography } from "@/components/ui/typography"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+
+interface CommandConfirmDialogProps {
+  command: string
+  reason: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function CommandConfirmDialog({ command, reason, onConfirm, onCancel }: CommandConfirmDialogProps) {
+  return (
+    <Dialog.Root onOpenChange={(open) => !open && onCancel()} open>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-30 bg-black/50" />
+        <Dialog.Content asChild>
+          <div className="fixed inset-0 z-40 flex items-center justify-center">
+            <div className="w-full max-w-md bg-white dark:bg-tw-dark-primary dark:border-tw-dark-border 
+            rounded-lg shadow-lg border p-4 flex flex-col gap-4">
+              <div className="flex justify-between items-start">
+                <Dialog.Title asChild>
+                  <Typography variant="subheading">Confirm Dangerous Command</Typography>
+                </Dialog.Title>
+                <Dialog.Close asChild>
+                  <Button className="hover:text-primary h-auto" onClick={onCancel} variant="ghost">
+                    <X size={20} />
+                  </Button>
+                </Dialog.Close>
+              </div>
+
+              <Alert variant="warning">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>{reason}</AlertDescription>
+              </Alert>
+
+              <div>
+                <Typography variant="bodySm">Are you sure you want to run:</Typography>
+                <Typography className="mt-1" variant="code">{command}</Typography>
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <Button onClick={onCancel} variant="outline">Cancel</Button>
+                <Button onClick={onConfirm} variant="destructive">Run anyway</Button>
+              </div>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/frontend/src/components/send-command/SendCommand.tsx
+++ b/apps/frontend/src/components/send-command/SendCommand.tsx
@@ -4,7 +4,9 @@ import { useSelector } from "react-redux"
 import { useParams } from "react-router"
 import { toast } from "sonner"
 import { truncateText } from "@common/src/truncate-text"
+import { findBlockedCommand, findConfirmCommand } from "@common/src/command-restrictions"
 import type { JSONObject } from "@common/src/json-utils.ts"
+import { CommandConfirmDialog } from "@/components/send-command/CommandConfirmDialog"
 import { getNth, selectAllCommands } from "@/state/valkey-features/command/commandSelectors.ts"
 import { type CommandMetadata, sendRequested } from "@/state/valkey-features/command/commandSlice.ts"
 import RouteContainer from "@/components/ui/route-container.tsx"
@@ -30,16 +32,35 @@ export function SendCommand() {
   const [compareWith, setCompareWith] = useState<number | null>(null)
   const [keysFilter, setKeysFilter] = useState("")
   const [historyFilter, setHistoryFilter] = useState("")
+  const [pendingConfirm, setPendingConfirm] = useState<{ command: string; reason: string } | null>(null)
 
   const { id, clusterId } = useParams()
   const clusterAlias = useSelector(selectClusterAlias(id!))
   const allCommands = useSelector(selectAllCommands(id as string)) || []
   const { error, response } = useSelector(getNth(commandIndex, id as string)) as CommandMetadata
 
-  const onSubmit = (command?: string) => {
-    dispatch(sendRequested({ command: command || text, connectionId: id }))
+  const dispatchCommand = (command: string) => {
+    dispatch(sendRequested({ command, connectionId: id }))
     setCommandIndex(length)
     setText("")
+  }
+
+  const onSubmit = (command?: string) => {
+    const cmd = command || text
+
+    const blocked = findBlockedCommand(cmd)
+    if (blocked) {
+      toast.error(`Command blocked: ${blocked.reason}`)
+      return
+    }
+
+    const confirm = findConfirmCommand(cmd)
+    if (confirm) {
+      setPendingConfirm({ command: cmd, reason: confirm.reason })
+      return
+    }
+
+    dispatchCommand(cmd)
   }
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -236,5 +257,16 @@ export function SendCommand() {
           Send
         </Button>
       </div>
+      {pendingConfirm && (
+        <CommandConfirmDialog
+          command={pendingConfirm.command}
+          onCancel={() => setPendingConfirm(null)}
+          onConfirm={() => {
+            dispatchCommand(pendingConfirm.command)
+            setPendingConfirm(null)
+          }}
+          reason={pendingConfirm.reason}
+        />
+      )}
     </RouteContainer>)
 }

--- a/apps/server/src/actions/command.ts
+++ b/apps/server/src/actions/command.ts
@@ -1,4 +1,4 @@
-import { VALKEY } from "valkey-common"
+import { VALKEY, findBlockedCommand } from "valkey-common"
 import { sendValkeyRunCommand } from "../send-command"
 import { type Deps, withDeps } from "./utils"
 
@@ -9,10 +9,24 @@ type CommandAction = {
 
 export const sendRequested = withDeps<Deps, void>(
   async ({ ws, clients, connectionId, action }) => {
+    const payload = action.payload as CommandAction
+
+    const blocked = findBlockedCommand(payload.command)
+    if (blocked) {
+      ws.send(
+        JSON.stringify({
+          meta: { command: payload.command, connectionId: payload.connectionId },
+          type: VALKEY.COMMAND.sendFailed,
+          payload: `Command blocked: ${blocked.reason}`,
+        }),
+      )
+      return
+    }
+
     const connection = clients.get(connectionId!)
 
     if (connection) {
-      sendValkeyRunCommand(connection.client, ws, action.payload as CommandAction)
+      sendValkeyRunCommand(connection.client, ws, payload)
       return
     }
 

--- a/common/src/command-restrictions.ts
+++ b/common/src/command-restrictions.ts
@@ -1,0 +1,38 @@
+export type CommandRestriction = {
+  pattern: string[]
+  reason: string
+}
+
+// these commands are blocked and cannot be executed because they can cause server problems
+export const BLOCKED_COMMANDS: CommandRestriction[] = [
+  { pattern: ["SHUTDOWN"], reason: "SHUTDOWN stops the server and cannot be undone remotely." },
+  { pattern: ["DEBUG"], reason: "DEBUG can cause crashes or data corruption." },
+]
+
+// these commands require confirmation before execution because they can cause severe problems or data loss
+export const CONFIRM_COMMANDS: CommandRestriction[] = [
+  { pattern: ["FLUSHALL"], reason: "FLUSHALL deletes all keys in all databases. This cannot be undone." },
+  { pattern: ["FLUSHDB"], reason: "FLUSHDB deletes all keys in the current database. This cannot be undone." },
+  { pattern: ["KEYS"], reason: "KEYS can block the server for a long time when many keys exist. Consider using SCAN instead." },
+  { pattern: ["CONFIG", "RESETSTAT"], reason: "CONFIG RESETSTAT resets all server statistics." },
+  { pattern: ["CONFIG", "REWRITE"], reason: "CONFIG REWRITE overwrites the server configuration file." },
+  { pattern: ["SLAVEOF"], reason: "SLAVEOF changes replication topology." },
+  { pattern: ["REPLICAOF"], reason: "REPLICAOF changes replication topology." },
+  { pattern: ["CLUSTER", "RESET"], reason: "CLUSTER RESET resets the cluster state and may cause data loss." },
+]
+
+export function matchesRestriction(command: string, restriction: CommandRestriction): boolean {
+  const parts = command.trim().toUpperCase().split(/\s+/)
+  return (
+    restriction.pattern.length <= parts.length &&
+    restriction.pattern.every((token, i) => parts[i] === token)
+  )
+}
+
+export function findBlockedCommand(command: string): CommandRestriction | undefined {
+  return BLOCKED_COMMANDS.find((r) => matchesRestriction(command, r))
+}
+
+export function findConfirmCommand(command: string): CommandRestriction | undefined {
+  return CONFIRM_COMMANDS.find((r) => matchesRestriction(command, r))
+}

--- a/common/src/command-restrictions.ts
+++ b/common/src/command-restrictions.ts
@@ -7,12 +7,12 @@ export type CommandRestriction = {
 export const BLOCKED_COMMANDS: CommandRestriction[] = [
   { pattern: ["SHUTDOWN"], reason: "SHUTDOWN stops the server and cannot be undone remotely." },
   { pattern: ["DEBUG"], reason: "DEBUG can cause crashes or data corruption." },
+  { pattern: ["FLUSHALL"], reason: "FLUSHALL deletes all keys in all databases. This cannot be undone." },
+  { pattern: ["FLUSHDB"], reason: "FLUSHDB deletes all keys in the current database. This cannot be undone." },
 ]
 
 // these commands require confirmation before execution because they can cause severe problems or data loss
 export const CONFIRM_COMMANDS: CommandRestriction[] = [
-  { pattern: ["FLUSHALL"], reason: "FLUSHALL deletes all keys in all databases. This cannot be undone." },
-  { pattern: ["FLUSHDB"], reason: "FLUSHDB deletes all keys in the current database. This cannot be undone." },
   { pattern: ["KEYS"], reason: "KEYS can block the server for a long time when many keys exist. Consider using SCAN instead." },
   { pattern: ["CONFIG", "RESETSTAT"], reason: "CONFIG RESETSTAT resets all server statistics." },
   { pattern: ["CONFIG", "REWRITE"], reason: "CONFIG REWRITE overwrites the server configuration file." },

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./bytes-conversion"
+export * from "./command-restrictions"
 export * from "./cache-hit-ratio"
 export * from "./constants"
 export * from "./dashboard-metrics"


### PR DESCRIPTION
## Description

Include a summary of the change.

Restricting destructive commands with two methods 

1. defining BLOCKED_COMMANDS (hard-blocked) that causes server crashes (DEBUG and SHUTDOWN)
2. defining CONFIRM_COMMANDS (require user confirmation) can still cause crashes and data loss

### Change Visualization

Include a screenshot/video of before and after the change.
