### PR TITLE
Enforce session-based connection authorization in dispatch loop

### DIFF
--- a/apps/server/src/__tests__/session.test.ts
+++ b/apps/server/src/__tests__/session.test.ts
@@ -81,4 +81,42 @@ describe("session", () => {
     assert.deepStrictEqual(orphaned, [])
     assert.strictEqual(isConnectionAuthorized(sessionB, "shared"), true)
   })
+
+  // Shared use: two users connect to the same cluster — both are authorized
+  it("allows multiple sessions to share a connection when both have connected", () => {
+    const sessionA = ensureSession(makeReq()).sessionId
+    const sessionB = ensureSession(makeReq()).sessionId
+    const connectionId = "10-0-1-5-6379-db0"
+
+    // Both users go through the connect flow (connectPending → authorizeConnection)
+    authorizeConnection(sessionA, connectionId)
+    authorizeConnection(sessionB, connectionId)
+
+    // Both can access the shared connection
+    assert.strictEqual(isConnectionAuthorized(sessionA, connectionId), true)
+    assert.strictEqual(isConnectionAuthorized(sessionB, connectionId), true)
+  })
+
+  // Attack: a session tries to use a connection it never established
+  it("rejects a session that never connected from using another session's connection", () => {
+    const victim = ensureSession(makeReq()).sessionId
+    const attacker = ensureSession(makeReq()).sessionId
+    const connectionId = "10-0-1-5-6379-db0"
+
+    // Victim connects — gets authorized
+    authorizeConnection(victim, connectionId)
+
+    // Attacker skips connectPending and tries to use the connection directly
+    assert.strictEqual(isConnectionAuthorized(attacker, connectionId), false)
+  })
+
+  // Attack: guessing deterministic connectionIds without connecting
+  it("rejects guessed connectionIds from unauthorized sessions", () => {
+    const attacker = ensureSession(makeReq()).sessionId
+
+    // connectionIds are deterministic (host-port-dbN) and therefore guessable
+    assert.strictEqual(isConnectionAuthorized(attacker, "production-redis-6379-db0"), false)
+    assert.strictEqual(isConnectionAuthorized(attacker, "10-0-1-5-6379-db0"), false)
+    assert.strictEqual(isConnectionAuthorized(attacker, "cache-cluster-6379-db2"), false)
+  })
 })

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -42,7 +42,7 @@ import {
   updateClusterNodeRegistry
 } from "./metrics-orchestrator"
 import { isAllowedWebSocketOrigin } from "./websocket-origin"
-import { ensureSession, hasAuthorizedSession, setSessionExpiryListener } from "./session"
+import { ensureSession, hasAuthorizedSession, isConnectionAuthorized, setSessionExpiryListener } from "./session"
 import type { Request, Response } from "express"
 import type { IncomingMessage } from "http"
 
@@ -279,6 +279,17 @@ wss.on("connection", (ws: AliveWebSocket) => {
 
     try {
       const handler = handlers[action.type] ?? unknownHandler
+
+      // Enforce session ownership: reject actions targeting a connection this session doesn't own.
+      // Connection-establishing actions are exempt (authorization happens after successful connect).
+      const exempt = action.type === VALKEY.CONNECTION.connectPending
+        || action.type === VALKEY.TOPOLOGY.discoveryEndpointPending
+      const targetConnectionId = action.payload?.connectionId
+      if (!exempt && targetConnectionId && !isConnectionAuthorized(ws.sessionId, targetConnectionId)) {
+        console.warn(`Rejected: session does not own connection ${targetConnectionId}`)
+        return
+      }
+
       await handler(
         { ws,
           clients,


### PR DESCRIPTION
## Description

The dispatch loop passes ws.sessionId to handlers but never enforces ownership. Since connectionId is deterministic (host-port-dbN), a second user on a shared deployment could send actions with a guessed connectionId and piggyback on another user's authenticated GLIDE client without ever connecting themselves.

Actions targeting a connectionId are rejected unless the requesting session has previously connected to that connection via connectPending. Connection-establishing actions (connectPending, discoveryEndpointPending) bypass the check since they are required for a session to become authorized

### Change Visualization

Include a screenshot/video of before and after the change.
