### PR TITLE
Fix session authorization rejecting db-stripped node IDs

### DIFF
--- a/apps/server/src/actions/connection.ts
+++ b/apps/server/src/actions/connection.ts
@@ -1,5 +1,5 @@
 import { GlideClusterClient } from "@valkey/valkey-glide"
-import { EndpointType } from "valkey-common"
+import { EndpointType, toNodeId } from "valkey-common"
 import { VALKEY } from "valkey-common"
 import { connectToValkey, teardownConnection  } from "../connection"
 import { unsubscribe, getWatcherCount } from "../node-watchers"
@@ -53,7 +53,10 @@ export const connectPending = withDeps<Deps, void>(
       payload,
     )
 
-    if (client) authorizeConnection(sessionId, connectionId)
+    if (client) {
+      authorizeConnection(sessionId, connectionId)
+      authorizeConnection(sessionId, toNodeId(connectionId))
+    }
   },
 )
 


### PR DESCRIPTION
## Description

Fix the session authorization guard rejecting actions that use the db-stripped node ID format (127-0-0-1-7000) by authorizing both ID formats at connect time.

The stripped node ID and the full connection ID refer to the same Valkey node. If a session has access to 127-0-0-1-7000-db0, it inherently has access to node 127-0-0-1-7000. The db suffix is trivially guessable (0–15), so restricting by format provides no additional security.

### Change Visualization

Include a screenshot/video of before and after the change.
