### PR TITLE
Fix hot keys returning empty on first MONITOR cycle

### DIFF
--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -84,19 +84,19 @@ export const hotKeysRequested = withDeps<Deps, void>(
         if (initialParsedResponse.checkAt) {
           // Monitor collects data in memory for the full duration, then writes
           // to disk asynchronously after collectLogs returns. The re-fetch may
-          // arrive before the write completes. Wait checkAt + 1s, then retry up
-          // to 3 times (1s apart) if data still isn't available. 
-          const delay = initialParsedResponse.checkAt - Date.now() + 1000
+          // arrive before the write completes. Wait until checkAt, then retry up
+          // to 3 times (1s apart) if data still isn't available.
+          const delay = initialParsedResponse.checkAt - Date.now()
           await new Promise((resolve) => setTimeout(resolve, Math.max(delay, 0)))
 
+          let result: HotKeysResponse = initialParsedResponse
           for (let attempt = 0; attempt < 3; attempt++) {
-            const dataResponse = await fetch(url)
-            const result = await dataResponse.json() as HotKeysResponse
-            if (result.hotKeys?.length > 0 || !result.monitorRunning) return result
             await new Promise((resolve) => setTimeout(resolve, 1000))
+            const dataResponse = await fetch(url)
+            result = await dataResponse.json() as HotKeysResponse
+            if (result.hotKeys?.length > 0) return result
           }
-          const finalResponse = await fetch(`${metricsServerURI}/hot-keys`)
-          return await finalResponse.json() as HotKeysResponse
+          return result
         }
         else {
           return initialParsedResponse

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -82,10 +82,21 @@ export const hotKeysRequested = withDeps<Deps, void>(
         const initialParsedResponse: HotKeysResponse = await initialResponse.json() as HotKeysResponse
         // Reads monitor data and returns when to fetch results (`checkAt`).
         if (initialParsedResponse.checkAt) {
-          const delay = initialParsedResponse.checkAt - Date.now()
-          await new Promise((resolve) => setTimeout(resolve, delay))
-          const dataResponse = await fetch(`${metricsServerURI}/hot-keys`)
-          return await dataResponse.json() as HotKeysResponse
+          // Monitor collects data in memory for the full duration, then writes
+          // to disk asynchronously after collectLogs returns. The re-fetch may
+          // arrive before the write completes. Wait checkAt + 1s, then retry up
+          // to 3 times (1s apart) if data still isn't available. 
+          const delay = initialParsedResponse.checkAt - Date.now() + 1000
+          await new Promise((resolve) => setTimeout(resolve, Math.max(delay, 0)))
+
+          for (let attempt = 0; attempt < 3; attempt++) {
+            const dataResponse = await fetch(url)
+            const result = await dataResponse.json() as HotKeysResponse
+            if (result.hotKeys?.length > 0 || !result.monitorRunning) return result
+            await new Promise((resolve) => setTimeout(resolve, 1000))
+          }
+          const finalResponse = await fetch(`${metricsServerURI}/hot-keys`)
+          return await finalResponse.json() as HotKeysResponse
         }
         else {
           return initialParsedResponse


### PR DESCRIPTION
### Summary
  
Prior to this change, the server waits until checkAt (collection end time) then immediately re-fetches /hot-keys. But monitor data is collected in memory for the full duration, then written to disk after collectLogs returns. The re-fetch arrives before the write completes, returning empty results.
  
This PR adds a 1-second buffer to the hot keys re-fetch delay after checkAt to account for the asynchronous disk write that happens after monitor collection ends. The 1-second buffer accounts for: promise resolution + event listener cleanup + JSON serialization of rows + fs.appendFile. 

### Before the fix

https://github.com/user-attachments/assets/9473b28c-e5e5-429a-99a4-b7b5171e3890

### After the fix

https://github.com/user-attachments/assets/c89589cd-be35-4966-86e9-aadbef252661

