### PR TITLE
Fix number inputs snapping to unexpected values

### DIFF
--- a/apps/frontend/src/components/activity-view/bigkeys/big-keys-params-modal.tsx
+++ b/apps/frontend/src/components/activity-view/bigkeys/big-keys-params-modal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { ChartModal } from "../../ui/chart-modal"
 import { Button } from "../../ui/button"
-import { Input } from "../../ui/input"
+import { NumberInput } from "../../ui/number-input"
 import { Typography } from "../../ui/typography"
 import { TooltipIcon } from "../../ui/tooltip-icon"
 
@@ -44,13 +44,12 @@ export function BigKeysParamsModal({ open, onClose, scanLimit, topN, onScan }: B
               size={16}
             />
           </div>
-          <Input
+          <NumberInput
             aria-label="Scan Limit"
-            min="1"
-            onChange={(e) => setDraftScanLimit(Number(e.target.value))}
-            step="1000"
+            min={1}
+            onChange={setDraftScanLimit}
+            step={1000}
             style={{ width: "120px" }}
-            type="number"
             value={draftScanLimit}
           />
         </div>
@@ -63,13 +62,12 @@ export function BigKeysParamsModal({ open, onClose, scanLimit, topN, onScan }: B
               size={16}
             />
           </div>
-          <Input
+          <NumberInput
             aria-label="Top N"
-            min="1"
-            onChange={(e) => setDraftTopN(Number(e.target.value))}
-            step="10"
+            min={1}
+            onChange={setDraftTopN}
+            step={10}
             style={{ width: "120px" }}
-            type="number"
             value={draftTopN}
           />
         </div>

--- a/apps/frontend/src/components/activity-view/command-logs-params-modal.tsx
+++ b/apps/frontend/src/components/activity-view/command-logs-params-modal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { ChartModal } from "../ui/chart-modal"
 import { Button } from "../ui/button"
-import { Input } from "../ui/input"
+import { NumberInput } from "../ui/number-input"
 import { Typography } from "../ui/typography"
 import { TooltipIcon } from "../ui/tooltip-icon"
 
@@ -40,13 +40,12 @@ export function CommandLogsParamsModal({ open, onClose, topN, onApply }: Command
               size={16}
             />
           </div>
-          <Input
+          <NumberInput
             aria-label="Top N"
-            min="1"
-            onChange={(e) => setDraftTopN(Number(e.target.value))}
-            step="50"
+            min={1}
+            onChange={setDraftTopN}
+            step={50}
             style={{ width: "120px" }}
-            type="number"
             value={draftTopN}
           />
         </div>

--- a/apps/frontend/src/components/activity-view/hotkeys/count-range-filter.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/count-range-filter.tsx
@@ -89,6 +89,7 @@ export function CountRangeFilter({
                 allowEmpty
                 className="h-7 text-xs"
                 min={countMin ?? dataMin}
+                max={dataMax}
                 onChange={onCountMaxChange}
                 placeholder={dataMax.toLocaleString()}
                 value={countMax}

--- a/apps/frontend/src/components/activity-view/hotkeys/count-range-filter.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/count-range-filter.tsx
@@ -88,8 +88,8 @@ export function CountRangeFilter({
               <NumberInput
                 allowEmpty
                 className="h-7 text-xs"
-                min={countMin ?? dataMin}
                 max={dataMax}
+                min={countMin ?? dataMin}
                 onChange={onCountMaxChange}
                 placeholder={dataMax.toLocaleString()}
                 value={countMax}

--- a/apps/frontend/src/components/activity-view/hotkeys/count-range-filter.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/count-range-filter.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useRef, useState } from "react"
 import { ChevronDown, Hash } from "lucide-react"
 import { Button } from "../../ui/button"
-import { Input } from "../../ui/input"
+import { NumberInput } from "../../ui/number-input"
 import { Typography } from "../../ui/typography"
 
 interface CountRangeFilterProps {
-  countMin: string
-  countMax: string
-  onCountMinChange: (v: string) => void
-  onCountMaxChange: (v: string) => void
+  countMin: number | null
+  countMax: number | null
+  onCountMinChange: (v: number | null) => void
+  onCountMaxChange: (v: number | null) => void
   dataMin: number
   dataMax: number
 }
@@ -19,9 +19,7 @@ export function CountRangeFilter({
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
-  const parsedMin = countMin !== "" ? Number(countMin) : null
-  const parsedMax = countMax !== "" ? Number(countMax) : null
-  const isFiltered = parsedMin !== null || parsedMax !== null
+  const isFiltered = countMin !== null || countMax !== null
 
   useEffect(() => {
     if (!open) return
@@ -43,7 +41,7 @@ export function CountRangeFilter({
         <Hash className="text-primary" size={14} />
         <span className="text-xs w-24">
           {isFiltered
-            ? `${parsedMin ?? dataMin} – ${parsedMax ?? dataMax}`
+            ? `${countMin ?? dataMin} – ${countMax ?? dataMax}`
             : "Access Count"
           }
         </span>
@@ -58,7 +56,7 @@ export function CountRangeFilter({
             </Typography>
             {isFiltered && (
               <Button
-                onClick={() => { onCountMinChange(""); onCountMaxChange("") }}
+                onClick={() => { onCountMinChange(null); onCountMaxChange(null) }}
                 size={"sm"}
                 variant={"link"}
               >
@@ -75,24 +73,24 @@ export function CountRangeFilter({
           <div className="grid grid-cols-2 gap-2">
             <div className="space-y-1">
               <Typography variant={"bodyXs"}>Min</Typography>
-              <Input
+              <NumberInput
+                allowEmpty
                 className="h-7 text-xs"
-                max={parsedMax ?? dataMax}
+                max={countMax ?? dataMax}
                 min={0}
-                onChange={(e) => onCountMinChange(e.target.value)}
+                onChange={onCountMinChange}
                 placeholder={dataMin.toLocaleString()}
-                type="number"
                 value={countMin}
               />
             </div>
             <div className="space-y-1">
               <Typography variant={"bodyXs"}>Max</Typography>
-              <Input
+              <NumberInput
+                allowEmpty
                 className="h-7 text-xs"
-                min={parsedMin ?? dataMin}
-                onChange={(e) => onCountMaxChange(e.target.value)}
+                min={countMin ?? dataMin}
+                onChange={onCountMaxChange}
                 placeholder={dataMax.toLocaleString()}
-                type="number"
                 value={countMax}
               />
             </div>

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-params-modal.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-params-modal.tsx
@@ -6,7 +6,7 @@ import { MONITOR_ACTION } from "@common/src/constants"
 import { toNodeId } from "@common/src/connection-id.ts"
 import { ChartModal } from "../../ui/chart-modal"
 import { Button } from "../../ui/button"
-import { Input } from "../../ui/input"
+import { NumberInput } from "../../ui/number-input"
 import { Typography } from "../../ui/typography"
 import { TooltipIcon } from "../../ui/tooltip-icon"
 import type { RootState } from "@/store"
@@ -117,13 +117,12 @@ export function HotKeysParamsModal({ open, onClose, connectionId, clusterId }: H
               <Typography variant="bodySm">Monitor Duration (ms)</Typography>
               <TooltipIcon description="Duration in milliseconds during which monitoring data is collected." size={16} />
             </div>
-            <Input
+            <NumberInput
               aria-label="Monitor Duration"
-              min="1"
-              onChange={(e) => setMonitorDuration(Number(e.target.value))}
-              step="1000"
+              min={1}
+              onChange={setMonitorDuration}
+              step={1000}
               style={{ width: "100px" }}
-              type="number"
               value={monitorDuration}
             />
           </div>
@@ -133,13 +132,12 @@ export function HotKeysParamsModal({ open, onClose, connectionId, clusterId }: H
               <Typography variant="bodySm">Monitor Interval (ms)</Typography>
               <TooltipIcon description="Delay in milliseconds between consecutive monitoring cycles." size={16} />
             </div>
-            <Input
+            <NumberInput
               aria-label="Monitor Interval"
-              min="1"
-              onChange={(e) => setMonitorInterval(Number(e.target.value))}
-              step="1000"
+              min={1}
+              onChange={setMonitorInterval}
+              step={1000}
               style={{ width: "100px" }}
-              type="number"
               value={monitorInterval}
             />
           </div>
@@ -153,13 +151,12 @@ export function HotKeysParamsModal({ open, onClose, connectionId, clusterId }: H
                 size={16}
               />
             </div>
-            <Input
+            <NumberInput
               aria-label="Max Commands Per Run"
-              min="1"
-              onChange={(e) => setMaxCommandsPerRun(Number(e.target.value))}
-              step="100000"
+              min={1}
+              onChange={setMaxCommandsPerRun}
+              step={100000}
               style={{ width: "140px" }}
-              type="number"
               value={maxCommandsPerRun}
             />
           </div>
@@ -173,13 +170,12 @@ export function HotKeysParamsModal({ open, onClose, connectionId, clusterId }: H
                 size={16}
               />
             </div>
-            <Input
+            <NumberInput
               aria-label="Cutoff Frequency"
-              min="1"
-              onChange={(e) => setCutoffFrequency(Number(e.target.value))}
-              step="10"
+              min={1}
+              onChange={setCutoffFrequency}
+              step={10}
               style={{ width: "100px" }}
-              type="number"
               value={cutoffFrequency}
             />
           </div>

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-toolbar.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-toolbar.tsx
@@ -12,10 +12,10 @@ interface HotKeysToolbarProps {
   nodes: string[]
   selectedNode: string
   onNodeSelect: (node: string) => void
-  countMin: string
-  countMax: string
-  onCountMinChange: (v: string) => void
-  onCountMaxChange: (v: string) => void
+  countMin: number | null
+  countMax: number | null
+  onCountMinChange: (v: number | null) => void
+  onCountMaxChange: (v: number | null) => void
   dataMin: number
   dataMax: number
   onHeatmapOpen: () => void

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
@@ -33,8 +33,8 @@ export function HotKeys({
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc")
   const [searchQuery, setSearchQuery] = useState("")
   const [selectedNode, setSelectedNode] = useState("all")
-  const [countMin, setCountMin] = useState("")
-  const [countMax, setCountMax] = useState("")
+  const [countMin, setCountMin] = useState<number | null>(null)
+  const [countMax, setCountMax] = useState<number | null>(null)
   const [isHeatmapOpen, setIsHeatmapOpen] = useState(false)
 
   if (status === "Pending") return <LoadingState message="Loading hot keys..." />
@@ -50,15 +50,13 @@ export function HotKeys({
 
   const dataMin = sorted.length > 0 ? Math.min(...sorted.map(([, count]) => count)) : 0
   const dataMax = sorted.length > 0 ? Math.max(...sorted.map(([, count]) => count)) : 0
-  const parsedCountMin = countMin !== "" ? Number(countMin) : null
-  const parsedCountMax = countMax !== "" ? Number(countMax) : null
-  const isCountFiltered = parsedCountMin !== null || parsedCountMax !== null
+  const isCountFiltered = countMin !== null || countMax !== null
 
   const filtered = sorted.filter(([keyName, count, , , nodeId]) => {
     const matchesSearch = !searchQuery || keyName.toLowerCase().includes(searchQuery.toLowerCase())
     const matchesNode = selectedNode === "all" || nodeId === selectedNode
-    const matchesMin = parsedCountMin === null || count >= parsedCountMin
-    const matchesMax = parsedCountMax === null || count <= parsedCountMax
+    const matchesMin = countMin === null || count >= countMin
+    const matchesMax = countMax === null || count <= countMax
     return matchesSearch && matchesNode && matchesMin && matchesMax
   })
 
@@ -140,8 +138,8 @@ export function HotKeys({
           isHotSlots={isHotSlots}
           onKeyClick={onKeyClick}
           onToggleSort={() => setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"))}
-          parsedCountMax={parsedCountMax}
-          parsedCountMin={parsedCountMin}
+          parsedCountMax={countMax}
+          parsedCountMin={countMin}
           rows={filtered}
           searchQuery={searchQuery}
           selectedKey={selectedKey}

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-slots-params-modal.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-slots-params-modal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { ChartModal } from "../../ui/chart-modal"
 import { Button } from "../../ui/button"
-import { Input } from "../../ui/input"
+import { NumberInput } from "../../ui/number-input"
 import { Typography } from "../../ui/typography"
 import { TooltipIcon } from "../../ui/tooltip-icon"
 
@@ -40,13 +40,12 @@ export function HotSlotsParamsModal({ open, onClose, topN, onApply }: HotSlotsPa
               size={16}
             />
           </div>
-          <Input
+          <NumberInput
             aria-label="Top N"
-            min="1"
-            onChange={(e) => setDraftTopN(Number(e.target.value))}
-            step="10"
+            min={1}
+            onChange={setDraftTopN}
+            step={10}
             style={{ width: "120px" }}
-            type="number"
             value={draftTopN}
           />
         </div>

--- a/apps/frontend/src/components/ui/number-input.tsx
+++ b/apps/frontend/src/components/ui/number-input.tsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+import { ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Input } from "@/components/ui/input"
+
+interface NumberInputProps extends Omit<React.ComponentProps<"input">, "type" | "value" | "onChange" | "step" | "min" | "max"> {
+  value: number
+  onChange: (value: number) => void
+  min?: number
+  max?: number
+  // Custom increment applied from the current value, unlike the native step
+  // attribute which snaps to a min-anchored grid of legal values.
+  step?: number
+}
+
+function clamp(value: number, min?: number, max?: number) {
+  if (min !== undefined && value < min) return min
+  if (max !== undefined && value > max) return max
+  return value
+}
+
+function NumberInput({ value, onChange, min, max, step = 1, className, style, ...props }: NumberInputProps) {
+  const stepBy = (direction: 1 | -1) => {
+    onChange(clamp(value + direction * step, min, max))
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+      e.preventDefault()
+      stepBy(e.key === "ArrowUp" ? 1 : -1)
+    }
+  }
+
+  return (
+    <div className="relative" style={style}>
+      <Input
+        className={cn(
+          "pr-6 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+          className,
+        )}
+        onBlur={() => onChange(clamp(value, min, max))}
+        onChange={(e) => onChange(Number(e.target.value))}
+        onKeyDown={handleKeyDown}
+        type="number"
+        value={value}
+        {...props}
+      />
+      <div aria-hidden className="absolute inset-y-0 right-0 flex flex-col justify-center pr-1">
+        <button
+          className="flex h-3.5 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+          onClick={() => stepBy(1)}
+          tabIndex={-1}
+          type="button"
+        >
+          <ChevronUp size={14} />
+        </button>
+        <button
+          className="flex h-3.5 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+          onClick={() => stepBy(-1)}
+          tabIndex={-1}
+          type="button"
+        >
+          <ChevronDown size={14} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export { NumberInput }

--- a/apps/frontend/src/components/ui/number-input.tsx
+++ b/apps/frontend/src/components/ui/number-input.tsx
@@ -4,9 +4,7 @@ import { ChevronDown, ChevronUp } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
 
-interface NumberInputProps extends Omit<React.ComponentProps<"input">, "type" | "value" | "onChange" | "step" | "min" | "max"> {
-  value: number
-  onChange: (value: number) => void
+interface BaseNumberInputProps extends Omit<React.ComponentProps<"input">, "type" | "value" | "onChange" | "step" | "min" | "max"> {
   min?: number
   max?: number
   // Custom increment applied from the current value, unlike the native step
@@ -14,15 +12,37 @@ interface NumberInputProps extends Omit<React.ComponentProps<"input">, "type" | 
   step?: number
 }
 
+interface NonNullableNumberInputProps extends BaseNumberInputProps {
+  allowEmpty?: false
+  value: number
+  onChange: (value: number) => void
+}
+
+// With allowEmpty, a cleared input reports null (e.g. "no filter set") and
+// blur preserves the empty state instead of clamping it to a number.
+interface NullableNumberInputProps extends BaseNumberInputProps {
+  allowEmpty: true
+  value: number | null
+  onChange: (value: number | null) => void
+}
+
+type NumberInputProps = NonNullableNumberInputProps | NullableNumberInputProps
+
 function clamp(value: number, min?: number, max?: number) {
   if (min !== undefined && value < min) return min
   if (max !== undefined && value > max) return max
   return value
 }
 
-function NumberInput({ value, onChange, min, max, step = 1, className, style, ...props }: NumberInputProps) {
+function NumberInput({ value, onChange, min, max, step = 1, allowEmpty, className, style, ...props }: NumberInputProps) {
+  const emit = onChange as (value: number | null) => void
+
   const stepBy = (direction: 1 | -1) => {
-    onChange(clamp(value + direction * step, min, max))
+    if (value === null) {
+      emit(clamp(min ?? 0, min, max))
+      return
+    }
+    emit(clamp(value + direction * step, min, max))
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -39,11 +59,11 @@ function NumberInput({ value, onChange, min, max, step = 1, className, style, ..
           "pr-6 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
           className,
         )}
-        onBlur={() => onChange(clamp(value, min, max))}
-        onChange={(e) => onChange(Number(e.target.value))}
+        onBlur={() => { if (value !== null) emit(clamp(value, min, max)) }}
+        onChange={(e) => emit(allowEmpty && e.target.value === "" ? null : Number(e.target.value))}
         onKeyDown={handleKeyDown}
         type="number"
-        value={value}
+        value={value ?? ""}
         {...props}
       />
       <div aria-hidden className="absolute inset-y-0 right-0 flex flex-col justify-center pr-1">


### PR DESCRIPTION
## Description

Fixes #417.

Previously, number inputs snapped to step grids anchored to min which was set to 1. So when step is a factor of 10, the grid will always look like 1, 11, 21 etc. Or for 100, 1, 101, 201 etc.

This fix creates a custom NumberInput function that returns an numbered input that calculates step correctly. Which replaces the previous number Input in related modals.

### Change Visualization

https://github.com/user-attachments/assets/d2818353-ff19-4a9c-832b-3bcbb6ec88d7
