### PR TITLE
Fix Electron CSP blocking websocket connections

### DIFF
--- a/apps/frontend/electron.main.js
+++ b/apps/frontend/electron.main.js
@@ -65,7 +65,7 @@ app.whenReady().then(() => {
         "Content-Security-Policy": [
           "default-src 'self'; script-src 'self'; " +
           "style-src 'self' 'unsafe-inline'; " +
-          "connect-src 'self'; " +
+          "connect-src 'self' ws://localhost:* http://localhost:*; " +
           "img-src 'self' data:; font-src 'self'; " +
           "object-src 'none'; base-uri 'self'; form-action 'self';",
         ],


### PR DESCRIPTION
## Description
 The onHeadersReceived CSP in electron.main.js had connect-src 'self' which overrides the permissive meta tag in index.html. When both are present, the browser enforces the intersection (most restrictive). Add ws://localhost:* and http://localhost:* to match the meta tag.

### Change Visualization

Include a screenshot/video of before and after the change.
