### PR TITLE
Make search case-insensitive in Send Command view

### DIFF
--- a/apps/frontend/src/components/send-command/DiffCommands.tsx
+++ b/apps/frontend/src/components/send-command/DiffCommands.tsx
@@ -16,7 +16,8 @@ const DiffCommands = ({ filter, id, indexA, indexB }) => {
 
   if (R.isEmpty(diffs)) return "Responses are identical"
 
-  const filteredDiffs = filter ? diffs.filter(({ keyPathString }) => keyPathString.includes(filter)) : diffs
+  const normalisedFilter = filter.toLowerCase()
+  const filteredDiffs = normalisedFilter ? diffs.filter(({ keyPathString }) => keyPathString.toLowerCase().includes(normalisedFilter)) : diffs
 
   const onCopy = () =>
     R.pipe(

--- a/apps/frontend/src/components/send-command/Response.tsx
+++ b/apps/frontend/src/components/send-command/Response.tsx
@@ -6,6 +6,7 @@ import { cn, copyToClipboard } from "@/lib/utils.ts"
 import { CopyToClipboard, KeyFilterable, KV, spacing } from "@/components/send-command/CommandElements.tsx"
 
 const Response = ({ filter, response }: { filter: string, response: JSONObject }) => {
+  const normalisedFilter = filter.toLowerCase()
   const filtered =
     R.pipe(
       toKeyPaths,
@@ -15,13 +16,14 @@ const Response = ({ filter, response }: { filter: string, response: JSONObject }
         value: R.path(keyPath as string[], response),
         valueString: JSON.stringify(R.path(keyPath as string[], response)),
       })),
-      R.isEmpty(filter) ? R.identity : 
-        R.filter(({ keyPathString, valueString }) => keyPathString.includes(filter) || valueString.includes(filter)),
+      R.isEmpty(normalisedFilter) ? R.identity :
+        R.filter(({ keyPathString, valueString }) =>
+          keyPathString.toLowerCase().includes(normalisedFilter) || valueString.toLowerCase().includes(normalisedFilter)),
     )(response)
 
   const onCopy = () =>
     R.pipe(
-      R.isEmpty(filter) // we don't need to assemble a JSON from DiffEntry[] if not filtering keys
+      R.isEmpty(normalisedFilter) // we don't need to assemble a JSON from DiffEntry[] if not filtering keys
         ? R.always(response)
         : toJson(response),
       (r) => JSON.stringify(r, null, 2),

--- a/apps/frontend/src/components/send-command/SendCommand.tsx
+++ b/apps/frontend/src/components/send-command/SendCommand.tsx
@@ -40,6 +40,7 @@ export function SendCommand() {
   const [suggestionsDismissed, setSuggestionsDismissed] = useState(false)
   const [configOpen, setConfigOpen] = useState(false)
 
+  const normalisedHistoryFilter = historyFilter.toLowerCase()
   const suggestions: MatchResult[] = useMemo(
     () => (text.includes(" ") || text.includes("\n") ? [] : matchCommands(text)),
     [text],
@@ -214,7 +215,7 @@ export function SendCommand() {
                 allCommands
                   .slice(0, historyLimit)
                   .map((c, i) => ({ ...c, i })) // moving index inside objects because filter will ruin the sequence
-                  .filter(({ command }) => command.includes(historyFilter))
+                  .filter(({ command }) => command.toLowerCase().includes(normalisedHistoryFilter))
                   .map(({ command, timestamp, i }) =>
                     <div
                       className={cn(


### PR DESCRIPTION
## Description

Closes #424 

This PR makes search case-insensitive in the Send Command view.
Affected search bars are:
- History search bar
- Response search bar
- Diff search bar

This works by lowercasing the filter (once per change/render) and lowercasing the entries (once per entry).

### Known limitation

Text highlighting in diff view is still case-sensitive in `CommandElements.tsx`/`KeyFilterable`.

I did not find a straight-forward way to implement it, and did not know if it was included in the scope of the issue.

A possible implementation (not explored) would be to manually split the "normal-case" keyPathString based on split results of the lowercase filter against a lowercased keyPathString. If it should be included in the PR, I can look to add it.

### Tests ran

- Manual testing of the feature
- `npm run build:frontend`
- `npm run lint`

### Change Visualization

Before the changes:
https://github.com/user-attachments/assets/855c386f-39e1-4ecc-91c9-7d56e7698cac

After the changes:
https://github.com/user-attachments/assets/8873c25f-8f08-4230-be43-168140f2f907


