### PR TITLE
Update security reporting to use GitHub security advisories

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Check existing issues
     url: https://github.com/valkey-io/valkey-admin/issues
     about: Please search existing issues before creating a new one to avoid duplicates
+  - name: Report a security vulnerability
+    url: https://github.com/valkey-io/valkey-admin/security/advisories/new
+    about: Please report security issues privately through GitHub's security advisory feature

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,9 @@
 # Reporting a Vulnerability
 
-If you believe you've discovered a security vulnerability, please contact the Valkey team at security@lists.valkey.io.
-Please *DO NOT* create an issue.
-We follow a responsible disclosure procedure, so depending on the severity of the issue we may notify Valkey vendors about the issue before releasing it publicly.
+If you believe you've discovered a security vulnerability, please report it through GitHub's private security advisory feature:
+
+**[Report a vulnerability](https://github.com/valkey-io/valkey-admin/security/advisories/new)**
+
+Please **DO NOT** create a public issue for security vulnerabilities.
+
+We follow responsible disclosure and will work with you to address the issue before any public disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,9 @@
 # Reporting a Vulnerability
 
-If you believe you've discovered a security vulnerability, please report it through GitHub's private security advisory feature:
+If you believe you've discovered a security vulnerability, please report it through one of the following channels:
 
-**[Report a vulnerability](https://github.com/valkey-io/valkey-admin/security/advisories/new)**
+- **GitHub Security Advisory (preferred):** [Report a vulnerability](https://github.com/valkey-io/valkey-admin/security/advisories/new)
+- **Email:** security@lists.valkey.io
 
 Please **DO NOT** create a public issue for security vulnerabilities.
 


### PR DESCRIPTION
Update SECURITY.md and issue template config to direct vulnerability reports to GitHub's private security advisory feature instead of the mailing list.