### PR TITLE
Fix Electron CSP and cluster metrics server startup

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost:* http://localhost:*; img-src 'self' data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';" />
     <link rel="icon" href="./assets/img/favicon-32x32.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Valkey Admin</title>

--- a/apps/frontend/src/components/activity-view/bigkeys/big-keys.tsx
+++ b/apps/frontend/src/components/activity-view/bigkeys/big-keys.tsx
@@ -57,7 +57,7 @@ export function BigKeys({
     filtered,
   )
 
-  const banner = nodeErrors && nodeErrors.length > 0 && <NodeErrorsBanner nodeErrors={nodeErrors} />
+  const banner = nodeErrors && nodeErrors.length > 0 && <NodeErrorsBanner label="Big keys" nodeErrors={nodeErrors} />
 
   if (allKeys.length === 0) {
     return (

--- a/apps/frontend/src/components/activity-view/command-log-table.tsx
+++ b/apps/frontend/src/components/activity-view/command-log-table.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react"
-import { Clock, AlertCircle, ChevronDown, ChevronUp } from "lucide-react"
+import { Clock } from "lucide-react"
 import * as R from "ramda"
 import { SORT_ORDER, SORT_FIELD } from "@common/src/constants"
 import { truncateText } from "@common/src/truncate-text"
-import { Alert, AlertDescription } from "../ui/alert"
 import { EmptyState } from "../ui/empty-state"
 import { TableContainer } from "../ui/table-container"
 import { SortableTableHeader, StaticTableHeader } from "../ui/sortable-table-header"
 import { Typography } from "../ui/typography"
 import { CustomTooltip } from "../ui/tooltip"
+import { NodeErrorsBanner } from "./hotkeys/hot-keys-banners"
 import { NodeFilterDropdown } from "./hotkeys/node-filter-dropdown"
 
 type SortOrder = typeof SORT_ORDER.ASC | typeof SORT_ORDER.DESC
@@ -78,40 +78,11 @@ const logTypeConfig = {
 export function CommandLogTable({ data, logType, nodeErrors, isCluster }: CommandLogTableProps) {
   const [sortField, setSortField] = useState<SortField>(SORT_FIELD.METRIC)
   const [sortOrder, setSortOrder] = useState<SortOrder>(SORT_ORDER.DESC)
-  const [nodeErrorsExpanded, setNodeErrorsExpanded] = useState(false)
   const [selectedNode, setSelectedNode] = useState("all")
   const config = logTypeConfig[logType]
 
   const nodeErrorsBanner = nodeErrors && nodeErrors.length > 0 && (
-    <div className="m-3 relative">
-      <Alert
-        className="cursor-pointer"
-        onClick={() => setNodeErrorsExpanded((prev) => !prev)}
-        variant="warning"
-      >
-        <AlertDescription className="flex items-center gap-2">
-          <AlertCircle className="h-4 w-4" />
-          Command log data is partial — {nodeErrors.length} node{nodeErrors.length > 1 ? "s " : " "}
-          failed to respond or {nodeErrors.length > 1 ? "are" : "is"} not connected
-          {nodeErrorsExpanded
-            ? <ChevronUp className="w-4 h-4 shrink-0 ml-auto" />
-            : <ChevronDown className="w-4 h-4 shrink-0 ml-auto" />
-          }
-        </AlertDescription>
-      </Alert>
-      {nodeErrorsExpanded && (
-        <ul className="absolute z-50 left-0 mt-0.5 right-0 p-3 max-h-40 overflow-y-auto space-y-0.5
-           rounded-md border bg-accent shadow-sm">
-          {nodeErrors.map(({ nodeId, error }) => (
-            <li key={nodeId}>
-              <Typography variant="bodySm">
-                <span className="font-mono">{nodeId}</span>: {error}
-              </Typography>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
+    <NodeErrorsBanner label="Command log" nodeErrors={nodeErrors} />
   )
 
   const toggleSort = (field: SortField) => {

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-banners.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-banners.tsx
@@ -5,9 +5,10 @@ import { Typography } from "../../ui/typography"
 
 interface NodeErrorsBannerProps {
   nodeErrors: { nodeId: string; error: string }[]
+  label?: string
 }
 
-export function NodeErrorsBanner({ nodeErrors }: NodeErrorsBannerProps) {
+export function NodeErrorsBanner({ nodeErrors, label = "Hot keys" }: NodeErrorsBannerProps) {
   const [expanded, setExpanded] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -33,7 +34,7 @@ export function NodeErrorsBanner({ nodeErrors }: NodeErrorsBannerProps) {
       >
         <AlertDescription className="flex items-center gap-2">
           <AlertCircle className="h-4 w-4" />
-          Hot keys data is partial — {nodeErrors.length} node{nodeErrors.length > 1 ? "s " : " "}
+          {label} data is partial — {nodeErrors.length} node{nodeErrors.length > 1 ? "s " : " "}
           failed to respond or {nodeErrors.length > 1 ? "are" : "is"} not connected
           {expanded
             ? <ChevronUp className="w-4 h-4 shrink-0 ml-auto" />

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -237,6 +237,15 @@ async function connectToValkeyLocked(
     // The finally block below ensures we close this gate on every exit path.
     clients.set(connectionId, { client: standaloneClient })
 
+    // Start metrics server for the connected node before cluster detection.
+    // The spawn is independent of the probe client and does not affect SELECT gating.
+    if (!isKubernetes) {
+      const metricsNodeId = toNodeId(connectionId)
+      if (!metricsServerMap.has(metricsNodeId)) {
+        await startMetricsServer(payload.connectionDetails, metricsNodeId)
+      }
+    }
+
     // Detect cluster mode and Server_Version on the probe BEFORE issuing any
     // `SELECT`. This is required for cluster gating: cluster nodes reject
     // `SELECT N` for any N (even 0), so we cannot bind the probe to a `db`
@@ -365,17 +374,6 @@ async function connectToValkeyLocked(
       throw new ConnectionRejectedError(
         `Database_Index ${db} is out of range (server allows 0..${databasesCount - 1})`,
       )
-    }
-
-    // In K8s or Web, metrics servers register themselves.
-    if (!isKubernetes) {
-      // `metricsServerMap` is keyed by node-id, not Connection_Identifier.
-      // Strip the `-db<N>` suffix so a second user connection on a different
-      // db reuses the existing metrics process for the same node (N:1).
-      const metricsNodeId = toNodeId(payload.connectionId)
-      if (!metricsServerMap.has(metricsNodeId)) {
-        await startMetricsServer(payload.connectionDetails, metricsNodeId)
-      }
     }
 
     console.log("Connected to standalone")


### PR DESCRIPTION
## Description

CSP fix (index.html): connect-src 'self' blocks ws://localhost:8080 when loaded from file:// in Electron. Added ws://localhost:* http://localhost:* to allow the renderer to reach the local backend server.
  
Metrics server fix (connection.ts): PR #366 moved startMetricsServer below the cluster/standalone fork, so cluster connections in Electron mode never started a metrics server. Moved it back to before belongsToCluster() so the connected node always gets a metrics server regardless of topology.
  
NodeErrorsBanner (hot-keys-banners.tsx, big-keys.tsx, command-log-table.tsx): Added a label prop so each tab shows the correct context ("Hot keys", "Big keys", "Command log") instead of hardcoding "Hot keys". Replaced the duplicated inline banner in command-log-table with the shared component.

### Change Visualization

Include a screenshot/video of before and after the change.
