### PR TITLE
decline helmet default values for "upgrade-insecure-requests"

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -81,6 +81,7 @@ app.use((req, res, next) => {
 // Content Security Policy via helmet
 app.use(helmet({
   contentSecurityPolicy: {
+    useDefaults: false,
     directives: {
       defaultSrc: ["'self'"],
       scriptSrc: ["'self'"],


### PR DESCRIPTION
## Description

Fixes issue 384 - by declining the helmet default Content-Security-Policy values we take only what we declare, and do not pull in the default "upgrade-insecure-requests".

This fixes a regression in behaviour from 1.0.x to edge, not seen when testing is only done against http://localhost:8080 or http://127.0.0.1:8080/
