### PR TITLE
Document Homebrew cask install for the desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For the full walkthrough see the [connection docs](https://valkey-admin.valkey.i
 
 **Install:**
 
-- **Desktop (macOS / Linux)** — Download from [GitHub Releases](https://github.com/valkey-io/valkey-admin/releases). See the [Desktop deployment guide](https://valkey-admin.valkey.io/deployment/desktop/).
+- **Desktop (macOS / Linux)** — On macOS, install with [Homebrew](https://brew.sh): `brew install --cask valkey-admin`. Otherwise download from [GitHub Releases](https://github.com/valkey-io/valkey-admin/releases). See the [Desktop deployment guide](https://valkey-admin.valkey.io/deployment/desktop/).
 - **Docker** — Images published to GHCR, Docker Hub, and ECR Public. See the [Docker deployment guide](https://valkey-admin.valkey.io/deployment/docker/).
 - **Kubernetes** — Sidecar-based deployment for cluster-scale collection. See the [Kubernetes deployment guide](https://valkey-admin.valkey.io/deployment/kubernetes/).
 - **AWS ElastiCache** — See the [AWS ElastiCache guide](https://valkey-admin.valkey.io/deployment/aws-elasticache/).

--- a/docs-site/src/content/docs/deployment/desktop.md
+++ b/docs-site/src/content/docs/deployment/desktop.md
@@ -15,7 +15,13 @@ Choose the desktop app when you:
 
 ## Installation
 
-Download the latest release from [GitHub Releases](https://github.com/valkey-io/valkey-admin/releases):
+On macOS, install with [Homebrew](https://brew.sh):
+
+```sh
+brew install --cask valkey-admin
+```
+
+Or download the latest release from [GitHub Releases](https://github.com/valkey-io/valkey-admin/releases):
 
 - **macOS:** Download the `.dmg` file, open it, and drag Valkey Admin to Applications
 - **Linux:** Download the `.AppImage` or `.deb` package


### PR DESCRIPTION
## Description

Homebrew now has a `valkey-admin` cask, so `brew install --cask valkey-admin` installs the desktop app on macOS (1.0.1, macOS 12+):

- https://github.com/Homebrew/homebrew-cask/pull/271913

The README Install section and the desktop deployment guide currently point only to the GitHub Releases `.dmg`. This change adds the Homebrew command next to the existing download in both places.

Two files change:

- `README.md`: the Desktop bullet under Install mentions `brew install --cask valkey-admin` for macOS and keeps the GitHub Releases link.
- `docs-site/src/content/docs/deployment/desktop.md`: the Installation section lists Homebrew as the macOS option before the `.dmg` download.

### Change Visualization

This is a documentation-only change, so there is no UI to capture. The rendered result:

- README Install, Desktop: "On macOS, install with Homebrew: `brew install --cask valkey-admin`. Otherwise download from GitHub Releases."
- Desktop deployment guide, Installation: leads with the `brew install --cask valkey-admin` code block, then the existing GitHub Releases download list for the `.dmg`, `.AppImage`, and `.deb`.

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
