### PR TITLE
Fix monitor and node error banners

### DIFF
--- a/apps/frontend/src/components/activity-view/ActivityView.tsx
+++ b/apps/frontend/src/components/activity-view/ActivityView.tsx
@@ -35,7 +35,6 @@ import {
   monitorRequested,
   selectMonitorRunning,
   selectClusterMonitorRunning,
-  selectClusterMonitorNodeErrors,
   selectMonitorError
 } from "@/state/valkey-features/monitor/monitorSlice"
 import { selectConnectionDetails, selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
@@ -95,16 +94,7 @@ export const ActivityView = () => {
   const monitorRunning = useSelector((state: RootState) =>
     clusterId ? selectClusterMonitorRunning(clusterId)(state) : selectMonitorRunning(nodeId)(state),
   )
-  // Cluster: surface any node's monitor start failure (e.g. unreachable) in
-  // the monitor error banner. The cluster reports running as long as one
-  // node monitors, so the route node's own entry may carry no error.
-  const monitorNodeErrors = useSelector((state: RootState) =>
-    clusterId ? selectClusterMonitorNodeErrors(clusterId)(state) : [],
-  )
-  const standaloneMonitorError = useSelector(selectMonitorError(nodeId))
-  const monitorError = clusterId
-    ? (monitorNodeErrors[0] ? `${monitorNodeErrors[0].nodeId}: ${monitorNodeErrors[0].error}` : null)
-    : standaloneMonitorError
+  const monitorError = useSelector(selectMonitorError(nodeId))
   const connectionDetails = useSelector((state: RootState) => selectConnectionDetails(id!)(state))
   const clusterAlias = useSelector(selectClusterAlias(id!))
   const useHotSlots = connectionDetails?.keyEvictionPolicy?.includes("lfu") && connectionDetails?.clusterSlotStatsEnabled
@@ -369,7 +359,9 @@ export const ActivityView = () => {
                   errorMessage={hotKeysErrorMessage as string | null}
                   isCluster={!!clusterId}
                   isHotSlots={!!useHotSlots}
-                  monitorError={monitorError}
+                  // Cluster errors are surfaced by NodeErrorsBanner; passing monitorError
+                  // here would hide the start button in MonitorNotRunningBanner.
+                  monitorError={clusterId ? null : monitorError}
                   monitorRunning={monitorRunning}
                   nodeErrors={hotKeysNodeErrors}
                   onKeyClick={handleKeyClick}

--- a/apps/frontend/src/components/activity-view/ActivityView.tsx
+++ b/apps/frontend/src/components/activity-view/ActivityView.tsx
@@ -35,6 +35,7 @@ import {
   monitorRequested,
   selectMonitorRunning,
   selectClusterMonitorRunning,
+  selectClusterMonitorNodeErrors,
   selectMonitorError
 } from "@/state/valkey-features/monitor/monitorSlice"
 import { selectConnectionDetails, selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
@@ -94,7 +95,16 @@ export const ActivityView = () => {
   const monitorRunning = useSelector((state: RootState) =>
     clusterId ? selectClusterMonitorRunning(clusterId)(state) : selectMonitorRunning(nodeId)(state),
   )
-  const monitorError = useSelector(selectMonitorError(nodeId))
+  // Cluster: surface any node's monitor start failure (e.g. unreachable) in
+  // the monitor error banner. The cluster reports running as long as one
+  // node monitors, so the route node's own entry may carry no error.
+  const monitorNodeErrors = useSelector((state: RootState) =>
+    clusterId ? selectClusterMonitorNodeErrors(clusterId)(state) : [],
+  )
+  const standaloneMonitorError = useSelector(selectMonitorError(nodeId))
+  const monitorError = clusterId
+    ? (monitorNodeErrors[0] ? `${monitorNodeErrors[0].nodeId}: ${monitorNodeErrors[0].error}` : null)
+    : standaloneMonitorError
   const connectionDetails = useSelector((state: RootState) => selectConnectionDetails(id!)(state))
   const clusterAlias = useSelector(selectClusterAlias(id!))
   const useHotSlots = connectionDetails?.keyEvictionPolicy?.includes("lfu") && connectionDetails?.clusterSlotStatsEnabled

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
@@ -62,7 +62,9 @@ export function HotKeys({
 
   const banners = (
     <>
-      {!monitorRunning && onStartMonitoring && (
+      {/* Also shown while running when a node's monitor failed to start
+          (partial cluster): the error variant reports the failed node. */}
+      {(!monitorRunning || monitorError) && onStartMonitoring && (
         <MonitorNotRunningBanner error={monitorError} onStartMonitoring={onStartMonitoring} />
       )}
       {nodeErrors && nodeErrors.length > 0 && (

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
@@ -62,9 +62,7 @@ export function HotKeys({
 
   const banners = (
     <>
-      {/* Also shown while running when a node's monitor failed to start
-          (partial cluster): the error variant reports the failed node. */}
-      {(!monitorRunning || monitorError) && onStartMonitoring && (
+      {!monitorRunning && onStartMonitoring && (
         <MonitorNotRunningBanner error={monitorError} onStartMonitoring={onStartMonitoring} />
       )}
       {nodeErrors && nodeErrors.length > 0 && (

--- a/apps/frontend/src/state/valkey-features/config/configSlice.test.ts
+++ b/apps/frontend/src/state/valkey-features/config/configSlice.test.ts
@@ -153,6 +153,50 @@ describe("configSlice", () => {
       expect(state["cluster-1"].errorMessage).toBe("bad config")
     })
 
+    it("applies monitoring settings on a partial failure (succeeded nodes run with them)", () => {
+      const state = configReducer(
+        initialState,
+        updateConfigFailed({
+          clusterId: "cluster-1",
+          outcome: "failed",
+          nodeResults: [
+            { nodeId: "node-1", success: true, message: "ok" },
+            { nodeId: "node-2", success: false, message: "boom" },
+          ],
+          appliedConfig: { epic: { name: "monitor", monitoringDuration: 5000, monitoringInterval: 7000 } },
+        }),
+      )
+
+      expect(state["cluster-1"].status).toBe("partial")
+      expect(state["cluster-1"].monitoring.monitoringDuration).toBe(5000)
+      expect(state["cluster-1"].monitoring.monitoringInterval).toBe(7000)
+    })
+
+    it("keeps the previous monitoring settings on a total failure", () => {
+      const seeded = configReducer(
+        initialState,
+        setConfig({ connectionId: "node-1-db0", connectionDetails: { clusterId: "cluster-1" } }),
+      )
+      const previousDuration = seeded["cluster-1"].monitoring.monitoringDuration
+
+      const state = configReducer(
+        seeded,
+        updateConfigFailed({
+          clusterId: "cluster-1",
+          outcome: "failed",
+          nodeResults: [
+            { nodeId: "node-1", success: false, message: "boom" },
+            { nodeId: "node-2", success: false, message: "also boom" },
+          ],
+          appliedConfig: { epic: { name: "monitor", monitoringDuration: 5000 } },
+        }),
+      )
+
+      // No node applied the config; showing the new values would misreport.
+      expect(state["cluster-1"].status).toBe("failed")
+      expect(state["cluster-1"].monitoring.monitoringDuration).toBe(previousDuration)
+    })
+
     it("represents a partial failure distinctly from a total failure", () => {
       const state = configReducer(
         initialState,

--- a/apps/frontend/src/state/valkey-features/config/configSlice.ts
+++ b/apps/frontend/src/state/valkey-features/config/configSlice.ts
@@ -136,6 +136,22 @@ const reconcileNodeStatuses = (
   entry.nodeStatuses = reconciled
 }
 
+/**
+ * Merge the monitoring fields of a reply's appliedConfig into the entry. 
+ */
+const applyMonitoringConfig = (entry: ConfigEntry, appliedConfig: unknown): void => {
+  const epic = (appliedConfig as { epic?: Record<string, unknown> } | undefined)?.epic
+  if (!epic) return
+  const updatedMonitoringConfig = R.pick(
+    Object.keys(defaultConfig().monitoring),
+    epic,
+  )
+  entry.monitoring = {
+    ...entry.monitoring,
+    ...updatedMonitoringConfig,
+  }
+}
+
 const configSlice = createSlice({
   name: "config",
   initialState,
@@ -208,17 +224,7 @@ const configSlice = createSlice({
         state[targetId] = defaultConfig({ status: "updating" })
       }
 
-      const epic = appliedConfig?.epic
-      if (epic) {
-        const updatedMonitoringConfig = R.pick(
-          Object.keys(defaultConfig().monitoring),
-          epic,
-        )
-        state[targetId].monitoring = {
-          ...state[targetId].monitoring,
-          ...updatedMonitoringConfig,
-        }
-      }
+      applyMonitoringConfig(state[targetId], appliedConfig)
 
       state[targetId].status = "updated"
       state[targetId].errorMessage = null
@@ -273,6 +279,11 @@ const configSlice = createSlice({
       entry.succeededCount = succeeded.length
       // Partial when at least one node also succeeded, failure otherwise.
       entry.status = succeeded.length > 0 ? "partial" : "failed"
+      // On a partial outcome the succeeded nodes applied (and monitor with)
+      // the new config; only a full failure keeps the previous values.
+      if (entry.status === "partial") {
+        applyMonitoringConfig(entry, action.payload.appliedConfig)
+      }
       const firstFailed = results.find((result) => !result.success)
       entry.errorMessage = firstFailed
         ? (firstFailed.message ? firstFailed.message : MISSING_MESSAGE)

--- a/apps/frontend/src/state/valkey-features/monitor/monitorSlice.test.ts
+++ b/apps/frontend/src/state/valkey-features/monitor/monitorSlice.test.ts
@@ -7,6 +7,7 @@ import monitorReducer, {
   selectMonitorLoading,
   selectClusterMonitorRunning,
   selectClusterMonitorLoading,
+  selectClusterMonitorNodeErrors,
   selectRunningMonitorConnections
 } from "./monitorSlice"
 
@@ -90,19 +91,42 @@ describe("monitorSlice", () => {
       expect(state["node-1"].monitorRunning).toBe(true)
     })
 
-    it("selectClusterMonitorRunning is true only when all present cluster nodes run", () => {
+    it("selectClusterMonitorRunning is true when any cluster node runs", () => {
       const running = {
         "node-1": { monitorRunning: true, checkAt: null, loading: false, startedAt: null, clusterId: "c1" },
         "node-2": { monitorRunning: true, checkAt: null, loading: false, startedAt: null, clusterId: "c1" },
       }
+      // One node failed to start (e.g. unreachable): the cluster is still
+      // monitoring on the other nodes and must report running.
       const partial = {
         ...running,
+        "node-2": { monitorRunning: false, checkAt: null, loading: false, startedAt: null, clusterId: "c1", error: "node down" },
+      }
+      const stopped = {
+        "node-1": { monitorRunning: false, checkAt: null, loading: false, startedAt: null, clusterId: "c1" },
         "node-2": { monitorRunning: false, checkAt: null, loading: false, startedAt: null, clusterId: "c1" },
       }
       expect(selectClusterMonitorRunning("c1")({ monitor: running } as never)).toBe(true)
-      expect(selectClusterMonitorRunning("c1")({ monitor: partial } as never)).toBe(false)
+      expect(selectClusterMonitorRunning("c1")({ monitor: partial } as never)).toBe(true)
+      expect(selectClusterMonitorRunning("c1")({ monitor: stopped } as never)).toBe(false)
       // No entries for the cluster → not running.
       expect(selectClusterMonitorRunning("c1")({ monitor: {} } as never)).toBe(false)
+      // Entries from another cluster do not leak in.
+      expect(selectClusterMonitorRunning("c2")({ monitor: running } as never)).toBe(false)
+    })
+
+    it("selectClusterMonitorNodeErrors lists non-running cluster nodes with an error", () => {
+      const state = {
+        "node-1": { monitorRunning: true, checkAt: null, loading: false, startedAt: null, clusterId: "c1" },
+        "node-2": { monitorRunning: false, checkAt: null, loading: false, startedAt: null, clusterId: "c1", error: "node down" },
+        // A running node with a stale error is NOT reported.
+        "node-3": { monitorRunning: true, checkAt: null, loading: false, startedAt: null, clusterId: "c1", error: "old" },
+        // Another cluster's failure does not leak in.
+        "node-4": { monitorRunning: false, checkAt: null, loading: false, startedAt: null, clusterId: "c2", error: "boom" },
+      }
+      expect(selectClusterMonitorNodeErrors("c1")({ monitor: state } as never)).toEqual([
+        { nodeId: "node-2", error: "node down" },
+      ])
     })
 
     it("selectClusterMonitorLoading is true when any cluster node is loading", () => {

--- a/apps/frontend/src/state/valkey-features/monitor/monitorSlice.ts
+++ b/apps/frontend/src/state/valkey-features/monitor/monitorSlice.ts
@@ -19,6 +19,20 @@ export const selectMonitorError =
     (state: RootState) =>
       R.path<string | null>([VALKEY.MONITOR.name, connectionId, "error"], state) ?? null
 
+/**
+ * Per-node monitor errors for a cluster (e.g. a node whose MONITOR failed to
+ * start because it is unreachable), so the UI can report a partially-running
+ * monitor instead of silently dropping the failed nodes.
+ */
+export const selectClusterMonitorNodeErrors =
+  (clusterId: string) =>
+    (state: RootState): { nodeId: string; error: string }[] => {
+      const monitorState = R.path<MonitorState>([VALKEY.MONITOR.name], state) ?? {}
+      return Object.entries(monitorState)
+        .filter(([, entry]) => entry.clusterId === clusterId && !entry.monitorRunning && entry.error)
+        .map(([nodeId, entry]) => ({ nodeId, error: entry.error! }))
+    }
+
 export const selectRunningMonitorConnections =
   (state: RootState): { nodeId: string; clusterId?: string; startedAt: number | null }[] => {
     const monitorState = R.path<MonitorState>([VALKEY.MONITOR.name], state) ?? {}
@@ -33,15 +47,16 @@ export const selectRunningMonitorConnections =
  * Cluster monitor state is stored PER NODE (keyed by `nodeId` and
  * tagged with `clusterId`). The cluster route `id` is a db-suffixed
  * Connection_Identifier, so it never matches those entries directly. Roll the
- * per-node entries up by `clusterId` and report running iff at least one node is
- * present and all present nodes are running.
+ * per-node entries up by `clusterId` and report running iff at least one node
+ * is running: a node that failed to start (or is unreachable) will not mask
+ * the nodes that ARE monitoring.
  */
 export const selectClusterMonitorRunning =
   (clusterId: string) =>
     (state: RootState): boolean => {
       const monitorState = R.path<MonitorState>([VALKEY.MONITOR.name], state) ?? {}
-      const entries = Object.values(monitorState).filter((entry) => entry.clusterId === clusterId)
-      return entries.length > 0 && entries.every((entry) => entry.monitorRunning)
+      return Object.values(monitorState)
+        .some((entry) => entry.clusterId === clusterId && entry.monitorRunning)
     }
 
 /** Cluster-aware loading: loading iff any node entry for the cluster is loading. */

--- a/apps/server/src/__tests__/config.test.ts
+++ b/apps/server/src/__tests__/config.test.ts
@@ -149,6 +149,30 @@ describe("config actions", () => {
       assert.strictEqual(sent[0].type, VALKEY.CONFIG.updateConfigFailed)
       const node2Result = sent[0].payload.nodeResults.find((r: any) => r.nodeId === "node-2")
       assert.strictEqual(node2Result.success, false)
+      // The failed reply is PARTIAL here (node-1 succeeded), so it still
+      // carries the applied config: node-1 DID apply it and the frontend
+      // shows it.
+      assert.deepStrictEqual(sent[0].payload.appliedConfig, { epic: { name: "monitor" } })
+    })
+
+    it("omits appliedConfig from a total-failure reply (no node applied it)", async () => {
+      process.env.CONFIG_RETRY_MAX_RETRIES = "0"
+      clusterNodesRegistry = twoNodeRegistry()
+      metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
+      metricsServerMap.set("node-2", { metricsURI: "http://localhost:9002" })
+      mockFetch({ success: false, message: "down", data: {} }, false, 500)
+
+      const action = {
+        type: VALKEY.CONFIG.updateConfig,
+        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epic: { name: "monitor" } } },
+      }
+
+      await runConfigPushSession(deps())(action as any)
+
+      const sent = aggregateReplies()
+      assert.strictEqual(sent.length, 1)
+      assert.strictEqual(sent[0].type, VALKEY.CONFIG.updateConfigFailed)
+      assert.strictEqual(sent[0].payload.appliedConfig, undefined)
     })
 
     it("a new request for the same target aborts the in-flight session and only the new session replies", async () => {

--- a/apps/server/src/actions/config.ts
+++ b/apps/server/src/actions/config.ts
@@ -206,23 +206,20 @@ const sendConfigReply = (
 ) => {
   const outcome = toOutcome(result)
 
-  if (outcome === "fulfilled") {
-    const payload: AggregateReplyId & NodeResultsReply = {
-      ...replyId,
-      outcome,
-      nodeResults: result.attempted,
-      notAttemptedNodeIds: result.notAttempted,
-      appliedConfig: config as Record<string, unknown>,
-    }
-    safeSend(ws, JSON.stringify({ type: VALKEY.CONFIG.updateConfigFulfilled, payload }))
-    return
-  }
-
+  // The wire outcome `failed` also covers PARTIAL failures (some nodes
+  // succeeded); those nodes DID apply the config, so the reply must carry it
+  // for the frontend to display. On a total failure nothing applied it and
+  // the field is omitted.
+  const anyApplied = result.attempted.some((r) => r.success)
   const payload: AggregateReplyId & NodeResultsReply = {
     ...replyId,
     outcome,
     nodeResults: result.attempted,
     notAttemptedNodeIds: result.notAttempted,
+    ...(anyApplied ? { appliedConfig: config as Record<string, unknown> } : {}),
   }
-  safeSend(ws, JSON.stringify({ type: VALKEY.CONFIG.updateConfigFailed, payload }))
+  const type = outcome === "fulfilled"
+    ? VALKEY.CONFIG.updateConfigFulfilled
+    : VALKEY.CONFIG.updateConfigFailed
+  safeSend(ws, JSON.stringify({ type, payload }))
 }

--- a/docs-site/src/content/docs/features/activity.md
+++ b/docs-site/src/content/docs/features/activity.md
@@ -55,6 +55,8 @@ This creates a repeating cycle: capture for *duration*, pause for *interval*, ca
 
 In both modes, hot keys are aggregated across all monitored nodes and sorted by access count.
 
+If some nodes are unreachable when monitoring starts, the reachable nodes still start (and apply any changed settings); monitoring is reported as running, and the failed nodes are listed in a separate partial-data warning.
+
 :::caution
 `MONITOR` has a performance impact on the server — it streams every command to the monitoring client. Best suited for short diagnostic sessions, not continuous monitoring.
 :::


### PR DESCRIPTION
## Description
Addresses #425.

Instead of reading the current node's entry, which made the error invisible if a different node failed, monitorError is derived from the first cluster node whose MONITOR failed to start.

For the Hot Keys config changes not being reflected, the sendConfigReply now includes appliedConfig in the partial reply, so that the frontend will update config even on partial successes.

### Change Visualization

<img width="1183" height="1127" alt="image" src="https://github.com/user-attachments/assets/8c1f4bc7-f6ed-49ef-b589-2afea02460e3" />

