### PR TITLE
Add preconfigured metrics server for standalone

### DIFF
--- a/apps/server/src/__tests__/metrics-orchestrator.test.ts
+++ b/apps/server/src/__tests__/metrics-orchestrator.test.ts
@@ -238,11 +238,9 @@ describe("metrics-orchestrator", () => {
   })
 
   describe("reconcileClusterMetricsServers", () => {
-    let connectionDetails: ConnectionDetails
 
     beforeEach(() => {
       metricsServerMap.clear()
-      connectionDetails = { host: "127.0.0.1", port: "6379", tls: false, verifyTlsCertificate: false, endpointType: "node", db: 0 }
 
       // Mock all side-effectful internal functions
       mock.method(__test__, "createClient", async () => ({}))
@@ -260,10 +258,11 @@ describe("metrics-orchestrator", () => {
       mock.restoreAll()
     })
 
-    it("should discover cluster if registry is empty", async () => {
+    it("should early return if registry is empty", async () => {
+      const emptyRegistry = {}
       await reconcileClusterMetricsServers(
-        mockClusterNodesRegistry,metricsServerMap, connectionDetails)
-      assert.ok(mockClusterNodesRegistry["cluster-1"])
+        emptyRegistry, metricsServerMap)
+      assert.strictEqual(Object.keys(emptyRegistry).length, 0)
     })
 
     it("should early return if nothing changed", async () => {
@@ -273,7 +272,7 @@ describe("metrics-orchestrator", () => {
         node1: { host: "127.0.0.1", port: 6379, tls: false, verifyTlsCertificate: false },
       }
       await reconcileClusterMetricsServers(
-        mockClusterNodesRegistry,metricsServerMap, connectionDetails)
+        mockClusterNodesRegistry,metricsServerMap)
       // updateMetricsServers should not be called because nothing changed
     })
   })

--- a/apps/server/src/__tests__/metrics-orchestrator.test.ts
+++ b/apps/server/src/__tests__/metrics-orchestrator.test.ts
@@ -7,7 +7,6 @@ import {
   stopAllMetricsServers,
   reconcileClusterMetricsServers,
   clients,
-  clusterNodesRegistry,
   __test__,
   type ClusterNodeMap, 
   type MetricsServerMap 
@@ -150,35 +149,20 @@ describe("metrics-orchestrator", () => {
     // })
   })
 
-  describe("isKnownClusterNode", () => {
+  describe("register endpoint", () => {
     afterEach(() => {
       mock.restoreAll()
-      for (const key in clusterNodesRegistry) {
-        delete clusterNodesRegistry[key]
-      }
+      metricsServerMap.clear()
     })
 
-    it("should recognize replica node ids by sanitized host-port", () => {
-      clusterNodesRegistry["cluster-1"] = {
-        "valkey-0-valkey-headless-valkey-svc-cluster-local-6379": {
-          host: "valkey-0.valkey-headless.valkey.svc.cluster.local",
-          port: 6379,
-          tls: false,
-          verifyTlsCertificate: false,
-          replicas: [
-            {
-              id: "raw-replica-node-id",
-              host: "valkey-5.valkey-headless.valkey.svc.cluster.local",
-              port: 6379,
-            },
-          ],
-        },
-      }
+    it("should accept registration when nodeId exists in metricsServerMap", () => {
+      metricsServerMap.set("127-0-0-1-6379", { metricsURI: "", pid: 123, lastSeen: Date.now() })
 
-      assert.strictEqual(
-        __test__.isKnownClusterNode("valkey-5-valkey-headless-valkey-svc-cluster-local-6379"),
-        true,
-      )
+      assert.strictEqual(metricsServerMap.has("127-0-0-1-6379"), true)
+    })
+
+    it("should reject registration when nodeId is not in metricsServerMap", () => {
+      assert.strictEqual(metricsServerMap.has("unknown-node-6379"), false)
     })
   })
 

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -301,7 +301,7 @@ async function connectToValkeyLocked(
         clusterNodesRegistry[clusterId] = discoveredClusterNodes
 
         if (isWebMode) {
-          reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap, payload.connectionDetails)
+          reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap)
         }
 
         await commitClusterConnection(ctx, ws, {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -30,14 +30,14 @@ import { teardownConnection } from "./connection"
 import { Handler, ReduxAction, unknownHandler, type WsActionMessage } from "./actions/utils"
 import {
   createMetricsOrchestratorRouter,
-  reconcileClusterMetricsServers,
+  startPreconfiguredMetricsServers,
   metricsServerMap,
   clusterNodesRegistry,
   initialConnectionDetails,
   cleanupOrchestratorResources,
   clients,
-  isWebMode,
   isKubernetes,
+  preConfiguredConnection,
   getInitialClient,
   updateClusterNodeRegistry
 } from "./metrics-orchestrator"
@@ -109,19 +109,6 @@ const wss = new WebSocketServer({ noServer: true })
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
-async function runReconcileLoop() {
-
-  while (true) {
-    try {
-      await reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap, initialConnectionDetails)
-      await delay(10000)
-    } catch (err) {
-      console.error("Failed to reconcile metrics servers", err)
-      await delay(10000)
-    }
-  }
-}
-
 async function refreshAllClusterRegistries() {
   await Promise.all(
     Object.entries(clusterNodesRegistry).map(async ([clusterId]) => {
@@ -166,10 +153,10 @@ server.listen(port, () => {
   }
   refreshAllClusterRegistriesLoop()
 
-  if (isWebMode) {
-    runReconcileLoop()
+  if (preConfiguredConnection) {
+    startPreconfiguredMetricsServers()
   }
-  else if (isKubernetes) {
+  if (isKubernetes) {
     updateRegistryforK8()
   }
 })

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -83,15 +83,6 @@ export const initialConnectionDetails: ConnectionDetails = {
 
 const ttl = Number(process.env.TTL) || 60000
 
-function isKnownClusterNode(nodeId: string) {
-  return Object.values(clusterNodesRegistry).some((clusterNodes) =>
-    Object.entries(clusterNodes).some(([primaryNodeId, primaryNode]) =>
-      primaryNodeId === nodeId ||
-      primaryNode.replicas?.some((replica) => sanitizeUrl(`${replica.host}-${replica.port}`) === nodeId),
-    ),
-  )
-}
-
 // Reconciliation works on flat node ids, but cluster discovery stores replicas under their primary.
 function flattenClusterNodeMap(clusterNodeMap: ClusterNodeMap): ClusterNodeMap {
   return Object.entries(clusterNodeMap).reduce((acc, [primaryNodeId, primaryNode]) => {
@@ -117,16 +108,7 @@ export function createMetricsOrchestratorRouter() {
   router.post("/register", (req: Request, res: Response) => {
     const { metricsServerUri, nodeId, pid } = req.body
 
-    const nodeBelongsToCluster = isKnownClusterNode(nodeId)
-    // `clients` keys are Connection_Identifiers with `-db<N>`; the incoming
-    // `nodeId` is a metrics-node-id with no `db`. Match on the stripped form
-    // so any open user-visible connection under this node counts as a valid
-    // client.
-    const nodeConnected = [...clients.keys()].some(
-      (id) => toNodeId(id) === nodeId,
-    )
-
-    if (nodeBelongsToCluster || nodeConnected)  {
+    if (metricsServerMap.has(nodeId))  {
       const now = Date.now()  
       const entry = metricsServerMap.get(nodeId)
       console.log(`Metrics server registered for ${nodeId} at ${metricsServerUri}`)
@@ -435,7 +417,6 @@ const internals =  {
   getClusterTopology,
   updateClusterNodeRegistry,
   findDiff,
-  isKnownClusterNode,
   flattenClusterNodeMap,
   updateMetricsServers,
   stopMetricsServers,

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from "url"
 import { Router, type Request, type Response } from "express"
 import path from "path"
 import { DEPLOYMENT_TYPE, sanitizeUrl, toNodeId } from "valkey-common"
-import { discoverCluster } from "./connection"
+import { discoverCluster, belongsToCluster } from "./connection"
 import { ConnectionDetails } from "./actions/connection"
 import { createOrchestratorValkeyClient } from "./valkey-client"
 
@@ -31,7 +31,7 @@ export type MetricsServerMap = Map<string,
   }
 >
 
-type ClusterNodeInfo = {
+type NodeInfo = {
   host: string;
   port: number | string;
   username?: string;
@@ -44,7 +44,7 @@ type ClusterNodeInfo = {
   awsReplicationGroupId?: string;
 }
 
-export type ClusterNodeMap = Record<string, ClusterNodeInfo>;
+export type ClusterNodeMap = Record<string, NodeInfo>;
 
 export interface ClusterRegistry {
   [clusterId: string]: ClusterNodeMap
@@ -280,7 +280,7 @@ export async function stopAllMetricsServers(metricsMap: MetricsServerMap) {
   metricsMap.clear()
 }
 
-export async function startMetricsServer(nodeToStart: ClusterNodeInfo, nodeId: string) {
+export async function startMetricsServer(nodeToStart: NodeInfo, nodeId: string) {
   const processResourcesPath = process.env.PROCESS_RESOURCES_PATH  ?? ""
   const metricsServerPath = isElectron
     ? path.join(processResourcesPath, "server-metrics.js")
@@ -363,39 +363,58 @@ async function stopMetricsServer(nodeToStop: string) {
 export async function reconcileClusterMetricsServers(
   clusterNodesRegistry: ClusterRegistry, 
   metricsServerMap: MetricsServerMap, 
-  connectionDetails: ConnectionDetails, 
 ) {
-  let clusterIds = Object.keys(clusterNodesRegistry)
-  // Start metrics server for all nodes if it is preconfigured before manual connection
-  if (clusterIds.length === 0 && preConfiguredConnection) {
-    try {
-      const client = await getInitialClient()
-      const { discoveredClusterNodes, clusterId } = await internals.getClusterTopology(client, connectionDetails)
-      if (clusterId && discoveredClusterNodes) {
-        clusterNodesRegistry[clusterId] = discoveredClusterNodes 
-        if (!clusterCredentials.has(clusterId)) clusterCredentials.set(clusterId, initialConnectionDetails.password)
-      } 
-      clusterIds = Object.keys(clusterNodesRegistry)
-    } catch (err) {
-      console.error(err)
-    }
-  }
-  else if (clusterIds.length > 0) {
-    await Promise.all(
-      clusterIds.map(async (clusterId) => {
-        try {
-          const { nodesToAdd, nodesToRemove } = await internals.findDiff(metricsServerMap, clusterNodesRegistry[clusterId])
-          // Early return if nothing has changed
-          if (Object.keys(nodesToAdd).length === 0 && nodesToRemove.length === 0) {
-            console.debug("Cluster nodes and metrics servers are in sync")
-            return
-          }
-          await internals.updateMetricsServers(nodesToAdd, nodesToRemove, clusterId)
-        } catch (err) {
-          console.error(`Failed to reconcile metrics servers for cluster ${clusterId}:`, err)
+  const clusterIds = Object.keys(clusterNodesRegistry)
+  if (clusterIds.length === 0) return
+
+  await Promise.all(
+    clusterIds.map(async (clusterId) => {
+      try {
+        const { nodesToAdd, nodesToRemove } = await internals.findDiff(metricsServerMap, clusterNodesRegistry[clusterId])
+        // Early return if nothing has changed
+        if (Object.keys(nodesToAdd).length === 0 && nodesToRemove.length === 0) {
+          console.debug("Cluster nodes and metrics servers are in sync")
+          return
         }
-      }),
-    )
+        await internals.updateMetricsServers(nodesToAdd, nodesToRemove, clusterId)
+      } catch (err) {
+        console.error(`Failed to reconcile metrics servers for cluster ${clusterId}:`, err)
+      }
+    }),
+  )
+}
+
+export async function startPreconfiguredStandaloneMetricsServer() {
+  const nodeId = sanitizeUrl(`${initialConnectionDetails.host}-${initialConnectionDetails.port}`)
+  await startMetricsServer(initialConnectionDetails, nodeId)
+}
+
+export async function startPreconfiguredMetricsServers() {
+  const client = await getInitialClient()
+  if (await belongsToCluster(client)) {
+    if (isWebMode) {
+      const { discoveredClusterNodes, clusterId } = await internals.getClusterTopology(client, initialConnectionDetails)
+      if (clusterId && discoveredClusterNodes) {
+        clusterNodesRegistry[clusterId] = discoveredClusterNodes
+        if (!clusterCredentials.has(clusterId)) clusterCredentials.set(clusterId, initialConnectionDetails.password)
+      }
+      runReconcileLoop()
+    }
+  } else if (!isKubernetes) {
+    await startPreconfiguredStandaloneMetricsServer()
+  }
+}
+
+export async function runReconcileLoop() {
+  const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
+  while (true) {
+    try {
+      await reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap)
+      await delay(10000)
+    } catch (err) {
+      console.error("Failed to reconcile metrics servers", err)
+      await delay(10000)
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Extracts preconfigured connection logic into explicit methods in the orchestrator. A new startPreconfiguredMetricsServers() entry point checks whether the preconfigured connection is a cluster or standalone, then takes the appropriate path: 
1. for clusters in web mode it discovers topology, populates the registry, and starts the reconcile loop
2. for standalone nodes it starts a single metrics server directly regardless of web or electron modes
3. for Kubernetes mode it's a no-op since sidecars handle metrics collection.
  
reconcileClusterMetricsServers now only diffs the registry against running metrics servers and starts/stops as needed. Discovery is now a setup concern handled before the loop starts. The reconcile loop and NodeInfo type (renamed from ClusterNodeInfo) were moved to the orchestrator to reduce noise in index.ts.

### Change Visualization

Include a screenshot/video of before and after the change.
