### PR TITLE
Remove db on all boundaries between connectionId and metricsId

### DIFF
--- a/apps/server/src/__tests__/connection.test.ts
+++ b/apps/server/src/__tests__/connection.test.ts
@@ -13,7 +13,7 @@ import {
 import { resolveHostnameOrIpAddress, dns } from "../utils"
 import { checkJsonModuleAvailability } from "../check-json-module"
 import { ConnectionDetails } from "../actions/connection"
-import { type MetricsServerMap } from "../metrics-orchestrator"
+import { toMetricsNodeId, type MetricsServerMap } from "../metrics-orchestrator"
 import { _reset as resetNodeWatchers } from "../node-watchers"
 
 const DEFAULT_PAYLOAD = {
@@ -135,7 +135,10 @@ describe("connectToValkey", () => {
     clients = new Map()
     connectedNodesByCluster = new Map()
     metricsServerMap = new Map()
-    metricsServerMap.set(DEFAULT_PAYLOAD.connectionId, {
+    // metricsServerMap is keyed by metrics-node-id; the empty Connection_Identifier
+    // strips to the empty string, which matches the empty connectionId used by
+    // the default payload in these tests.
+    metricsServerMap.set(toMetricsNodeId(DEFAULT_PAYLOAD.connectionId), {
       metricsURI: "http://localhost:1234",
       pid: 12345,
       lastSeen: Date.now(),

--- a/apps/server/src/__tests__/metrics-orchestrator.test.ts
+++ b/apps/server/src/__tests__/metrics-orchestrator.test.ts
@@ -8,6 +8,7 @@ import {
   reconcileClusterMetricsServers,
   clients,
   clusterNodesRegistry,
+  toMetricsNodeId,
   __test__,
   type ClusterNodeMap, 
   type MetricsServerMap 
@@ -97,6 +98,30 @@ describe("metrics-orchestrator", () => {
       assert.strictEqual(Object.keys(nodesToAdd).length, 0)
     })
 
+    it("should NOT remove a node whose only client is keyed `-db<N>`", async () => {
+      // N:1 invariant: a single metrics process can serve many user-visible
+      // connections under different `db`s. The reconciler must not evict it
+      // just because the client is keyed by Connection_Identifier (with `-db`)
+      // while the metrics map is keyed by metrics-node-id (without `-db`).
+      const now = Date.now()
+
+      const metricsMap: MetricsServerMap = new Map([
+        ["127-0-0-1-6379", { metricsURI: "uri", pid: 123, lastSeen: now }],
+      ])
+
+      const clusterNodes: ClusterNodeMap = {
+        // intentionally missing — standalone, not in any cluster
+      }
+
+      // simulate a user connection on db 5 against the same node
+      clients.set("127-0-0-1-6379-db5", { client })
+
+      const { nodesToAdd, nodesToRemove } = await __test__.findDiff(metricsMap, clusterNodes)
+
+      assert.strictEqual(nodesToRemove.includes("127-0-0-1-6379"), false)
+      assert.strictEqual(Object.keys(nodesToAdd).length, 0)
+    })
+
     // We only store data from primary nodes. This can be a TODO
     // it("should keep replica metrics servers because replicas belong to the cluster map", async () => {
     //   const now = Date.now()
@@ -181,7 +206,7 @@ describe("metrics-orchestrator", () => {
           }
         },
       )
-      await __test__.startMetricsServers({ node1: nodes })
+      await __test__.startMetricsServers({ node1: nodes }, "cluster-1")
 
       // Assert that the node was added to metricsServerMap
       assert.strictEqual(metricsServerMap.has("node1"), true)
@@ -218,7 +243,7 @@ describe("metrics-orchestrator", () => {
 
     beforeEach(() => {
       metricsServerMap.clear()
-      connectionDetails = { host: "127.0.0.1", port: "6379", tls: false, verifyTlsCertificate: false, endpointType: "node" }
+      connectionDetails = { host: "127.0.0.1", port: "6379", tls: false, verifyTlsCertificate: false, endpointType: "node", db: 0 }
 
       // Mock all side-effectful internal functions
       mock.method(__test__, "createClient", async () => ({}))
@@ -251,6 +276,34 @@ describe("metrics-orchestrator", () => {
       await reconcileClusterMetricsServers(
         mockClusterNodesRegistry,metricsServerMap, connectionDetails)
       // updateMetricsServers should not be called because nothing changed
+    })
+  })
+
+  describe("toMetricsNodeId", () => {
+    // The boundary helper between Connection_Identifier-keyed `clients` and
+    // metrics-node-id-keyed `metricsServerMap`.
+    it("strips a trailing -db0 suffix", () => {
+      assert.strictEqual(toMetricsNodeId("127-0-0-1-6379-db0"), "127-0-0-1-6379")
+    })
+
+    it("strips a trailing -db15 suffix (multi-digit)", () => {
+      assert.strictEqual(toMetricsNodeId("valkey-7001-7001-db15"), "valkey-7001-7001")
+    })
+
+    it("is idempotent on already-stripped ids", () => {
+      assert.strictEqual(toMetricsNodeId("valkey-7001-7001"), "valkey-7001-7001")
+    })
+
+    it("does not touch a non-trailing -db<N> token", () => {
+      assert.strictEqual(toMetricsNodeId("dbserver-db5-host-6379"), "dbserver-db5-host-6379")
+    })
+
+    it("does not strip when -db is followed by non-digits", () => {
+      assert.strictEqual(toMetricsNodeId("host-6379-dbx"), "host-6379-dbx")
+    })
+
+    it("returns the empty string unchanged", () => {
+      assert.strictEqual(toMetricsNodeId(""), "")
     })
   })
 })

--- a/apps/server/src/actions/commandLogs.ts
+++ b/apps/server/src/actions/commandLogs.ts
@@ -2,6 +2,7 @@ import { type WebSocket } from "ws"
 import { VALKEY, COMMANDLOG_TYPE } from "valkey-common"
 import * as R from "ramda"
 import { withDeps, Deps } from "./utils"
+import { toMetricsNodeId } from "../metrics-orchestrator"
 
 type CommandLogType = typeof COMMANDLOG_TYPE.SLOW | typeof COMMANDLOG_TYPE.LARGE_REQUEST | typeof COMMANDLOG_TYPE.LARGE_REPLY
 
@@ -103,7 +104,9 @@ export const commandLogsRequested = withDeps<Deps, void>(
     const connectionIds = nodes ? Object.keys(nodes) : [connectionId]
 
     const promises = connectionIds.map(async (nodeId: string) => {
-      const metricsServerURI = metricsServerMap.get(nodeId)?.metricsURI
+      // metricsServerMap is keyed by metrics-node-id; map at the boundary.
+      // Idempotent on the cluster-fan-out path where ids already lack `-db`.
+      const metricsServerURI = metricsServerMap.get(toMetricsNodeId(nodeId))?.metricsURI
       if (!metricsServerURI) {
         if (!nodes) sendCommandLogsError(ws, nodeId, new Error("Metrics server URI not found"))
         return { connectionId: nodeId, error: "Metrics server not started" } as NodeError

--- a/apps/server/src/actions/config.ts
+++ b/apps/server/src/actions/config.ts
@@ -1,6 +1,7 @@
 import { type WebSocket } from "ws"
 import { VALKEY } from "valkey-common"
 import { Deps, withDeps, fetchWithTimeout } from "./utils"
+import { toMetricsNodeId } from "../metrics-orchestrator"
 
 interface ParsedResponse  {
   success: boolean, 
@@ -17,7 +18,9 @@ export const updateConfig = withDeps<Deps, void>(
       : [connectionId]
 
     const promises = connectionIds.map(async (connectionId: string) => {
-      const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
+      // metricsServerMap is keyed by metrics-node-id; map at the boundary.
+      // Idempotent on the cluster-fan-out path where ids already lack `-db`.
+      const metricsServerURI = metricsServerMap.get(toMetricsNodeId(connectionId))?.metricsURI
 
       if (!metricsServerURI) {
         const normalizedError = {

--- a/apps/server/src/actions/cpuUsage.ts
+++ b/apps/server/src/actions/cpuUsage.ts
@@ -1,6 +1,7 @@
 import { type WebSocket } from "ws"
 import { VALKEY } from "valkey-common"
 import { withDeps, Deps, fetchWithTimeout } from "./utils"
+import { toMetricsNodeId } from "../metrics-orchestrator"
 
 type CpuUsageResponse = Array<{
   timestamp: number
@@ -54,7 +55,9 @@ export const cpuUsageRequested = withDeps<Deps, void>(
     const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
 
     const promises = connectionIds.map(async (connectionId: string) => {
-      const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
+      // metricsServerMap is keyed by metrics-node-id; map at the boundary.
+      // Idempotent on the cluster-fan-out path where ids already lack `-db`.
+      const metricsServerURI = metricsServerMap.get(toMetricsNodeId(connectionId))?.metricsURI
 
       if (!metricsServerURI) {
         sendCpuUsageError(ws, connectionId, new Error("Metrics server URI not found"))

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -2,6 +2,7 @@ import { type WebSocket } from "ws"
 import { VALKEY } from "valkey-common"
 import * as R from "ramda"
 import { withDeps, Deps } from "./utils"
+import { toMetricsNodeId } from "../metrics-orchestrator"
 
 type HotKeysResponse = {
   nodeId: string
@@ -65,7 +66,9 @@ export const hotKeysRequested = withDeps<Deps, void>(
       : [connectionId]
     
     const promises = connectionIds.map(async (connectionId: string) => {
-      const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
+      // metricsServerMap is keyed by metrics-node-id; map at the boundary.
+      // Idempotent on the cluster-fan-out path where ids already lack `-db`.
+      const metricsServerURI = metricsServerMap.get(toMetricsNodeId(connectionId))?.metricsURI
       if (!metricsServerURI) {
         if (!nodes) {
           console.warn("Metrics server not started for node: ", connectionId)

--- a/apps/server/src/actions/memoryUsage.ts
+++ b/apps/server/src/actions/memoryUsage.ts
@@ -1,6 +1,7 @@
 import { type WebSocket } from "ws"
 import { VALKEY } from "valkey-common"
 import { withDeps, Deps, fetchWithTimeout } from "./utils"
+import { toMetricsNodeId } from "../metrics-orchestrator"
 
 interface MemoryMetric {
   description: string
@@ -60,7 +61,9 @@ export const memoryUsageRequested = withDeps<Deps, void>(
     const { connectionId, clusterId, timeRange = "12h" } = action.payload as unknown as RequestPayload
     const connectionIds = clusterId ? connectedNodesByCluster.get(clusterId as string) ?? [] : [connectionId]
     const promises = connectionIds.map(async (connectionId: string) => {
-      const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
+      // metricsServerMap is keyed by metrics-node-id; map at the boundary.
+      // Idempotent on the cluster-fan-out path where ids already lack `-db`.
+      const metricsServerURI = metricsServerMap.get(toMetricsNodeId(connectionId))?.metricsURI
 
       if (!metricsServerURI) {
         sendMemoryUsageError(ws, connectionId, new Error("Metrics server URI not found"))

--- a/apps/server/src/actions/monitorAction.ts
+++ b/apps/server/src/actions/monitorAction.ts
@@ -3,6 +3,7 @@ import { VALKEY, type MonitorAction } from "valkey-common"
 import { withDeps, type Deps, fetchWithTimeout, type ReduxAction } from "./utils"
 import { updateConfig } from "./config"
 import { getOtherWatchers } from "../node-watchers"
+import { toMetricsNodeId } from "../metrics-orchestrator"
 
 type MonitorResponse = {
   monitorRunning: boolean
@@ -53,7 +54,9 @@ export const monitorRequested = withDeps<Deps, void>(
       : [connectionId]
 
     const promises = connectionIds.map(async (connectionId: string) => {
-      const metricsServerURI = metricsServerMap.get(connectionId)?.metricsURI
+      // metricsServerMap is keyed by metrics-node-id; map at the boundary.
+      // Idempotent on the cluster-fan-out path where ids already lack `-db`.
+      const metricsServerURI = metricsServerMap.get(toMetricsNodeId(connectionId))?.metricsURI
 
       if (!metricsServerURI) {
         sendMonitorError(ws, connectionId, new Error("Metrics server URI not found"))

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -22,6 +22,7 @@ import {
   clusterCredentials, 
   reconcileClusterMetricsServers, 
   isKubernetes, 
+  toMetricsNodeId, 
   ClusterNodeMap } from "./metrics-orchestrator"
 import { subscribe } from "./node-watchers"
 import { createClusterValkeyClient, createStandaloneValkeyClient } from "./valkey-client"
@@ -368,8 +369,14 @@ async function connectToValkeyLocked(
     }
 
     // In K8s or Web, metrics servers register themselves.
-    if (!isKubernetes && !metricsServerMap.has(payload.connectionId)) {
-      await startMetricsServer(payload.connectionDetails, payload.connectionId)
+    if (!isKubernetes) {
+      // `metricsServerMap` is keyed by metrics-node-id, not Connection_Identifier.
+      // Strip the `-db<N>` suffix so a second user connection on a different
+      // db reuses the existing metrics process for the same node (N:1).
+      const metricsNodeId = toMetricsNodeId(payload.connectionId)
+      if (!metricsServerMap.has(metricsNodeId)) {
+        await startMetricsServer(payload.connectionDetails, metricsNodeId)
+      }
     }
 
     console.log("Connected to standalone")
@@ -636,8 +643,26 @@ export async function getExistingConnection(
   return existingConnectionId ? clients.get(existingConnectionId) : undefined
 }
 
-export async function closeMetricsServer(connectionId: string, metricsServerMap: MetricsServerMap) {
-  const metricsServerUri = metricsServerMap.get(connectionId)?.metricsURI
+export async function closeMetricsServer(
+  connectionId: string,
+  metricsServerMap: MetricsServerMap,
+  clients: Map<string, { client: GlideClient | GlideClusterClient; clusterId?: string }>,
+) {
+  // Map Connection_Identifier → metrics-node-id at the boundary.
+  const metricsNodeId = toMetricsNodeId(connectionId)
+
+  // N:1 invariant: many user-visible connections may share one metrics
+  // process for the same (host, port). Only close when this is the LAST
+  // sibling, otherwise we'd orphan still-active dbs on the same node.
+  // The `id !== connectionId` guard tolerates callers that haven't yet
+  // removed `connectionId` from `clients`; teardownConnection currently
+  // removes first, so this is belt-and-suspenders.
+  const stillReferenced = [...clients.keys()].some(
+    (id) => id !== connectionId && toMetricsNodeId(id) === metricsNodeId,
+  )
+  if (stillReferenced) return
+
+  const metricsServerUri = metricsServerMap.get(metricsNodeId)?.metricsURI
   if (metricsServerUri) {
     const res = await fetch(`${metricsServerUri}/connection/close`, 
       { method: "POST",
@@ -645,8 +670,8 @@ export async function closeMetricsServer(connectionId: string, metricsServerMap:
         body: JSON.stringify({ connectionId }), 
       })
     if (res.ok) {
-      metricsServerMap.delete(connectionId)
-      console.log(`Metrics server for ${connectionId} closed successfully`)
+      metricsServerMap.delete(metricsNodeId)
+      console.log(`Metrics server for ${metricsNodeId} closed successfully`)
     }
     else console.warn("Could not kill metrics server process")
   }
@@ -660,7 +685,7 @@ export function teardownConnection(
 
   // In web mode, metrics servers are managed by the orchestrator
   if (!isWebMode) {
-    closeMetricsServer(connectionId, metricsServerMap).catch((err) =>
+    closeMetricsServer(connectionId, metricsServerMap, clients).catch((err) =>
       console.error(`Error closing metrics server for ${connectionId}:`, err),
     )
   }

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -1,3 +1,17 @@
+/**
+ * Metrics orchestration boundary.
+ *
+ * Two id-spaces flow through this module:
+ *   - Connection_Identifier `<host>-<port>-db<N>` — keys of the `clients` map.
+ *   - Metrics-node-id       `<host>-<port>`       — keys of `metricsServerMap`
+ *                                                   and `clusterNodesRegistry[clusterId]`.
+ *
+ * The relationship is N:1 (many Connection_Identifiers per metrics-node-id):
+ * a metrics process is one OS process per Valkey node, and the data it
+ * collects (INFO, MEMORY STATS, MONITOR, COMMANDLOG) is server-global, not
+ * db-scoped. Use `toMetricsNodeId` at every boundary; never use the metrics
+ * map directly with a Connection_Identifier.
+ */
 import { GlideClient, GlideClusterClient, ConnectionError, ServiceType } from "@valkey/valkey-glide"
 import { ChildProcess, spawn } from "child_process"
 import { fileURLToPath } from "url"
@@ -7,6 +21,28 @@ import { DEPLOYMENT_TYPE, sanitizeUrl } from "valkey-common"
 import { discoverCluster } from "./connection"
 import { ConnectionDetails } from "./actions/connection"
 import { createOrchestratorValkeyClient } from "./valkey-client"
+
+/**
+ * Strip the `-db<N>` suffix from a Connection_Identifier so it matches the
+ * metrics-node-id format used as a key in `metricsServerMap`.
+ *
+ * Why this helper exists:
+ *   - `clients` keys carry `db` because each (host, port, db) is a distinct
+ *     user-visible connection with its own Glide client.
+ *   - `metricsServerMap` keys do NOT carry `db`. A metrics process is one OS
+ *     process per Valkey node (host, port); the data it collects is
+ *     server-global, not db-scoped.
+ *   - The two maps therefore have an N:1 relationship: many user-visible
+ *     connections under one metrics process. Use this helper at every
+ *     boundary that turns a Connection_Identifier into the matching
+ *     metrics-node-id.
+ *
+ * Idempotent — calling it on an already-stripped id returns the same id.
+ * The `$` anchor only strips a trailing `-db<digits>` group, never random
+ * text earlier in the id.
+ */
+export const toMetricsNodeId = (connectionId: string): string =>
+  connectionId.replace(/-db\d+$/, "")
 
 // Assumes nodeId is unique among all clusters
 export type MetricsServerMap = Map<string,
@@ -104,7 +140,13 @@ export function createMetricsOrchestratorRouter() {
     const { metricsServerUri, nodeId, pid } = req.body
 
     const nodeBelongsToCluster = isKnownClusterNode(nodeId)
-    const nodeConnected = clients.has(nodeId)
+    // `clients` keys are Connection_Identifiers with `-db<N>`; the incoming
+    // `nodeId` is a metrics-node-id with no `db`. Match on the stripped form
+    // so any open user-visible connection under this node counts as a valid
+    // client.
+    const nodeConnected = [...clients.keys()].some(
+      (id) => toMetricsNodeId(id) === nodeId,
+    )
 
     if (nodeBelongsToCluster || nodeConnected)  {
       const now = Date.now()  
@@ -206,7 +248,14 @@ async function findDiff(metricsServerMap: MetricsServerMap, clusterNodeMap: Clus
   // These are nodes that are in the metricsMap but not in clusterMap and clientsMap or stale nodes
   const nodesToRemove: string[] = Array.from(metricsServerMap.entries())
     .filter(([key, value]) => {
-      return (!clusterNodes[key] && !clients.has(key)) || (now - value.lastSeen) > ttl
+      // `key` is a metrics-node-id. `clients` keys are Connection_Identifiers.
+      // Treat the metrics process as still-claimed if any open client strips
+      // down to this node (N:1). Avoids evicting standalone metrics whose
+      // owner connection is keyed `-db<N>`.
+      const knownToClients = [...clients.keys()].some(
+        (id) => toMetricsNodeId(id) === key,
+      )
+      return (!clusterNodes[key] && !knownToClients) || (now - value.lastSeen) > ttl
     })
     .map(([key]) => key)
 


### PR DESCRIPTION
## Description

This PR fixes the boundaries between client connectionIds and metrics server Ids by stripping db at all instances client connectionIds are used to access metrics instances.

Client connectionIds keys carry `db` because each (host, port, db) is a distinct user-visible connection with its own Glide client.

Metrics server keys do not carry `db`. A metrics process is one OS process per Valkey node (host, port); the data it collects is node level, not db-scoped.