### PR TITLE
Set NodeDiscoveryMode to Static in client creation

### DIFF
--- a/apps/metrics/src/valkey-client.js
+++ b/apps/metrics/src/valkey-client.js
@@ -1,4 +1,4 @@
-import { GlideClient, GlideClusterClient, ServiceType } from "@valkey/valkey-glide"
+import { GlideClient, GlideClusterClient, ServiceType, NodeDiscoveryMode } from "@valkey/valkey-glide"
 
 const SUPPORTED_VALKEY_MODES = new Set(["standalone", "cluster"])
 
@@ -60,5 +60,6 @@ export const createValkeyClient = async (cfg = {}) => {
     : GlideClient.createClient({
       ...sharedOptions,
       clientName: "valkey_admin_metrics_standalone_client",
+      nodeDiscoveryMode: NodeDiscoveryMode.Static
     })
 }

--- a/apps/metrics/src/valkey-client.js
+++ b/apps/metrics/src/valkey-client.js
@@ -60,6 +60,6 @@ export const createValkeyClient = async (cfg = {}) => {
     : GlideClient.createClient({
       ...sharedOptions,
       clientName: "valkey_admin_metrics_standalone_client",
-      nodeDiscoveryMode: NodeDiscoveryMode.Static
+      nodeDiscoveryMode: NodeDiscoveryMode.Static,
     })
 }

--- a/apps/metrics/src/valkey-client.test.js
+++ b/apps/metrics/src/valkey-client.test.js
@@ -12,7 +12,7 @@ vi.mock("@valkey/valkey-glide", () => ({
   GlideClusterClient: {
     createClient: glideMocks.clusterCreateClient,
   },
-  NodeDiscoveryMode: { Standard: 0, Static: 1, DiscoverAll: 2 }
+  NodeDiscoveryMode: { Standard: 0, Static: 1, DiscoverAll: 2 },
 }))
 
 describe("valkey client mode selection", () => {

--- a/apps/metrics/src/valkey-client.test.js
+++ b/apps/metrics/src/valkey-client.test.js
@@ -12,6 +12,7 @@ vi.mock("@valkey/valkey-glide", () => ({
   GlideClusterClient: {
     createClient: glideMocks.clusterCreateClient,
   },
+  NodeDiscoveryMode: { Standard: 0, Static: 1, DiscoverAll: 2 }
 }))
 
 describe("valkey client mode selection", () => {

--- a/apps/server/src/valkey-client.ts
+++ b/apps/server/src/valkey-client.ts
@@ -1,4 +1,4 @@
-import { GlideClient, GlideClusterClient, type ServerCredentials } from "@valkey/valkey-glide"
+import { GlideClient, GlideClusterClient, NodeDiscoveryMode, type ServerCredentials } from "@valkey/valkey-glide"
 
 type Address = {
   host: string
@@ -46,6 +46,7 @@ export const createStandaloneValkeyClient = ({
   GlideClient.createClient({
     ...buildSharedOptions(options),
     clientName: "valkey_admin_standalone_client",
+    nodeDiscoveryMode: NodeDiscoveryMode.Static
   })
 
 export const createClusterValkeyClient = ({
@@ -62,4 +63,5 @@ export const createOrchestratorValkeyClient = ({
   GlideClient.createClient({
     ...buildSharedOptions(options),
     clientName: "valkey_admin_orchestrator_client",
+    nodeDiscoveryMode: NodeDiscoveryMode.Static
   })

--- a/apps/server/src/valkey-client.ts
+++ b/apps/server/src/valkey-client.ts
@@ -46,7 +46,7 @@ export const createStandaloneValkeyClient = ({
   GlideClient.createClient({
     ...buildSharedOptions(options),
     clientName: "valkey_admin_standalone_client",
-    nodeDiscoveryMode: NodeDiscoveryMode.Static
+    nodeDiscoveryMode: NodeDiscoveryMode.Static,
   })
 
 export const createClusterValkeyClient = ({
@@ -63,5 +63,5 @@ export const createOrchestratorValkeyClient = ({
   GlideClient.createClient({
     ...buildSharedOptions(options),
     clientName: "valkey_admin_orchestrator_client",
-    nodeDiscoveryMode: NodeDiscoveryMode.Static
+    nodeDiscoveryMode: NodeDiscoveryMode.Static,
   })


### PR DESCRIPTION
## Description

Prior to this change, GlideClient connections intermittently failed with "No primary node found" when connecting to large clusters. Setting the NodeDiscoveryMode to STATIC fixes the issue. See https://github.com/valkey-io/valkey-glide/issues/5809 for more details.

The clustercfg.* endpoint round-robins DNS across all nodes. In STANDARD mode, the client checks INFO REPLICATION to find the primary, but when it lands on a replica, it can't locate a primary in its address list and errors out. STATIC mode skips this check entirely, just uses whatever node it gets, and relies on MOVED redirects for routing. 
### Change Visualization

Used a script to test the change. Before the change 5/20 attempts failed. After the change 20/20 attempts succeeded. 
