### PR TITLE
 Fix command parsing for quoted keys and binary value display

### DIFF
--- a/apps/server/src/__tests__/keys-browser.test.ts
+++ b/apps/server/src/__tests__/keys-browser.test.ts
@@ -59,6 +59,31 @@ describe("getKeyInfo", () => {
       assert.strictEqual(result.size, -1)
     })
 
+    it("should display binary values as hex when decoding fails", async () => {
+      const mockClient = {
+        customCommand: mock.fn(async (cmd: string[], options?: any) => {
+          const key = cmd[0]
+          if (key === "TYPE") return "string"
+          if (key === "TTL") return -1
+          if (key === "MEMORY") return 4
+          if (key === "GET") {
+            if (options?.decoder !== undefined) {
+              // Second call with Decoder.Bytes — return a Buffer
+              return Buffer.from([0x80, 0x00, 0x80, 0x88])
+            }
+            // First call with default decoder — throw decoding error
+            throw new Error("Decoding error: 'Error: invalid utf-8 sequence of 1 bytes from index 0'")
+          }
+          return null
+        }),
+      }
+
+      const result = await getKeyInfo(mockClient as any, "mykey")
+
+      assert.strictEqual(result.elements, "\\x80\\x00\\x80\\x88")
+      assert.strictEqual(result.elementsWarning, undefined)
+    })
+
   })
 
   describe("hash keys", () => {

--- a/apps/server/src/__tests__/send-command.test.ts
+++ b/apps/server/src/__tests__/send-command.test.ts
@@ -3,7 +3,7 @@ import { describe, it, mock, beforeEach } from "node:test"
 import assert from "node:assert"
 import { ConnectionError, TimeoutError, ClosingError } from "@valkey/valkey-glide"
 import { VALKEY } from "valkey-common"
-import { sendValkeyRunCommand } from "../send-command"
+import { sendValkeyRunCommand, parseCommandArgs } from "../send-command"
 
 describe("sendValkeyRunCommand", () => {
   let mockWs: any
@@ -194,5 +194,50 @@ describe("sendValkeyRunCommand", () => {
     assert.deepStrictEqual(mockClient.customCommand.mock.calls[0].arguments, [
       ["SET", "mykey", "myvalue", "EX", "3600"],
     ])
+  })
+})
+
+describe("parseCommandArgs", () => {
+  it("should split simple commands on whitespace", () => {
+    assert.deepStrictEqual(parseCommandArgs("GET mykey"), ["GET", "mykey"])
+    assert.deepStrictEqual(parseCommandArgs("SET key value"), ["SET", "key", "value"])
+  })
+
+  it("should handle double-quoted arguments", () => {
+    assert.deepStrictEqual(
+      parseCommandArgs("TYPE \"seatmap:RIPC-UJGD-KLZC-ULGG:General:IZ\""),
+      ["TYPE", "seatmap:RIPC-UJGD-KLZC-ULGG:General:IZ"],
+    )
+  })
+
+  it("should handle keys with spaces inside quotes", () => {
+    assert.deepStrictEqual(parseCommandArgs("GET \"my key\""), ["GET", "my key"])
+  })
+
+  it("should handle single-quoted arguments", () => {
+    assert.deepStrictEqual(parseCommandArgs("SET 'my key' 'my value'"), ["SET", "my key", "my value"])
+  })
+
+  it("should handle escaped quotes within quoted strings", () => {
+    assert.deepStrictEqual(
+      parseCommandArgs("SET key \"hello\\\"world\""),
+      ["SET", "key", "hello\"world"],
+    )
+  })
+
+  it("should handle extra whitespace", () => {
+    assert.deepStrictEqual(parseCommandArgs("  GET   mykey  "), ["GET", "mykey"])
+  })
+
+  it("should return empty array for empty string", () => {
+    assert.deepStrictEqual(parseCommandArgs(""), [])
+    assert.deepStrictEqual(parseCommandArgs("   "), [])
+  })
+
+  it("should handle commands with multiple arguments", () => {
+    assert.deepStrictEqual(
+      parseCommandArgs("MSET key1 val1 key2 val2"),
+      ["MSET", "key1", "val1", "key2", "val2"],
+    )
   })
 })

--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -7,6 +7,7 @@ import {
   ConnectionError, 
   TimeoutError, 
   ClosingError, 
+  Decoder,
   GlideReturnType
 } from "@valkey/valkey-glide"
 import pLimit from "p-limit"
@@ -325,7 +326,15 @@ async function getFullKeyInfo(
     console.log(`Could not get elements for key ${keyInfo.name}:`, err)
     // Valkey client uses String decoder, which throws this error when it encounters non-UTF-8 bytes
     if (err instanceof Error && err.message.includes("Decoding error")) {
-      return { ...keyInfo, elementsWarning: VALKEY_CLIENT.MESSAGES.NOT_READABLE }
+      try {
+        const raw = await client.customCommand(commands.elementsCmd, { decoder: Decoder.Bytes }) as Buffer
+        const hex = Buffer.from(raw).reduce((s, byte) =>
+          s + (byte >= 0x20 && byte <= 0x7e ? String.fromCharCode(byte) : "\\x" + byte.toString(16).padStart(2, "0")), "",
+        )
+        return { ...keyInfo, elements: hex }
+      } catch {
+        return { ...keyInfo, elementsWarning: VALKEY_CLIENT.MESSAGES.NOT_READABLE }
+      }
     }
     return keyInfo
   }

--- a/apps/server/src/send-command.ts
+++ b/apps/server/src/send-command.ts
@@ -7,14 +7,21 @@ export const isRequestError = (x: unknown): x is Error | string =>
   x instanceof Error ||
   (typeof x === "string" && x.startsWith("ResponseError:"))
 
+/**
+ * Parses a command string into arguments, respecting quoted strings and escaped quotes.
+ * Matches valkey-cli behavior: 'GET "my key"' → ['GET', 'my key']
+ */
+export const parseCommandArgs = (command: string): string[] =>
+  command.trim().match(/(?:[^\s"']+|"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')+/g)
+    ?.map((arg) => arg.replace(/^["']|["']$/g, "").replace(/\\(["'])/g, "$1")) ?? []
+
 export async function sendValkeyRunCommand(
   client: GlideClient | GlideClusterClient,
   ws: WebSocket,
   payload: { command: string; connectionId: string },
 ) {
   try {
-    // split on whitespace, ignoring extra/leading/trailing spaces
-    const response = await client.customCommand(payload.command.trim().split(/\s+/))
+    const response = await client.customCommand(parseCommandArgs(payload.command))
     const isError = isRequestError(response)
 
     ws.send(


### PR DESCRIPTION
## Description

Send Command now correctly handles quoted arguments (e.g., TYPE "my:key") by parsing quotes like valkey-cli instead of passing them as part of the key name. Previously, quotes were included literally in the command arguments, causing key lookups to fail with "none."

For keys with binary (non-UTF-8) values, the Key Browser now retries with a binary decoder and displays the value in hex notation (\x80\x00\x80\x88) instead of showing "Not human readable." Printable ASCII bytes are shown as-is, matching valkey-cli's --no-raw behavior.

### Change Visualization

Include a screenshot/video of before and after the change.
