### PR TITLE
Create and seed numbered databases for test environments (cluster and standalone)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,16 @@ cd tools/valkey-cluster
 docker compose down -v
 ```
 
+### Local Valkey seed data
+
+Both `tools/valkey-cluster` and `tools/valkey-standalone` expose **16 logical databases** by default, and the bundled `populate.mjs` scripts iterate every configured database and seed each one with the typed sample dataset (string, list, set, hash, sorted set, geo, bitmap, stream) plus a 100,000-key bulk string load. 
+
+Keys and string values carry a `db<d>` tag (for example `string:db3:1` with value `value_db3_1`, and `bulk:db3:42` with value `value_db3_42`) so each database is visibly distinguishable in the UI. 
+
+To shrink startup cost, set `POPULATE_DB_COUNT` (positive integer, default `16`) to limit how many databases are seeded, and `POPULATE_BULK_KEYS` (non-negative integer, default `100000`; `0` skips the bulk load) to shrink the per-database load. 
+
+See [`tools/README.md`](./tools/README.md) for the full reference.
+
 ## IDE Setup
 
 ### VSCode

--- a/apps/server/src/__integration__/key-browser.integration.test.ts
+++ b/apps/server/src/__integration__/key-browser.integration.test.ts
@@ -5,8 +5,9 @@ import { sanitizeUrl, VALKEY } from "valkey-common"
 import { WsClient } from "./harness/wsClient"
 import { defaultConnectionDetails, WS_URL } from "./harness/fixture"
 
-// Keys seeded by `tools/valkey-cluster/populate.mjs`.
-const SEEDED_STRING_KEYS = ["string:1", "string:2", "string:3", "string:4", "string:5"] as const
+// Keys seeded by `tools/valkey-cluster/populate.mjs` for database 0.
+// Every database `d` carries the same shape under the `db<d>` tag
+const SEEDED_STRING_KEYS = ["string:db0:1", "string:db0:2", "string:db0:3", "string:db0:4", "string:db0:5"] as const
 
 describe("integration / key browser", async () => {
   const ws = await WsClient.connect(WS_URL)

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -23,6 +23,7 @@ services:
       --port 7001
       --bind 0.0.0.0
       --cluster-enabled yes
+      --cluster-databases 16
       --cluster-config-file nodes.conf
       --cluster-node-timeout 5000
       --cluster-announce-port 7001
@@ -54,6 +55,7 @@ services:
       --port 7002
       --bind 0.0.0.0
       --cluster-enabled yes
+      --cluster-databases 16
       --cluster-config-file nodes.conf
       --cluster-node-timeout 5000
       --cluster-announce-port 7002
@@ -85,6 +87,7 @@ services:
       --port 7003
       --bind 0.0.0.0
       --cluster-enabled yes
+      --cluster-databases 16
       --cluster-config-file nodes.conf
       --cluster-node-timeout 5000
       --cluster-announce-port 7003
@@ -116,6 +119,7 @@ services:
       --port 7004
       --bind 0.0.0.0
       --cluster-enabled yes
+      --cluster-databases 16
       --cluster-config-file nodes.conf
       --cluster-node-timeout 5000
       --cluster-announce-port 7004
@@ -147,6 +151,7 @@ services:
       --port 7005
       --bind 0.0.0.0
       --cluster-enabled yes
+      --cluster-databases 16
       --cluster-config-file nodes.conf
       --cluster-node-timeout 5000
       --cluster-announce-port 7005
@@ -178,6 +183,7 @@ services:
       --port 7006
       --bind 0.0.0.0
       --cluster-enabled yes
+      --cluster-databases 16
       --cluster-config-file nodes.conf
       --cluster-node-timeout 5000
       --cluster-announce-port 7006
@@ -224,9 +230,10 @@ services:
     depends_on:
       cluster-init:
         condition: service_completed_successfully
-    working_dir: /app
+    working_dir: /app/valkey-cluster
     volumes:
-      - ../tools/valkey-cluster/populate.mjs:/app/populate.mjs:ro
+      - ../tools/valkey-cluster/populate.mjs:/app/valkey-cluster/populate.mjs:ro
+      - ../tools/common/populate-helpers.mjs:/app/common/populate-helpers.mjs:ro
     environment:
       VALKEY_START_NODE: "valkey-7001:7001"
     networks:
@@ -234,7 +241,6 @@ services:
     command: >
       sh -c "
         npm -s install @valkey/client >/dev/null 2>&1 &&
-        npm -s install ramda >/dev/null 2>&1 &&
         node populate.mjs
       "
 

--- a/docs-site/src/content/docs/development/platform-support.md
+++ b/docs-site/src/content/docs/development/platform-support.md
@@ -13,6 +13,7 @@ Valkey Admin works with all versions of Valkey. Some features require newer vers
 |---------|----------------|----------------------|
 | Command Logs (slow commands, large requests/replies) | Valkey 8.1+ | — |
 | Hot Slots Detection | Valkey 8.0+ | `cluster-slot-stats-enabled yes` + LFU eviction policy |
+| Multiple logical databases in cluster mode | Valkey 9.0+ | `--cluster-databases <n>` on every cluster node |
 
 Monitor-based hot keys detection works with any Valkey version.
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,4 +6,35 @@ From root run:
 
 `./tools/valkey-standalone/build_run_standalone.sh` for a standalone instance populated with seed data.
 
-`./tools/valkey-cluster/build_run_cluster.sh` for a cluster instance populated with seed data.
+`./tools/valkey-cluster/scripts/build_run_cluster.sh` for a cluster instance populated with seed data.
+
+### Logical databases
+
+Both stacks expose **16 logical databases** by default. The cluster stack passes `--cluster-databases 16` to every node, and the standalone stack passes `--databases 16`. The `populate.mjs` scripts iterate every configured database and seed each one with the typed sample dataset (string, list, set, hash, sorted set, geo, bitmap, stream) plus a bulk string load.
+
+Per-database content is distinguishable by construction: every key written into database `d` carries the literal token `db<d>` in its name, and every string value carries the same token. For example, the third sample string in database `3` is `string:db3:1` with value `value_db3_1`, and the 42nd bulk key is `bulk:db3:42` with value `value_db3_42`. Two distinct databases never share a key.
+
+#### Overrides
+
+Two environment variables tune what populate writes:
+
+| Variable | Default | Accepted values | Behaviour on overrun |
+|---|---|---|---|
+| `POPULATE_DB_COUNT` | `16` | Positive integer; unset or empty falls back to the default | Populate exits non-zero if the requested count exceeds the deployment's configured database count, naming both numbers in the error |
+| `POPULATE_BULK_KEYS` | `100000` | Non-negative integer (`0` is allowed and skips the bulk load); unset or empty falls back to the default | n/a (no upper bound enforced beyond available memory) |
+
+Non-integer or out-of-range values cause populate to exit non-zero with an error that names the offending environment variable and its rejected value.
+
+Pass overrides through the populate Compose service, for example:
+
+```bash
+POPULATE_DB_COUNT=4 POPULATE_BULK_KEYS=1000 \
+  docker compose -f tools/valkey-standalone/docker-compose.yml \
+  --profile populate run --rm populate
+```
+
+#### Cluster Valkey 9+ baseline
+
+Multiple logical databases on a Valkey **cluster** require Valkey 9.0.0 or newer. The bundled Compose files use `valkey/valkey:latest`, which satisfies the baseline. If you pin an older tag, pin `valkey/valkey:9.0` or newer — otherwise the cluster populate script exits non-zero before issuing any write to a database greater than `0`, naming the detected version and the required baseline.
+
+For the full platform-support matrix, see [the platform-support page](../docs-site/src/content/docs/development/platform-support.md).

--- a/tools/common/populate-helpers.mjs
+++ b/tools/common/populate-helpers.mjs
@@ -173,6 +173,19 @@ export async function writeBulkKeys(client, dbIndex, totalKeys) {
   }
 }
 
+async function flushCurrentDatabase(client) {
+  if (Array.isArray(client.masters)) {
+    await Promise.all(
+      client.masters.map(async node => {
+        const nodeClient = await client.nodeClient(node)
+        await nodeClient.sendCommand(["FLUSHDB"])
+      }),
+    )
+    return
+  }
+  await client.sendCommand(["FLUSHDB"])
+}
+
 /**
  * Orchestrate a full per-database seed: `FLUSHDB` → sample dataset → bulk load.
  *
@@ -201,7 +214,7 @@ export async function writeBulkKeys(client, dbIndex, totalKeys) {
  */
 export async function seedDatabase(client, dbIndex, { bulkKeys }) {
   console.log(`[db${dbIndex}] flushing database`)
-  await client.flushDb()
+  await flushCurrentDatabase(client)
 
   await writeSampleDataset(client, dbIndex)
 
@@ -254,12 +267,14 @@ export async function selectDatabase(client, dbIndex) {
  */
 export async function assertConfiguredDatabases(client, requestedDbCount, isCluster) {
   const key = isCluster ? "cluster-databases" : "databases"
-  const result = await client.sendCommand(["CONFIG", "GET", key])
+  const result = isCluster
+    ? await client.sendCommand(undefined, false, ["CONFIG", "GET", key])
+    : await client.sendCommand(["CONFIG", "GET", key])
   let configured = parseConfigGetValue(result, key)
   if (configured === undefined && isCluster) {
     // Older cluster configurations may report only "databases" even with
     // cluster mode on. Fall back before giving up.
-    const fallback = await client.sendCommand(["CONFIG", "GET", "databases"])
+    const fallback = await client.sendCommand(undefined, false, ["CONFIG", "GET", "databases"])
     configured = parseConfigGetValue(fallback, "databases")
   }
   if (configured === undefined) {
@@ -297,15 +312,17 @@ export async function assertConfiguredDatabases(client, requestedDbCount, isClus
  * @returns {Promise<void>}
  */
 export async function assertClusterVersion(cluster) {
-  const info = await cluster.sendCommand(["INFO", "server"])
+  const info = await cluster.sendCommand(undefined, false, ["INFO", "server"])
   const body = typeof info === "string" ? info : String(info)
-  const match = /\b(redis|valkey)_version:(\d+)\.(\d+)\.(\d+)/i.exec(body)
+  const match =
+    /\bvalkey_version:(\d+)\.(\d+)\.(\d+)/i.exec(body) ||
+    /\bredis_version:(\d+)\.(\d+)\.(\d+)/i.exec(body)
   if (!match) {
     throw new Error(`Could not parse Valkey version from INFO server output`)
   }
-  const major = match[2]
-  const minor = match[3]
-  const patch = match[4]
+  const major = match[1]
+  const minor = match[2]
+  const patch = match[3]
   const detected = `${major}.${minor}.${patch}`
   if (Number(major) < 9) {
     throw new Error(

--- a/tools/common/populate-helpers.mjs
+++ b/tools/common/populate-helpers.mjs
@@ -1,0 +1,385 @@
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/** Bulk write batch size: keys per parallel batch in `writeBulkKeys`. */
+export const BATCH_SIZE = 1000
+
+/** Default number of logical databases to populate per run. */
+export const DEFAULT_DB_COUNT = 16
+
+/** Default bulk string key count per database. */
+export const DEFAULT_BULK_KEYS = 100000
+
+/**
+ * Minimum Valkey version that supports multiple logical databases when
+ * cluster mode is enabled.
+ */
+export const MULTI_DB_BASELINE = "9.0.0"
+
+/**
+ * @typedef {Object} PopulateConfig
+ * @property {number} dbCount Number of logical databases to populate.
+ *   Default `16`. Validated as a positive integer.
+ * @property {number} bulkKeys Bulk string keys per database.
+ *   Default `100000`. Validated as a non-negative integer.
+ */
+
+/**
+ * Strictly parse an integer-shaped env-var string.
+ *
+ * Behaviour:
+ * - `undefined` and the empty string return `defaultValue` (treated as unset).
+ * - Otherwise the input MUST match `/^\d+$/` (no signs, no whitespace, no
+ *   decimals, no scientific notation, no mixed alphanumerics).
+ * - The matched string is parsed with `Number.parseInt(raw, 10)` and the
+ *   result MUST be a finite integer `>= min`.
+ * - Any rejection throws an `Error` whose message names `name` and embeds
+ *   `JSON.stringify(raw)` so the offending raw value is preserved verbatim.
+ *
+ * The strict regex matters because `Number.parseInt("16abc", 10)` returns
+ * `16`, which would silently accept malformed input.
+ *
+ * @param {string | undefined} raw Raw env-var value (or `undefined` if unset).
+ * @param {string} name Env-var name, used in error messages.
+ * @param {{ defaultValue: number, min: number }} opts
+ * @returns {number}
+ */
+export function parseStrictInt(raw, name, { defaultValue, min }) {
+  if (raw === undefined || raw === "") {
+    return defaultValue
+  }
+  const reject = () => {
+    throw new Error(
+      `${name} must be an integer >= ${min}, got ${JSON.stringify(raw)}`,
+    )
+  }
+  if (typeof raw !== "string" || !/^\d+$/.test(raw)) {
+    reject()
+  }
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < min) {
+    reject()
+  }
+  return parsed
+}
+
+/**
+ * Read `POPULATE_DB_COUNT` and `POPULATE_BULK_KEYS` from `process.env` and
+ * return a validated {@link PopulateConfig}.
+ *
+ * @returns {PopulateConfig}
+ */
+export function parseEnv() {
+  const dbCount = parseStrictInt(
+    process.env.POPULATE_DB_COUNT,
+    "POPULATE_DB_COUNT",
+    { defaultValue: DEFAULT_DB_COUNT, min: 1 },
+  )
+  const bulkKeys = parseStrictInt(
+    process.env.POPULATE_BULK_KEYS,
+    "POPULATE_BULK_KEYS",
+    { defaultValue: DEFAULT_BULK_KEYS, min: 0 },
+  )
+  return { dbCount, bulkKeys }
+}
+
+/**
+ * Write the canonical typed `Sample_Dataset` (string, list, set, hash, sorted
+ * set, geo, bitmap, stream) into the currently selected logical database.
+ *
+ * Every key embeds the `db<dbIndex>` tag so per-database key sets are
+ * structurally disjoint and the database index is visible in the UI without
+ * consulting the script source. String values for `string:*` and the helper
+ * field/list/set/zset values likewise embed the tag.
+ *
+ * The seven non-stream writes run in parallel via `Promise.all`. The five
+ * `XADD` calls run sequentially with a 50ms sleep between each so the auto-
+ * generated stream entry IDs are strictly increasing across distinct
+ * millisecond timestamps.
+ *
+ * @param {{
+ *   set: (key: string, value: string) => Promise<unknown>,
+ *   rPush: (key: string, value: string) => Promise<unknown>,
+ *   sAdd: (key: string, value: string) => Promise<unknown>,
+ *   hSet: (key: string, fields: Record<string, string>) => Promise<unknown>,
+ *   zAdd: (key: string, members: { score: number, value: string }[]) => Promise<unknown>,
+ *   geoAdd: (key: string, point: { member: string, longitude: number, latitude: number }) => Promise<unknown>,
+ *   setBit: (key: string, offset: number, value: number) => Promise<unknown>,
+ *   xAdd: (key: string, id: string, fields: Record<string, string>) => Promise<unknown>,
+ * }} client A `@valkey/client` standalone or cluster client.
+ * @param {number} dbIndex Target logical database index for the seed run.
+ * @returns {Promise<void>}
+ */
+export async function writeSampleDataset(client, dbIndex) {
+  console.log(`[db${dbIndex}] writing sample dataset`)
+
+  const tag = `db${dbIndex}`
+  const I = Array.from({ length: 5 }, (_, i) => i + 1)
+  const geoPoints = [
+    { member: "London",  longitude: -0.1278,  latitude:  51.5074 },
+    { member: "Paris",   longitude:  2.3522,  latitude:  48.8566 },
+    { member: "NewYork", longitude: -74.0060, latitude:  40.7128 },
+    { member: "Tokyo",   longitude: 139.6917, latitude:  35.6895 },
+    { member: "Sydney",  longitude: 151.2093, latitude: -33.8688 },
+  ]
+
+  await Promise.all([
+    ...I.map(i => client.set(`string:${tag}:${i}`, `value_${tag}_${i}`)),
+    ...I.map(i => client.rPush(`list:${tag}`, `item_${tag}_${i}`)),
+    ...I.map(i => client.sAdd(`set:${tag}`, `member_${tag}_${i}`)),
+    ...I.map(i => client.hSet(`hash:${tag}`, { [`field_${i}`]: `value_${tag}_${i}` })),
+    ...I.map(i => client.zAdd(`zset:${tag}`, [{ score: i, value: `zmember_${tag}_${i}` }])),
+    ...geoPoints.map(p => client.geoAdd(`geo:${tag}`, p)),
+    ...I.map(i => client.setBit(`bitmap:${tag}`, i, 1)),
+  ])
+
+  for (let i = 1; i <= 5; i++) {
+    await client.xAdd(`stream:${tag}`, "*", { sensor: `${1000 + i}`, value: `${20 + i}` })
+    await sleep(50)
+  }
+}
+
+/**
+ * Write `totalKeys` bulk string keys (`bulk:db<dbIndex>:<i>`) into the
+ * currently selected logical database in
+ * parallel-within-batch / sequential-across-batch shape.
+ *
+ * Each batch fans out up to {@link BATCH_SIZE} `SET` calls in parallel via
+ * `Promise.all`, then awaits the batch before moving on to the next.
+ *
+ * The loop bounds are inclusive `[1, totalKeys]`, so a `totalKeys` of `0`
+ * executes the loop body zero times (no writes, no batch logs).
+ *
+ * Key shape: `bulk:db<dbIndex>:<i>`. Value shape: `value_db<dbIndex>_<i>`.
+ *
+ * @param {{ set: (key: string, value: string) => Promise<unknown> }} client
+ *   A `@valkey/client` standalone or cluster client.
+ * @param {number} dbIndex Target logical database index for the bulk load.
+ * @param {number} totalKeys Number of bulk keys to write. Must be a
+ *   non-negative integer; `0` is a no-op.
+ * @returns {Promise<void>}
+ */
+export async function writeBulkKeys(client, dbIndex, totalKeys) {
+  const tag = `db${dbIndex}`
+  for (let start = 1; start <= totalKeys; start += BATCH_SIZE) {
+    const batchEnd = Math.min(start + BATCH_SIZE - 1, totalKeys)
+    const promises = []
+    for (let i = start; i <= batchEnd; i++) {
+      promises.push(client.set(`bulk:${tag}:${i}`, `value_${tag}_${i}`))
+    }
+    await Promise.all(promises)
+    console.log(`[db${dbIndex}] bulk ${start} → ${batchEnd}`)
+  }
+}
+
+/**
+ * Orchestrate a full per-database seed: `FLUSHDB` → sample dataset → bulk load.
+ *
+ * `FLUSHDB` is issued at the start of every per-database iteration so the
+ * populate run is idempotent across reruns. Without this, a second populate
+ * run with a smaller `POPULATE_BULK_KEYS` would leave stale keys behind from
+ * the previous run. `FLUSHDB` is per-database (it only flushes the currently
+ * selected database in standalone, and is routed to all masters for the
+ * currently selected database in cluster), so it does not touch other
+ * databases mid-run.
+ *
+ * @param {{
+ *   flushDb: () => Promise<unknown>,
+ *   set: (key: string, value: string) => Promise<unknown>,
+ *   rPush: (key: string, value: string) => Promise<unknown>,
+ *   sAdd: (key: string, value: string) => Promise<unknown>,
+ *   hSet: (key: string, fields: Record<string, string>) => Promise<unknown>,
+ *   zAdd: (key: string, members: { score: number, value: string }[]) => Promise<unknown>,
+ *   geoAdd: (key: string, point: { member: string, longitude: number, latitude: number }) => Promise<unknown>,
+ *   setBit: (key: string, offset: number, value: number) => Promise<unknown>,
+ *   xAdd: (key: string, id: string, fields: Record<string, string>) => Promise<unknown>,
+ * }} client A `@valkey/client` standalone or cluster client.
+ * @param {number} dbIndex Target logical database index for the seed run.
+ * @param {{ bulkKeys: number }} opts
+ * @returns {Promise<void>}
+ */
+export async function seedDatabase(client, dbIndex, { bulkKeys }) {
+  console.log(`[db${dbIndex}] flushing database`)
+  await client.flushDb()
+
+  await writeSampleDataset(client, dbIndex)
+
+  console.log(
+    `[db${dbIndex}] writing ${bulkKeys} bulk keys in batches of ${BATCH_SIZE}`,
+  )
+  await writeBulkKeys(client, dbIndex, bulkKeys)
+  console.log(`[db${dbIndex}] bulk load complete`)
+}
+
+/**
+ * Switch a standalone client to the given logical database via `SELECT`.
+ *
+ * Trivial wrapper around `client.select(dbIndex)` for symmetry with the
+ * cluster code path (which switches databases by reconnecting with
+ * `defaults.database = dbIndex` rather than issuing `SELECT` mid-flight).
+ *
+ * @param {{ select: (db: number) => Promise<unknown> }} client
+ *   A `@valkey/client` standalone client.
+ * @param {number} dbIndex Target logical database index.
+ * @returns {Promise<void>}
+ */
+export async function selectDatabase(client, dbIndex) {
+  await client.select(dbIndex)
+}
+
+/**
+ * Assert that the connected deployment is configured to support at least the
+ * requested `Database_Count`.
+ *
+ * Issues `CONFIG GET cluster-databases` for cluster deployments or
+ * `CONFIG GET databases` for standalone deployments, parses the reply with
+ * {@link parseConfigGetValue}, and compares the configured value against
+ * `requestedDbCount`. When the cluster-mode lookup yields `undefined` (older
+ * configurations may report only `databases` even with cluster mode on), we
+ * fall back to a `CONFIG GET databases` query before giving up.
+ *
+ * Throws an `Error` whose message names both `requestedDbCount` and the
+ * configured count when the request overruns the deployment's configured
+ * database count. The message also points the user at the appropriate
+ * `--databases` / `--cluster-databases` flag for the remediation. Lowering
+ * `POPULATE_DB_COUNT` below the configured count is allowed; only overruns
+ * are rejected.
+ *
+ * @param {{ sendCommand: (args: string[]) => Promise<unknown> }} client
+ *   A `@valkey/client` standalone or cluster client.
+ * @param {number} requestedDbCount The Database_Count requested for the run.
+ * @param {boolean} isCluster `true` if `client` is a cluster client.
+ * @returns {Promise<void>}
+ */
+export async function assertConfiguredDatabases(client, requestedDbCount, isCluster) {
+  const key = isCluster ? "cluster-databases" : "databases"
+  const result = await client.sendCommand(["CONFIG", "GET", key])
+  let configured = parseConfigGetValue(result, key)
+  if (configured === undefined && isCluster) {
+    // Older cluster configurations may report only "databases" even with
+    // cluster mode on. Fall back before giving up.
+    const fallback = await client.sendCommand(["CONFIG", "GET", "databases"])
+    configured = parseConfigGetValue(fallback, "databases")
+  }
+  if (configured === undefined) {
+    throw new Error(
+      `Could not read configured database count from CONFIG GET`,
+    )
+  }
+  const configuredNumber = Number(configured)
+  if (requestedDbCount > configuredNumber) {
+    throw new Error(
+      `POPULATE_DB_COUNT=${requestedDbCount} exceeds the deployment's configured database count of ${configured}. ` +
+      `Either lower POPULATE_DB_COUNT or raise --${key} on the Valkey server.`,
+    )
+  }
+}
+
+/**
+ * Probe `INFO server` on a cluster client and assert the reported Valkey
+ * version is at least {@link MULTI_DB_BASELINE}.
+ *
+ * Issues `INFO server` via `cluster.sendCommand(["INFO", "server"])` and
+ * parses the body for the version line. Both `redis_version` (Valkey reports
+ * this for Redis-protocol compatibility) and `valkey_version` (defensive,
+ * for future builds that may switch the field name) are accepted, in either
+ * case. The reply is coerced via `String(...)` so non-string shapes from
+ * exotic clients still flow through the regex.
+ *
+ * Throws an `Error` whose message names the parse failure when the regex
+ * does not match. Throws an `Error` whose message names both the detected
+ * `<x.y.z>` and the {@link MULTI_DB_BASELINE} when `major < 9`. On success,
+ * emits `[probe] cluster version <x.y.z> satisfies >= 9.0.0` on stdout.
+ *
+ * @param {{ sendCommand: (args: string[]) => Promise<unknown> }} cluster
+ *   A `@valkey/client` cluster client.
+ * @returns {Promise<void>}
+ */
+export async function assertClusterVersion(cluster) {
+  const info = await cluster.sendCommand(["INFO", "server"])
+  const body = typeof info === "string" ? info : String(info)
+  const match = /\b(redis|valkey)_version:(\d+)\.(\d+)\.(\d+)/i.exec(body)
+  if (!match) {
+    throw new Error(`Could not parse Valkey version from INFO server output`)
+  }
+  const major = match[2]
+  const minor = match[3]
+  const patch = match[4]
+  const detected = `${major}.${minor}.${patch}`
+  if (Number(major) < 9) {
+    throw new Error(
+      `Cluster Valkey version ${detected} does not meet the multi-database baseline of ${MULTI_DB_BASELINE}. ` +
+      `Pin valkey/valkey:9.0 or newer in tools/valkey-cluster/docker-compose.yml.`,
+    )
+  }
+  console.log(`[probe] cluster version ${detected} satisfies >= ${MULTI_DB_BASELINE}`)
+}
+
+/**
+ * Wrap a per-database write error with the multi-database baseline note when
+ * the underlying error looks like a `SELECT` rejection on `dbIndex > 0`.
+ *
+ * For all other inputs (`dbIndex === 0`, errors that do not match the
+ * SELECT-rejection family) the original `err` is returned unchanged so the
+ * top-level handler can log and exit on the original cause.
+ *
+ * @param {unknown} err Error caught from a per-database write.
+ * @param {number} dbIndex Logical database index that failed.
+ * @returns {unknown} A wrapped `Error` for SELECT-rejection on `dbIndex > 0`,
+ *   otherwise `err` unchanged.
+ */
+export function wrapDbError(err, dbIndex) {
+  const msg = String((err && err.message) || err)
+  if (dbIndex > 0 && /(DB index is out of range|SELECT is not allowed)/i.test(msg)) {
+    return new Error(
+      `Failed writing to database ${dbIndex}: ${msg}. This typically means the cluster does not support multiple ` +
+      `databases. Cluster multi-database support requires Valkey ${MULTI_DB_BASELINE} or newer.`,
+    )
+  }
+  return err
+}
+
+/**
+ * Parse a value for `key` out of a `CONFIG GET` reply.
+ *
+ * `@valkey/client` returns `CONFIG GET` historically as a flat
+ * `[key, value, key, value, …]` array (Redis RESP-2 shape) and, in newer
+ * versions, as an object map (`{ databases: "16" }`). Both shapes are
+ * accepted here so callers do not need to care about the wire format.
+ *
+ * Behaviour:
+ * - `null` / `undefined`: returns `undefined`.
+ * - Even-length array: walks pairwise, returning `result[idx + 1]` where
+ *   `result[idx] === key`. Returns `undefined` if the key is not present.
+ * - Non-null object: returns `result[key]` directly, or `undefined` if the
+ *   key is not present.
+ *
+ * The returned value is a string (Valkey's `CONFIG GET` reply is text).
+ * Callers are responsible for `Number(...)` conversion when a numeric value
+ * is expected.
+ *
+ * @param {unknown} result Reply from `CONFIG GET <key>`.
+ * @param {string} key Configuration key to extract.
+ * @returns {string | undefined}
+ */
+export function parseConfigGetValue(result, key) {
+  if (result === null || result === undefined) {
+    return undefined
+  }
+  if (Array.isArray(result)) {
+    if (result.length % 2 !== 0) {
+      return undefined
+    }
+    for (let idx = 0; idx < result.length; idx += 2) {
+      if (result[idx] === key) {
+        return result[idx + 1]
+      }
+    }
+    return undefined
+  }
+  if (typeof result === "object") {
+    return result[key]
+  }
+  return undefined
+}

--- a/tools/valkey-cluster/docker-compose.yml
+++ b/tools/valkey-cluster/docker-compose.yml
@@ -7,6 +7,7 @@ services:
             --port 7001
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7001
@@ -40,6 +41,7 @@ services:
             --port 7002
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7002
@@ -73,6 +75,7 @@ services:
             --port 7003
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7003
@@ -106,6 +109,7 @@ services:
             --port 7004
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7004
@@ -139,6 +143,7 @@ services:
             --port 7005
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7005
@@ -172,6 +177,7 @@ services:
             --port 7006
             --bind 0.0.0.0
             --cluster-enabled yes
+            --cluster-databases 16
             --cluster-config-file nodes.conf
             --cluster-node-timeout 5000
             --cluster-announce-port 7006
@@ -218,9 +224,10 @@ services:
         depends_on:
             cluster-init:
                 condition: service_completed_successfully
-        working_dir: /app
+        working_dir: /app/valkey-cluster
         volumes:
-            - ./populate.mjs:/app/populate.mjs:ro
+            - ./populate.mjs:/app/valkey-cluster/populate.mjs:ro
+            - ../common/populate-helpers.mjs:/app/common/populate-helpers.mjs:ro
         environment:
             # inside Docker network; on host use (ipconfig getifaddr en0):7001 instead
             VALKEY_START_NODE: "valkey-7001:7001"
@@ -229,7 +236,6 @@ services:
         command: >
             sh -c "
               npm -s install @valkey/client >/dev/null 2>&1 &&
-              npm -s install ramda >/dev/null 2>&1 &&
               node populate.mjs
             "
 

--- a/tools/valkey-cluster/populate.mjs
+++ b/tools/valkey-cluster/populate.mjs
@@ -1,69 +1,58 @@
-import * as R from "ramda"
 import { createCluster } from "@valkey/client"
-import { setTimeout as sleep } from "timers/promises"
+import {
+  parseEnv,
+  seedDatabase,
+  assertConfiguredDatabases,
+  assertClusterVersion,
+  wrapDbError,
+} from "../common/populate-helpers.mjs"
+
+const ROOT_NODES = [
+  { url: `valkey://${process.env.VALKEY_START_NODE ?? "valkey-7001:7001"}` },
+]
 
 async function main() {
-  const TOTAL_KEYS = 100000
-  const BATCH_SIZE = 1000
+  const { dbCount, bulkKeys } = parseEnv()
 
-  const startup = process.env.VALKEY_START_NODE || "valkey-node-0:6379"
-  const [host, portStr] = startup.split(":")
-  const port = Number(portStr)
-
-  const cluster = createCluster({
-    rootNodes: [{ url: `valkey://${host}:${port}` }],
-    defaults: { socket: { connectTimeout: 5000 } },
+  // Probe connection: validate the cluster's Valkey version meets the
+  // multi-database baseline and that the deployment is configured for at
+  // least `dbCount` logical databases. The probe pins itself to database 0
+  // so the version/CONFIG queries are safe on pre-multi-DB clusters.
+  const probe = createCluster({
+    rootNodes: ROOT_NODES,
+    defaults: { database: 0, socket: { connectTimeout: 5000 } },
   })
-  cluster.on("error", e => console.error("Valkey error:", e))
-  await cluster.connect()
-
-  const I = R.range(1, 6)
-
-  // --- keep your existing keys ---
-  const geoPoints = [
-    { member: "London",  longitude: -0.1278, latitude:  51.5074 },
-    { member: "Paris",   longitude:  2.3522, latitude:  48.8566 },
-    { member: "NewYork", longitude: -74.0060, latitude: 40.7128 },
-    { member: "Tokyo",   longitude: 139.6917, latitude: 35.6895 },
-    { member: "Sydney",  longitude: 151.2093, latitude: -33.8688 },
-  ]
-
-  await Promise.all([
-    ...I.map(i => cluster.set(`string:${i}`, `value_${i}`)),
-    ...I.map(i => cluster.rPush("list", `item_${i}`)),
-    ...I.map(i => cluster.sAdd("set", `member_${i}`)),
-    ...I.map(i => cluster.hSet("hash", { [`field_${i}`]: `value_${i}` })),
-    ...I.map(i => cluster.zAdd("zset", [{ score: i, value: `zmember_${i}` }])),
-    ...geoPoints.map(p => cluster.geoAdd("geo", p)),
-    ...I.map(i => cluster.setBit("bitmap", i, 1)),
-  ])
-
-  // streams gotta be sequential
-  for (let i = 1; i <= 5; i++) {
-    await cluster.xAdd("stream", "*", { sensor: `${1000 + i}`, value: `${20 + i}` })
-    await sleep(50) // sleep here is to make each xAdd get a unique, increasing timestamp
-
+  probe.on("error", e => console.error("Valkey error:", e))
+  await probe.connect()
+  try {
+    await assertClusterVersion(probe)
+    await assertConfiguredDatabases(probe, dbCount, true)
+  } finally {
+    await probe.quit()
   }
 
-  console.log("Loaded initial entries for all Valkey data types.")
-
-  console.log(`Adding ${TOTAL_KEYS} additional string keys in batches of ${BATCH_SIZE}...`)
-
-  for (let start = 1; start <= TOTAL_KEYS; start += BATCH_SIZE) {
-    const batchEnd = Math.min(start + BATCH_SIZE - 1, TOTAL_KEYS)
-    const promises = []
-
-    for (let i = start; i <= batchEnd; i++) {
-      promises.push(cluster.set(`bulk:key:${i}`, `value_${i}`))
+  // Per-DB seed: reconnect with `defaults.database = d` so every pooled node
+  // connection issues `SELECT d` on connect. The pool is short-lived (one
+  // database's worth of writes), so any reconnects within the pool also
+  // re-select. See design.md → Components and Interfaces / Top-level
+  // orchestration (cluster).
+  for (let d = 0; d < dbCount; d++) {
+    const cluster = createCluster({
+      rootNodes: ROOT_NODES,
+      defaults: { database: d, socket: { connectTimeout: 5000 } },
+    })
+    cluster.on("error", e => console.error(`[db${d}] valkey error:`, e))
+    await cluster.connect()
+    try {
+      await seedDatabase(cluster, d, { bulkKeys })
+    } catch (err) {
+      throw wrapDbError(err, d)
+    } finally {
+      await cluster.quit()
     }
-
-    await Promise.all(promises)
-    console.log(`Created keys ${start} → ${batchEnd}`)
   }
 
-  console.log("All additional string keys created successfully.")
   console.log(`Connect to your cluster using host: ${process.env.ANNOUNCE_HOST}`)
-  await cluster.quit()
 }
 
 main().catch(err => { console.error(err); process.exit(1) })

--- a/tools/valkey-standalone/docker-compose.yml
+++ b/tools/valkey-standalone/docker-compose.yml
@@ -2,6 +2,7 @@ services:
     valkey-standalone:
         image: valkey/valkey:latest
         container_name: valkey-standalone
+        command: ["valkey-server", "--databases", "16"]
         ports: ["6379:6379"]
         healthcheck:
             {
@@ -16,9 +17,10 @@ services:
         image: node:20
         depends_on:
             valkey-standalone: { condition: service_healthy }
-        working_dir: /app
+        working_dir: /app/valkey-standalone
         volumes:
-            - ./populate.mjs:/app/populate.mjs:ro
+            - ./populate.mjs:/app/valkey-standalone/populate.mjs:ro
+            - ../common/populate-helpers.mjs:/app/common/populate-helpers.mjs:ro
         environment:
             # inside Docker network; on host use valkey://localhost:6379 instead
             VALKEY_URL: "valkey://valkey-standalone:6379"
@@ -26,7 +28,6 @@ services:
         command: >
             sh -c "
               npm -s install @valkey/client >/dev/null 2>&1 &&
-              npm -s install ramda >/dev/null 2>&1 &&
               node populate.mjs
             "
         profiles: [populate]

--- a/tools/valkey-standalone/populate.mjs
+++ b/tools/valkey-standalone/populate.mjs
@@ -1,58 +1,28 @@
-import * as R from "ramda"
 import { createClient } from "@valkey/client"
-import { setTimeout as sleep } from "timers/promises"
+import {
+  parseEnv,
+  seedDatabase,
+  selectDatabase,
+  assertConfiguredDatabases,
+} from "../common/populate-helpers.mjs"
 
 async function main() {
-  const TOTAL_KEYS = 100000
-  const BATCH_SIZE = 1000
-
+  const { dbCount, bulkKeys } = parseEnv()
   const client = createClient({ url: process.env.VALKEY_URL ?? "valkey://localhost:6379" })
   client.on("error", e => console.error("Valkey error:", e))
   await client.connect()
 
-  const I = R.range(1, 6)
+  await assertConfiguredDatabases(client, dbCount, false)
 
-  const geoPoints = [
-    { member: "London",  longitude: -0.1278, latitude:  51.5074 },
-    { member: "Paris",   longitude:  2.3522, latitude:  48.8566 },
-    { member: "NewYork", longitude: -74.0060, latitude: 40.7128 },
-    { member: "Tokyo",   longitude: 139.6917, latitude: 35.6895 },
-    { member: "Sydney",  longitude: 151.2093, latitude: -33.8688 },
-  ]
-
-  await Promise.all([
-    ...I.map(i => client.set(`string:${i}`, `value_${i}`)),
-    ...I.map(i => client.rPush("list", `item_${i}`)),
-    ...I.map(i => client.sAdd("set", `member_${i}`)),
-    ...I.map(i => client.hSet("hash", { [`field_${i}`]: `value_${i}` })),
-    ...I.map(i => client.zAdd("zset", [{ score: i, value: `zmember_${i}` }])),
-    ...geoPoints.map(p => client.geoAdd("geo", p)),
-    ...I.map(i => client.setBit("bitmap", i, 1)),
-  ])
-
-  for (let i = 1; i <= 5; i++) {
-    await client.xAdd("stream", "*", { sensor: `${1000 + i}`, value: `${20 + i}` })
-    await sleep(50)
+  for (let d = 0; d < dbCount; d++) {
+    await selectDatabase(client, d)
+    await seedDatabase(client, d, { bulkKeys })
   }
 
-  console.log("Loaded initial entries for all Valkey data types.")
-
-  console.log(`Adding ${TOTAL_KEYS} additional string keys in batches of ${BATCH_SIZE}...`)
-
-  for (let start = 1; start <= TOTAL_KEYS; start += BATCH_SIZE) {
-    const batchEnd = Math.min(start + BATCH_SIZE - 1, TOTAL_KEYS)
-    const promises = []
-
-    for (let i = start; i <= batchEnd; i++) {
-      promises.push(client.set(`bulk:key:${i}`, `value_${i}`))
-    }
-
-    await Promise.all(promises)
-    console.log(`Created keys ${start} → ${batchEnd}`)
-  }
-
-  console.log("All additional string keys created successfully.")
   await client.quit()
 }
 
-main().catch(err => { console.error(err); process.exit(1) })
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Description

Addresses #357 by not only setting 16 numbered databases, but also seeding them all for both cluster and standalone test environments.
