### PR TITLE
exposed KEY_VALUE_SIZE_LIMIT_BYTES as a configurable env in docker co…

### DIFF
--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -14,6 +14,10 @@ import { VALKEY, VALKEY_CLIENT } from "valkey-common"
 import { formatBytes } from "valkey-common"
 import { buildScanCommandArgs } from "./valkey-client-commands"
 
+// Largest value the Key Browser renders before showing a size warning; override via env.
+const keyValueSizeLimitBytes =
+  Number(process.env.KEY_VALUE_SIZE_LIMIT_BYTES) || VALKEY_CLIENT.KEY_VALUE_SIZE_LIMIT_BYTES
+
 interface EnrichedKeyInfo {
   name: string;
   type: string;
@@ -366,11 +370,11 @@ export async function getKeyInfo(
       return keyInfo
     }
 
-    if (memoryUsage > VALKEY_CLIENT.KEY_VALUE_SIZE_LIMIT) {
+    if (memoryUsage > keyValueSizeLimitBytes) {
       if (commands.sizeCmd){
         keyInfo.collectionSize = await (client.customCommand([commands.sizeCmd, key])) as number
       }
-      keyInfo.elementsWarning = `This key is ${formatBytes(memoryUsage)}, which is larger than the maximum display size of ${formatBytes(VALKEY_CLIENT.KEY_VALUE_SIZE_LIMIT)}.`
+      keyInfo.elementsWarning = `This key is ${formatBytes(memoryUsage)}, which is larger than the maximum display size of ${formatBytes(keyValueSizeLimitBytes)}.`
 
       return keyInfo
     }

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -156,7 +156,7 @@ export const VALKEY_CLIENT = {
   } ,
   // chunk size for paginating elements to avoid blocking due to keys with too many elements
   ELEMENT_PAGE_SIZE: 50, 
-  KEY_VALUE_SIZE_LIMIT: 2048, // 2KiB
+  KEY_VALUE_SIZE_LIMIT_BYTES: 2048, // 2KiB
   MESSAGES: {
     NOT_READABLE: "Not human readable.",
   },

--- a/docker/description.md
+++ b/docker/description.md
@@ -81,6 +81,7 @@ Here are all the relevant environment variables for configuration
 | `VALKEY_AUTH_TYPE` | Authentication type (`password`, `iam`) | `password` |
 | `HOT_KEYS_COUNT` | Maximum hot keys returned per query | `50` |
 | `COMMAND_LOGS_COUNT` | Maximum command log entries returned per query | `100` |
+| `KEY_VALUE_SIZE_LIMIT_BYTES` | Max value size (bytes) shown in the Key Browser before a size warning | `2048` |
 | `CONFIG_PATH` | Path to custom metrics config.yml | — |
 
 ### Custom metrics configuration

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,3 +7,4 @@ services:
       - "8080:8080"
     environment:
       NODE_ENV: production
+      KEY_VALUE_SIZE_LIMIT_BYTES: 2048

--- a/docs-site/src/content/docs/configuration/server.md
+++ b/docs-site/src/content/docs/configuration/server.md
@@ -174,6 +174,13 @@ Maximum number of command log entries (slow logs, large requests, large replies)
 - **Default:** `100`
 - **Read in:** `apps/server/src/actions/commandLogs.ts`
 
+### `KEY_VALUE_SIZE_LIMIT_BYTES`
+
+Maximum value size (in bytes) the Key Browser will render. Keys larger than this show a size warning instead of their contents.
+
+- **Default:** `2048`
+- **Read in:** `apps/server/src/keys-browser.ts`
+
 ## Electron Packaging
 
 This variable is set automatically when the server runs as part of the Electron desktop app. It tells the server where to find bundled assets that live outside the workspace `node_modules` layout. You generally do not need to touch it by hand.


### PR DESCRIPTION
…mpose

## Description

Include a summary of the change.

1. Exposing KEY_VALUE_SIZE_LIMIT_BYTES as an env in docker compose
2. Adjusted the name from KEY_VALUE_SIZE_LIMIT to KEY_VALUE_SIZE_LIMIT_BYTES for better clarity 
3. Updated the docs to reflect the changes

### Change Visualization

Include a screenshot/video of before and after the change.
