### PR TITLE
Add db to cluster client nodes

### DIFF
--- a/apps/frontend/src/components/cluster-topology/Cluster.tsx
+++ b/apps/frontend/src/components/cluster-topology/Cluster.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux"
 import { Server, CheckCircle2 } from "lucide-react"
 import { useParams } from "react-router"
 import { CONNECTED, MAX_CONNECTIONS } from "@common/src/constants.ts"
+import { buildConnectionId } from "@common/src/connection-id.ts"
 import { truncateText } from "@common/src/truncate-text.ts"
 import { AppHeader } from "../ui/app-header"
 import RouteContainer from "../ui/route-container"
@@ -14,7 +15,7 @@ import type { RootState } from "@/store.ts"
 import { selectCluster } from "@/state/valkey-features/cluster/clusterSelectors"
 import { useAppDispatch } from "@/hooks/hooks"
 import { updateClusterData } from "@/state/valkey-features/cluster/clusterSlice"
-import { selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
+import { selectClusterAlias, selectClusterDb } from "@/state/valkey-features/connection/connectionSelectors"
 
 export function Cluster() {
   const { id, clusterId } = useParams()
@@ -29,6 +30,10 @@ export function Cluster() {
     state.valkeyConnection?.connections || {},
   )
   const clusterAlias = useSelector(selectClusterAlias(id!))
+  // The app reuses one shared cluster client per cluster (single databaseId), so
+  // every node connection uses the same db. Connections are stored under
+  // buildConnectionId(host, port, db), so resolve node status by that id.
+  const clusterDb = useSelector(selectClusterDb(clusterId!))
 
   if (!clusterData?.clusterNodes || !clusterData?.data) {
     return (
@@ -47,8 +52,8 @@ export function Cluster() {
 
   // cluster stats
   const totalNodes = clusterEntries.length
-  const connectedNodes = clusterEntries.filter(([primaryKey]) =>
-    connectionStatuses[primaryKey]?.status === CONNECTED,
+  const connectedNodes = clusterEntries.filter(([, primary]) =>
+    connectionStatuses[buildConnectionId(primary.host, primary.port, clusterDb)]?.status === CONNECTED,
   ).length
   const totalReplicas = clusterEntries.reduce((sum, [, primary]) =>
     sum + primary.replicas.length, 0,

--- a/apps/frontend/src/components/cluster-topology/cluster-node.tsx
+++ b/apps/frontend/src/components/cluster-topology/cluster-node.tsx
@@ -4,6 +4,7 @@ import { LayoutDashboard, Terminal, PowerIcon, Server, MemoryStick, Users, Loade
 import { useNavigate } from "react-router"
 import { useSelector } from "react-redux"
 import { CONNECTED, CONNECTING, ERROR, MAX_CONNECTIONS } from "@common/src/constants.ts"
+import { buildConnectionId } from "@common/src/connection-id.ts"
 import { TooltipProvider } from "@radix-ui/react-tooltip"
 import { Badge } from "../ui/badge"
 import { CustomTooltip } from "../ui/tooltip"
@@ -16,7 +17,7 @@ import type { PrimaryNode, ParsedNodeInfo } from "@/state/valkey-features/cluste
 import { connectPending, type ConnectionDetails } from "@/state/valkey-features/connection/connectionSlice.ts"
 import { useAppDispatch } from "@/hooks/hooks"
 import {
-  selectIsAtConnectionLimit, selectEncryptedPassword
+  selectIsAtConnectionLimit, selectEncryptedPassword, selectClusterDb
 } from "@/state/valkey-features/connection/connectionSelectors"
 import { secureStorage } from "@/utils/secureStorage.ts"
 import { cn } from "@/lib/utils"
@@ -38,7 +39,15 @@ export function ClusterNode({
 }: ClusterNodeProps) {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
-  const connectionId = primaryKey
+  // Inherit the parent cluster's Database_Index so node connections target the
+  // same logical database (defaults to 0 when no cluster connection is found).
+  const clusterDb = useSelector(selectClusterDb(clusterId))
+
+  // Match the db-aware id scheme from buildConnectionId so the seed node
+  // resolves to its status here, and node connects reuse that id
+  // instead of creating a db id less duplicate.
+  const connectionId = buildConnectionId(primary.host, primary.port, clusterDb)
+
   const connectionStatus = useSelector((state: RootState) =>
     state.valkeyConnection?.connections?.[connectionId]?.status,
   )
@@ -61,6 +70,7 @@ export function ClusterNode({
     tls: primary.tls,
     verifyTlsCertificate: primary.verifyTlsCertificate,
     endpointType: "node",
+    db: clusterDb,
   }
 
   const handleNodeConnect = () => {

--- a/apps/frontend/src/components/ui/app-header.tsx
+++ b/apps/frontend/src/components/ui/app-header.tsx
@@ -3,11 +3,12 @@ import { useSelector } from "react-redux"
 import { useState, useRef, useEffect, type ReactNode } from "react"
 import { CircleChevronDown, CircleChevronUp, Dot, CornerDownRight, Search } from "lucide-react"
 import { CONNECTED } from "@common/src/constants.ts"
+import { buildConnectionId } from "@common/src/connection-id.ts"
 import { Badge } from "./badge"
 import { Input } from "./input"
 import { Typography } from "./typography"
 import type { RootState } from "@/store.ts"
-import { selectConnectionDetails } from "@/state/valkey-features/connection/connectionSelectors.ts"
+import { selectConnectionDetails, selectClusterDb } from "@/state/valkey-features/connection/connectionSelectors.ts"
 import { selectCluster } from "@/state/valkey-features/cluster/clusterSelectors"
 import { cn } from "@/lib/utils.ts"
 
@@ -26,6 +27,10 @@ function AppHeader({ title, icon, description, className }: AppHeaderProps) {
   const { id, clusterId } = useParams<{ id: string; clusterId: string }>()
   const { host, port, username, alias } = useSelector(selectConnectionDetails(id!))
   const clusterData = useSelector(selectCluster(clusterId!))
+  // The app reuses one shared cluster client per cluster (single databaseId), so
+  // every node connection uses the same db. Connections are stored under
+  // buildConnectionId(host, port, db), used here for status + navigation.
+  const clusterDb = useSelector(selectClusterDb(clusterId!))
   const ToggleIcon = isOpen ? CircleChevronUp : CircleChevronDown
 
   const { pathname } = useLocation()
@@ -40,8 +45,8 @@ function AppHeader({ title, icon, description, className }: AppHeaderProps) {
     state.valkeyConnection?.connections,
   )
 
-  const handleNavigate = (primaryKey: string) => {
-    navigate(`/${clusterId}/${primaryKey}/dashboard`)
+  const handleNavigate = (connectionId: string) => {
+    navigate(`/${clusterId}/${connectionId}/dashboard`)
     setIsOpen(false)
     setSearch("")
   }
@@ -158,14 +163,15 @@ function AppHeader({ title, icon, description, className }: AppHeaderProps) {
                     )}
                     {/* TODO: Remove extra defensiveness */}
                     {nodesToRender.map(([primaryKey, primary]) => {
-                      const nodeIsConnected = allConnections?.[primaryKey]?.status === CONNECTED
+                      const connectionId = buildConnectionId(primary.host, primary.port, clusterDb)
+                      const nodeIsConnected = allConnections?.[connectionId]?.status === CONNECTED
 
                       return (
                         <li className="flex flex-col gap-1" key={primaryKey}>
                           <button
                             className="flex items-center cursor-pointer hover:bg-primary/20"
                             disabled={!nodeIsConnected}
-                            onClick={() => handleNavigate(primaryKey)}
+                            onClick={() => handleNavigate(connectionId)}
                           >
                             <Dot
                               className={nodeIsConnected ? "text-green-500" : "text-gray-400"}

--- a/apps/frontend/src/state/valkey-features/connection/connectionSelectors.ts
+++ b/apps/frontend/src/state/valkey-features/connection/connectionSelectors.ts
@@ -23,6 +23,11 @@ export const selectEncryptedPassword = (clusterId: string) => (state: RootState)
     (c) => c.connectionDetails?.clusterId === clusterId && R.isNotNil(c.connectionDetails?.password),
   )?.connectionDetails?.password
 
+export const selectClusterDb = (clusterId: string) => (state: RootState) =>
+  Object.values(state.valkeyConnection?.connections ?? {}).find(
+    (c) => c.connectionDetails?.clusterId === clusterId,
+  )?.connectionDetails?.db ?? 0
+
 export const selectClusterAlias = (id: string) => (state: RootState) =>
   atId(id, state)?.connectionDetails?.alias
 


### PR DESCRIPTION
## Description

Fixes the bug where cluster nodes status look ups used the connectionId without db. This led to the server side isValidDatabaseIndex returning false and connection rejected with `Invalid Database_index: must be a non-negative integer` error.

The fix uses the cluster's shared db id for each node, which resolves the issue.

### Change Visualization

<img width="1717" height="808" alt="image" src="https://github.com/user-attachments/assets/f8225a8c-144d-42c9-936b-de8022f2e443" />
