### PR TITLE
Handle monitor stop gracefully when metrics server is dead

### DIFF
--- a/apps/server/src/actions/monitorAction.ts
+++ b/apps/server/src/actions/monitorAction.ts
@@ -106,7 +106,16 @@ async function runMonitorForNode(
       })
     }
   } catch (error) {
-    sendMonitorError(ws, replyId, error)
+    // If we were trying to stop and the metrics server is dead,
+    // report monitor as stopped — it's not running anywhere.
+    if (monitorAction === "stop") {
+      sendMonitorFulfilled(ws, replyId, { monitorRunning: false, checkAt: null, startedAt: null })
+      getOtherWatchers(watcherId, ws).forEach((watcher) => {
+        sendMonitorFulfilled(watcher, replyId, { monitorRunning: false, checkAt: null, startedAt: null })
+      })
+    } else {
+      sendMonitorError(ws, replyId, error)
+    }
   }
 }
 


### PR DESCRIPTION
## Description

When a metrics server crashes (process exits), clicking "Stop" in the UI fails silently — ECONNREFUSED on the stop request leaves monitorRunning: true in the frontend, causing a stuck banner.

 In runMonitorForNode, when a stop request fails (catch block), send monitorFulfilled with monitorRunning: false instead of monitorError. The metrics server is dead, so monitor is effectively stopped. Start request errors still report as monitorError.

### Before the change

https://github.com/user-attachments/assets/45cdd3af-5621-4756-a209-9910ac04b3d5

### After the change

https://github.com/user-attachments/assets/aab3647e-f755-47ab-8394-c35f571180a7



