### PR TITLE
commands with no parameters will no longer get a trailing space and t…

### DIFF
--- a/apps/frontend/src/components/send-command/SendCommand.tsx
+++ b/apps/frontend/src/components/send-command/SendCommand.tsx
@@ -57,7 +57,9 @@ export function SendCommand() {
   }
 
   const acceptSuggestion = (cmd: ValkeyCommand) => {
-    setText(cmd.name + " ")
+    // add a trailing space only when the command actually has paramters
+    const needsArgs = cmd.parameters.some((p) => p.required)
+    setText(needsArgs ? cmd.name + " " : cmd.name)
     setSuggestionsDismissed(true)
     setSuggestionIndex(0)
     textareaRef.current?.focus()

--- a/apps/server/src/send-command.ts
+++ b/apps/server/src/send-command.ts
@@ -13,7 +13,8 @@ export async function sendValkeyRunCommand(
   payload: { command: string; connectionId: string },
 ) {
   try {
-    const response = await client.customCommand(payload.command.split(" "))
+    // split on whitespace, ignoring extra/leading/trailing spaces
+    const response = await client.customCommand(payload.command.trim().split(/\s+/))
     const isError = isRequestError(response)
 
     ws.send(


### PR DESCRIPTION
…he ones with parameter will do

## Description

- Commands like info do not need a trailing space and the space was causing Valkey not to return the command with no results
- Command like HGETALL needs parameters like Key name and etc. So adding a trailing space save the user from extra key stroke

Include a summary of the change.

### Change Visualization

Include a screenshot/video of before and after the change.
