### PR TITLE
Pipeline per-key commands for performance

### DIFF
--- a/apps/metrics/src/analyzers/calculate-hot-keys-slots.test.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys-slots.test.js
@@ -23,7 +23,7 @@ describe("calculate-hot-keys (calculateHotKeysFromHotSlots)", () => {
 
     client = createMockValkeyClient()
     client.exec = vi.fn(async (batch) =>
-      Promise.all(batch.commands.map((cmd) => client.customCommand(cmd)))
+      Promise.all(batch.commands.map((cmd) => client.customCommand(cmd))),
     )
   })
 

--- a/apps/metrics/src/analyzers/calculate-hot-keys-slots.test.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys-slots.test.js
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { createMockValkeyClient } from "../__tests__/test-helpers.js"
 
+// Mock @valkey/valkey-glide
+vi.mock("@valkey/valkey-glide", () => ({
+  Batch: class { constructor() { this.commands = [] } customCommand(args) { this.commands.push(args); return this } },
+}))
+
 // Mock get-hot-slots
 vi.mock("./get-hot-slots.js", () => ({
   getHotSlots: vi.fn(),
@@ -17,6 +22,9 @@ describe("calculate-hot-keys (calculateHotKeysFromHotSlots)", () => {
     getHotSlots = getHotSlotsModule.getHotSlots
 
     client = createMockValkeyClient()
+    client.exec = vi.fn(async (batch) =>
+      Promise.all(batch.commands.map((cmd) => client.customCommand(cmd)))
+    )
   })
 
   describe("basic functionality", () => {

--- a/apps/metrics/src/analyzers/calculate-hot-keys.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys.js
@@ -76,6 +76,8 @@ export const calculateHotKeysFromMonitor = ({ limit, cutoff }) => (rows) =>
     R.take(limit),
   )(rows)
 
+import { Batch } from "@valkey/valkey-glide"
+
 // Must have maxmemory-policy set to lfu*
 export const calculateHotKeysFromHotSlots = async (client, { count = 50 } = {}) => {
   const hotSlots = await getHotSlots(client)
@@ -93,26 +95,28 @@ export const calculateHotKeysFromHotSlots = async (client, { count = 50 } = {}) 
 
     } while (cursorToSlot === slotId && cursor !== 0)
     
-    return keys.map( async (key) => {
-      // Must have LFU enabled for this to work
-      const freq = parseInt(await client.customCommand(["OBJECT", "FREQ", key]))
-      return { key, freq }
-    })
+    return keys
   })
 
-  const keyFreqNestedPromises = await Promise.all(slotPromises)
-  const keyFreqPromises = keyFreqNestedPromises.flat()
-  const allKeyFreqs = await Promise.all(keyFreqPromises)
+  const slotKeys = await Promise.all(slotPromises)
+  const allKeys = slotKeys.flat()
+
+  // Pipeline all OBJECT FREQ commands in a single round trip
+  const batch = new Batch(false)
+  for (const key of allKeys) {
+    batch.customCommand(["OBJECT", "FREQ", key])
+  }
+  const freqResults = await client.exec(batch)
 
   const heap = new Heap((a, b) => a.freq - b.freq)
-  for (const { key, freq } of allKeyFreqs) {
-    if (freq <= 1) continue
-    if (heap.size() < count){
-      heap.push({ key, freq })
-    }
-    else if ( freq > heap.peek().freq) {
+  for (let i = 0; i < allKeys.length; i++) {
+    const freq = parseInt(freqResults[i])
+    if (isNaN(freq) || freq <= 1) continue
+    if (heap.size() < count) {
+      heap.push({ key: allKeys[i], freq })
+    } else if (freq > heap.peek().freq) {
       heap.pop()
-      heap.push({ key, freq })
+      heap.push({ key: allKeys[i], freq })
     }
   }
   return heap.toArray().map(({ key, freq }) => [key, freq])

--- a/apps/metrics/src/analyzers/calculate-hot-keys.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys.js
@@ -1,6 +1,7 @@
 import * as R from "ramda"
 import { Heap } from "heap-js"
 import { Batch } from "@valkey/valkey-glide"
+import { VALKEY_CLIENT } from "valkey-common"
 import { getHotSlots } from "./get-hot-slots.js"
 
 const ACCESS_COMMANDS = [
@@ -101,7 +102,7 @@ export const calculateHotKeysFromHotSlots = async (client, { count = 50 } = {}) 
   const allKeys = slotKeys.flat()
 
   // Pipeline OBJECT FREQ in chunks to avoid overwhelming the server
-  const PIPELINE_CHUNK_SIZE = 500
+  const { PIPELINE_CHUNK_SIZE } = VALKEY_CLIENT
   const freqResults = []
   for (let i = 0; i < allKeys.length; i += PIPELINE_CHUNK_SIZE) {
     const chunk = allKeys.slice(i, i + PIPELINE_CHUNK_SIZE)

--- a/apps/metrics/src/analyzers/calculate-hot-keys.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys.js
@@ -1,7 +1,7 @@
 import * as R from "ramda"
 import { Heap } from "heap-js"
 import { Batch } from "@valkey/valkey-glide"
-import { VALKEY_CLIENT } from "valkey-common"
+import { VALKEY_CLIENT } from "../../../../common/src/constants.js"
 import { getHotSlots } from "./get-hot-slots.js"
 
 const ACCESS_COMMANDS = [

--- a/apps/metrics/src/analyzers/calculate-hot-keys.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys.js
@@ -100,12 +100,18 @@ export const calculateHotKeysFromHotSlots = async (client, { count = 50 } = {}) 
   const slotKeys = await Promise.all(slotPromises)
   const allKeys = slotKeys.flat()
 
-  // Pipeline all OBJECT FREQ commands in a single round trip
-  const batch = new Batch(false)
-  for (const key of allKeys) {
-    batch.customCommand(["OBJECT", "FREQ", key])
+  // Pipeline OBJECT FREQ in chunks to avoid overwhelming the server
+  const PIPELINE_CHUNK_SIZE = 500
+  const freqResults = []
+  for (let i = 0; i < allKeys.length; i += PIPELINE_CHUNK_SIZE) {
+    const chunk = allKeys.slice(i, i + PIPELINE_CHUNK_SIZE)
+    const batch = new Batch(false)
+    for (const key of chunk) {
+      batch.customCommand(["OBJECT", "FREQ", key])
+    }
+    const chunkResults = await client.exec(batch)
+    freqResults.push(...chunkResults)
   }
-  const freqResults = await client.exec(batch)
 
   const heap = new Heap((a, b) => a.freq - b.freq)
   for (let i = 0; i < allKeys.length; i++) {

--- a/apps/metrics/src/analyzers/calculate-hot-keys.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys.js
@@ -1,5 +1,6 @@
 import * as R from "ramda"
 import { Heap } from "heap-js"
+import { Batch } from "@valkey/valkey-glide"
 import { getHotSlots } from "./get-hot-slots.js"
 
 const ACCESS_COMMANDS = [
@@ -75,8 +76,6 @@ export const calculateHotKeysFromMonitor = ({ limit, cutoff }) => (rows) =>
     R.reject(([, count]) => count <= cutoff),
     R.take(limit),
   )(rows)
-
-import { Batch } from "@valkey/valkey-glide"
 
 // Must have maxmemory-policy set to lfu*
 export const calculateHotKeysFromHotSlots = async (client, { count = 50 } = {}) => {

--- a/apps/metrics/src/analyzers/calculate-hot-keys.test.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys.test.js
@@ -1,4 +1,9 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("@valkey/valkey-glide", () => ({
+  Batch: class { constructor() { this.commands = [] } customCommand(args) { this.commands.push(args); return this } },
+}))
+
 import { calculateHotKeysFromMonitor } from "./calculate-hot-keys.js"
 
 describe("calculateHotKeysFromMonitor", () => {

--- a/apps/metrics/src/analyzers/enrich-hot-keys.js
+++ b/apps/metrics/src/analyzers/enrich-hot-keys.js
@@ -1,18 +1,24 @@
-export const enrichHotKeys = (client) => async (hotKeyPairs) => {
-  return Promise.all(
-    hotKeyPairs.map(async ([keyName, count]) => {
-      try {
-        const [ttl, memoryUsage] = await Promise.all([
-          client.customCommand(["TTL", keyName]).catch(() => -1),
-          client.customCommand(["MEMORY", "USAGE", keyName]).catch(() => null),
-        ])
+import { Batch } from "@valkey/valkey-glide"
 
-        // Keep the same shape as before: [keyName, count, size, ttl]
-        return [keyName, count, memoryUsage ?? null, ttl ?? -1]
-      } catch (error) {
-        console.error(`Error fetching data for the key ${keyName}:`, error)
-        return [keyName, count, null, -1]
-      }
-    }),
-  )
+export const enrichHotKeys = (client) => async (hotKeyPairs) => {
+  if (hotKeyPairs.length === 0) return []
+
+  const batch = new Batch(false)
+  for (const [keyName] of hotKeyPairs) {
+    batch.customCommand(["TTL", keyName])
+    batch.customCommand(["MEMORY", "USAGE", keyName])
+  }
+
+  let results
+  try {
+    results = await client.exec(batch)
+  } catch {
+    return hotKeyPairs.map(([keyName, count]) => [keyName, count, null, -1])
+  }
+
+  return hotKeyPairs.map(([keyName, count], i) => {
+    const ttl = results[i * 2] ?? -1
+    const memoryUsage = results[i * 2 + 1] ?? null
+    return [keyName, count, memoryUsage, ttl]
+  })
 }

--- a/apps/metrics/src/analyzers/enrich-hot-keys.js
+++ b/apps/metrics/src/analyzers/enrich-hot-keys.js
@@ -22,8 +22,7 @@ export const enrichHotKeys = (client) => async (hotKeyPairs) => {
   }
 
   return hotKeyPairs.map(([keyName, count], i) => {
-    const ttl = results[i * 2] ?? -1
-    const memoryUsage = results[i * 2 + 1] ?? null
-    return [keyName, count, memoryUsage, ttl]
+    const [ttl, memoryUsage] = results.slice(i * 2, i * 2 + 2)
+    return [keyName, count, memoryUsage ?? null, ttl ?? -1]
   })
 }

--- a/apps/metrics/src/analyzers/enrich-hot-keys.js
+++ b/apps/metrics/src/analyzers/enrich-hot-keys.js
@@ -1,19 +1,24 @@
 import { Batch } from "@valkey/valkey-glide"
 
+const PIPELINE_CHUNK_SIZE = 500
+
 export const enrichHotKeys = (client) => async (hotKeyPairs) => {
   if (hotKeyPairs.length === 0) return []
 
-  const batch = new Batch(false)
-  for (const [keyName] of hotKeyPairs) {
-    batch.customCommand(["TTL", keyName])
-    batch.customCommand(["MEMORY", "USAGE", keyName])
-  }
-
-  let results
-  try {
-    results = await client.exec(batch)
-  } catch {
-    return hotKeyPairs.map(([keyName, count]) => [keyName, count, null, -1])
+  const results = []
+  for (let i = 0; i < hotKeyPairs.length; i += PIPELINE_CHUNK_SIZE) {
+    const chunk = hotKeyPairs.slice(i, i + PIPELINE_CHUNK_SIZE)
+    const batch = new Batch(false)
+    for (const [keyName] of chunk) {
+      batch.customCommand(["TTL", keyName])
+      batch.customCommand(["MEMORY", "USAGE", keyName])
+    }
+    try {
+      const chunkResults = await client.exec(batch)
+      results.push(...chunkResults)
+    } catch {
+      results.push(...chunk.flatMap(() => [-1, null]))
+    }
   }
 
   return hotKeyPairs.map(([keyName, count], i) => {

--- a/apps/metrics/src/analyzers/enrich-hot-keys.js
+++ b/apps/metrics/src/analyzers/enrich-hot-keys.js
@@ -1,5 +1,5 @@
 import { Batch } from "@valkey/valkey-glide"
-import { VALKEY_CLIENT } from "valkey-common"
+import { VALKEY_CLIENT } from "../../../../common/src/constants.js"
 
 const { PIPELINE_CHUNK_SIZE } = VALKEY_CLIENT
 

--- a/apps/metrics/src/analyzers/enrich-hot-keys.js
+++ b/apps/metrics/src/analyzers/enrich-hot-keys.js
@@ -1,6 +1,7 @@
 import { Batch } from "@valkey/valkey-glide"
+import { VALKEY_CLIENT } from "valkey-common"
 
-const PIPELINE_CHUNK_SIZE = 500
+const { PIPELINE_CHUNK_SIZE } = VALKEY_CLIENT
 
 export const enrichHotKeys = (client) => async (hotKeyPairs) => {
   if (hotKeyPairs.length === 0) return []

--- a/apps/metrics/src/analyzers/scan-big-keys.js
+++ b/apps/metrics/src/analyzers/scan-big-keys.js
@@ -1,7 +1,8 @@
 import { Heap } from "heap-js"
 import { Batch } from "@valkey/valkey-glide"
+import { VALKEY_CLIENT } from "../../../../common/src/constants.js"
 
-export const scanBigKeys = async (client, { scanLimit = 10000, topN = 50, batchSize = 500 } = {}) => {
+export const scanBigKeys = async (client, { scanLimit = 10000, topN = 50, batchSize = VALKEY_CLIENT.PIPELINE_CHUNK_SIZE } = {}) => {
   const heap = new Heap((a, b) => a.sizeBytes - b.sizeBytes)
 
   const totalKeys = Number(await client.customCommand(["DBSIZE"]))

--- a/apps/metrics/src/analyzers/scan-big-keys.js
+++ b/apps/metrics/src/analyzers/scan-big-keys.js
@@ -1,6 +1,7 @@
 import { Heap } from "heap-js"
+import { Batch } from "@valkey/valkey-glide"
 
-export const scanBigKeys = async (client, { scanLimit = 10000, topN = 50, batchSize = 100 } = {}) => {
+export const scanBigKeys = async (client, { scanLimit = 10000, topN = 50, batchSize = 500 } = {}) => {
   const heap = new Heap((a, b) => a.sizeBytes - b.sizeBytes)
 
   const totalKeys = Number(await client.customCommand(["DBSIZE"]))
@@ -12,19 +13,27 @@ export const scanBigKeys = async (client, { scanLimit = 10000, topN = 50, batchS
     const [nextCursor, keys] = await client.customCommand(["SCAN", cursor, "COUNT", batchSize.toString()])
     cursor = nextCursor
 
-    for (const key of keys) {
-      const [sizeBytes, type, ttl] = await Promise.all([
-        // sample 5 elements to estimate size faster on big keys
-        client.customCommand(["MEMORY", "USAGE", key, "SAMPLES", "5"]),
-        client.customCommand(["TYPE", key]),
-        client.customCommand(["TTL", key]),
-      ])
+    if (keys.length === 0) continue
 
-      const entry = { key, sizeBytes: Number(sizeBytes), type, ttl: Number(ttl) }
+    // Pipeline all per-key commands in a single round trip
+    const batch = new Batch(false)
+    for (const key of keys) {
+      batch.customCommand(["MEMORY", "USAGE", key, "SAMPLES", "5"])
+      batch.customCommand(["TYPE", key])
+      batch.customCommand(["TTL", key])
+    }
+    const results = await client.exec(batch)
+
+    for (let i = 0; i < keys.length; i++) {
+      const sizeBytes = Number(results[i * 3])
+      const type = results[i * 3 + 1]
+      const ttl = Number(results[i * 3 + 2])
+
+      const entry = { key: keys[i], sizeBytes, type, ttl }
 
       if (heap.size() < topN) {
         heap.push(entry)
-      } else if (Number(sizeBytes) > heap.peek().sizeBytes) {
+      } else if (sizeBytes > heap.peek().sizeBytes) {
         heap.pop()
         heap.push(entry)
       }
@@ -37,14 +46,23 @@ export const scanBigKeys = async (client, { scanLimit = 10000, topN = 50, batchS
   // topN keys returned in descending order of sizeBytes
   const topKeys = heap.toArray().sort((a, b) => b.sizeBytes - a.sizeBytes)
 
-  // OBJECT FREQ requires an LFU maxmemory-policy, if not set, freq will be null
-  const keys = await Promise.all(topKeys.map(async (entry) => {
-    try {
-      return { ...entry, freq: Number(await client.customCommand(["OBJECT", "FREQ", entry.key])) }
-    } catch {
-      return { ...entry, freq: null }
-    }
-  }))
+  // Pipeline OBJECT FREQ for all top keys
+  const freqBatch = new Batch(false)
+  for (const entry of topKeys) {
+    freqBatch.customCommand(["OBJECT", "FREQ", entry.key])
+  }
+
+  let freqResults
+  try {
+    freqResults = await client.exec(freqBatch)
+  } catch {
+    freqResults = null
+  }
+
+  const keys = topKeys.map((entry, i) => {
+    const freq = freqResults?.[i] != null ? Number(freqResults[i]) : null
+    return { ...entry, freq }
+  })
 
   return { keys, scanned, totalKeys, scannedAt: Date.now() }
 }

--- a/apps/metrics/src/analyzers/scan-big-keys.js
+++ b/apps/metrics/src/analyzers/scan-big-keys.js
@@ -57,8 +57,8 @@ export const scanBigKeys = async (client, { scanLimit = 10000, topN = 50, batchS
   }
 
   const keys = topKeys.map((entry, i) => {
-    const freq = freqResults?.[i] != null ? Number(freqResults[i]) : null
-    return { ...entry, freq }
+    const freq = Number(freqResults?.[i])
+    return { ...entry, freq: Number.isNaN(freq) ? null : freq }
   })
 
   return { keys, scanned, totalKeys, scannedAt: Date.now() }

--- a/apps/metrics/src/analyzers/scan-big-keys.js
+++ b/apps/metrics/src/analyzers/scan-big-keys.js
@@ -30,7 +30,7 @@ export const scanBigKeys = async (client, { scanLimit = 10000, topN = 50, batchS
 
       if (heap.size() < topN) {
         heap.push(entry)
-      } else if (sizeBytes > heap.peek().sizeBytes) {
+      } else if (entry.sizeBytes > heap.peek().sizeBytes) {
         heap.pop()
         heap.push(entry)
       }

--- a/apps/metrics/src/analyzers/scan-big-keys.js
+++ b/apps/metrics/src/analyzers/scan-big-keys.js
@@ -25,11 +25,8 @@ export const scanBigKeys = async (client, { scanLimit = 10000, topN = 50, batchS
     const results = await client.exec(batch)
 
     for (let i = 0; i < keys.length; i++) {
-      const sizeBytes = Number(results[i * 3])
-      const type = results[i * 3 + 1]
-      const ttl = Number(results[i * 3 + 2])
-
-      const entry = { key: keys[i], sizeBytes, type, ttl }
+      const [sizeBytes, type, ttl] = results.slice(i * 3, i * 3 + 3)
+      const entry = { key: keys[i], sizeBytes: Number(sizeBytes), type, ttl: Number(ttl) }
 
       if (heap.size() < topN) {
         heap.push(entry)

--- a/apps/server/src/__tests__/keys-browser.test.ts
+++ b/apps/server/src/__tests__/keys-browser.test.ts
@@ -647,6 +647,14 @@ describe("getKeys", () => {
           if (cmd[0] === "GET") return "value"
           return null
         }),
+        exec: mock.fn(async (batch: any) => {
+          return batch.commands.map((cmd: string[]) => {
+            if (cmd[0] === "TYPE") return "string"
+            if (cmd[0] === "TTL") return -1
+            if (cmd[0] === "MEMORY") return 50
+            return null
+          })
+        }),
         instanceof: () => false, // Standalone client
       }
 

--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -542,9 +542,7 @@ export async function getKeys(
       keyList.map((key, i) =>
         limit(async () => {
           try {
-            const keyType = (metadataResults[i * 3] ?? "unknown") as string
-            const ttl = (metadataResults[i * 3 + 1] ?? -1) as number
-            const memoryUsage = (metadataResults[i * 3 + 2] ?? null) as number | null
+            const [keyType, ttl, memoryUsage] = metadataResults.slice(i * 3, i * 3 + 3) as [string, number, number | null]
 
             const keyInfo: EnrichedKeyInfo = {
               name: key,

--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -340,16 +340,48 @@ async function getFullKeyInfo(
   }
 }
 
+type KeyMetadata = { type: string; ttl: number; size: number | null }
+
+async function fetchSingleKeyMetadata(client: GlideClient | GlideClusterClient, key: string): Promise<KeyMetadata> {
+  const [type, ttl, size] = await Promise.all([
+    client.customCommand(["TYPE", key]) as Promise<string>,
+    client.customCommand(["TTL", key]).catch(() => -1) as Promise<number>,
+    client.customCommand(["MEMORY", "USAGE", key]).catch(() => null) as Promise<number | null>,
+  ])
+  return { type, ttl, size }
+}
+
+const PIPELINE_CHUNK_SIZE = 500
+
+async function fetchKeyMetadataBatch(client: GlideClient | GlideClusterClient, keys: string[]): Promise<KeyMetadata[]> {
+  const BatchClass = client instanceof GlideClusterClient ? ClusterBatch : Batch
+  const results: GlideReturnType[] = []
+
+  for (let i = 0; i < keys.length; i += PIPELINE_CHUNK_SIZE) {
+    const chunk = keys.slice(i, i + PIPELINE_CHUNK_SIZE)
+    const batch = new BatchClass(false)
+    for (const key of chunk) {
+      batch.customCommand(["TYPE", key])
+      batch.customCommand(["TTL", key])
+      batch.customCommand(["MEMORY", "USAGE", key])
+    }
+    const chunkResults = await client.exec(batch) as GlideReturnType[]
+    results.push(...chunkResults)
+  }
+
+  return keys.map((_, i) => {
+    const [type, ttl, size] = results.slice(i * 3, i * 3 + 3)
+    return { type: (type ?? "unknown") as string, ttl: (ttl ?? -1) as number, size: (size ?? null) as number | null }
+  })
+}
+
 export async function getKeyInfo(
   client: GlideClient | GlideClusterClient,
   key: string,
+  metadata?: KeyMetadata,
 ): Promise<EnrichedKeyInfo> {
   try {
-    const [keyType, ttl, memoryUsage] = await Promise.all([
-      client.customCommand(["TYPE", key]) as Promise<string>,
-      client.customCommand(["TTL", key]).catch(() => -1) as Promise<number>,
-      client.customCommand(["MEMORY", "USAGE", key]).catch(() => null) as Promise<number | null>,
-    ])
+    const { type: keyType, ttl, size: memoryUsage } = metadata ?? await fetchSingleKeyMetadata(client, key)
 
     const keyInfo: EnrichedKeyInfo = {
       name: key,
@@ -521,76 +553,16 @@ export async function getKeys(
     const allKeys = client instanceof GlideClusterClient ? await scanCluster(client, payload) : await scanStandalone(client, payload)
     const keyList = [...allKeys]
 
-    // Pipeline TYPE, TTL, MEMORY USAGE in chunks to avoid overwhelming the server
-    const BatchClass = client instanceof GlideClusterClient ? ClusterBatch : Batch
-    const PIPELINE_CHUNK_SIZE = 500
-    const metadataResults: GlideReturnType[] = []
-    for (let i = 0; i < keyList.length; i += PIPELINE_CHUNK_SIZE) {
-      const chunk = keyList.slice(i, i + PIPELINE_CHUNK_SIZE)
-      const metadataBatch = new BatchClass(false)
-      for (const key of chunk) {
-        metadataBatch.customCommand(["TYPE", key])
-        metadataBatch.customCommand(["TTL", key])
-        metadataBatch.customCommand(["MEMORY", "USAGE", key])
-      }
-      const chunkResults = await client.exec(metadataBatch) as GlideReturnType[]
-      metadataResults.push(...chunkResults)
-    }
+    const metadata = await fetchKeyMetadataBatch(client, keyList)
 
-    // Build enriched keys with type-specific follow-ups
     const enrichedKeys = await Promise.all(
       keyList.map((key, i) =>
-        limit(async () => {
-          try {
-            const [keyType, ttl, memoryUsage] = metadataResults.slice(i * 3, i * 3 + 3) as [string, number, number | null]
-
-            const keyInfo: EnrichedKeyInfo = {
-              name: key,
-              type: keyType,
-              ttl,
-              size: memoryUsage || -1,
-            }
-
-            const elementCommands: Record<string, { sizeCmd: string; elementsCmd: string[] }> = {
-              list: { sizeCmd: "LLEN", elementsCmd: ["LRANGE", key] },
-              zset: { sizeCmd: "ZCARD", elementsCmd: ["ZRANGE", key] },
-              stream: { sizeCmd: "XLEN", elementsCmd: ["XRANGE", key] },
-              "rejson-rl": { sizeCmd: "", elementsCmd: ["JSON.GET", key] },
-              string: { sizeCmd: "", elementsCmd: ["GET", key] },
-              set: { sizeCmd: "SCARD", elementsCmd: ["SSCAN", keyInfo.name] },
-              hash: { sizeCmd: "HLEN", elementsCmd: ["HSCAN", keyInfo.name] },
-            }
-
-            const commands = elementCommands[keyType.toLowerCase()]
-            if (!commands) return keyInfo
-
-            if (memoryUsage > keyValueSizeLimitBytes) {
-              if (commands.sizeCmd) {
-                keyInfo.collectionSize = await (client.customCommand([commands.sizeCmd, key])) as number
-              }
-              keyInfo.elementsWarning = `This key is ${formatBytes(memoryUsage)}, which is larger than the maximum display size of ${formatBytes(keyValueSizeLimitBytes)}.`
-              return keyInfo
-            }
-
-            switch (keyType.toLowerCase()) {
-              case "set":
-              case "hash":
-                return await getScanKeyInfo(client, keyInfo, commands)
-              case "list":
-                return await getPaginatedListInfo(client, keyInfo, commands)
-              case "stream":
-                return await getPaginatedStreamInfo(client, keyInfo, commands)
-              case "zset":
-                return await getPaginatedZSetInfo(client, keyInfo, commands)
-              case "rejson-rl":
-                return await getPaginatedJsonInfo(client, keyInfo, commands)
-              default:
-                return await getFullKeyInfo(client, keyInfo, commands)
-            }
-          } catch {
-            return { name: key, type: "unknown", ttl: -1, size: -1 }
-          }
-        }),
+        limit(() => getKeyInfo(client, key, metadata[i]).catch(() => ({
+          name: key,
+          type: "unknown",
+          ttl: -1,
+          size: -1,
+        }))),
       ),
     )
 

--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -519,16 +519,74 @@ export async function getKeys(
   try {
     const totalKeys = await client.customCommand(["DBSIZE"])
     const allKeys = client instanceof GlideClusterClient ? await scanCluster(client, payload) : await scanStandalone(client, payload)
+    const keyList = [...allKeys]
+
+    // Pipeline TYPE, TTL, MEMORY USAGE for all keys in one round trip
+    const BatchClass = client instanceof GlideClusterClient ? ClusterBatch : Batch
+    const metadataBatch = new BatchClass(false)
+    for (const key of keyList) {
+      metadataBatch.customCommand(["TYPE", key])
+      metadataBatch.customCommand(["TTL", key])
+      metadataBatch.customCommand(["MEMORY", "USAGE", key])
+    }
+    const metadataResults = await client.exec(metadataBatch) as GlideReturnType[]
+
+    // Build enriched keys with type-specific follow-ups
     const enrichedKeys = await Promise.all(
-      [...allKeys].map((k) =>
-        limit(() =>
-          getKeyInfo(client, k).catch(() => ({
-            name: k,
-            type: "unknown",
-            ttl: -1,
-            size: -1,
-          })),
-        ),
+      keyList.map((key, i) =>
+        limit(async () => {
+          try {
+            const keyType = (metadataResults[i * 3] ?? "unknown") as string
+            const ttl = (metadataResults[i * 3 + 1] ?? -1) as number
+            const memoryUsage = (metadataResults[i * 3 + 2] ?? null) as number | null
+
+            const keyInfo: EnrichedKeyInfo = {
+              name: key,
+              type: keyType,
+              ttl,
+              size: memoryUsage || -1,
+            }
+
+            const elementCommands: Record<string, { sizeCmd: string; elementsCmd: string[] }> = {
+              list: { sizeCmd: "LLEN", elementsCmd: ["LRANGE", key] },
+              zset: { sizeCmd: "ZCARD", elementsCmd: ["ZRANGE", key] },
+              stream: { sizeCmd: "XLEN", elementsCmd: ["XRANGE", key] },
+              "rejson-rl": { sizeCmd: "", elementsCmd: ["JSON.GET", key] },
+              string: { sizeCmd: "", elementsCmd: ["GET", key] },
+              set: { sizeCmd: "SCARD", elementsCmd: ["SSCAN", keyInfo.name] },
+              hash: { sizeCmd: "HLEN", elementsCmd: ["HSCAN", keyInfo.name] },
+            }
+
+            const commands = elementCommands[keyType.toLowerCase()]
+            if (!commands) return keyInfo
+
+            if (memoryUsage > keyValueSizeLimitBytes) {
+              if (commands.sizeCmd) {
+                keyInfo.collectionSize = await (client.customCommand([commands.sizeCmd, key])) as number
+              }
+              keyInfo.elementsWarning = `This key is ${formatBytes(memoryUsage)}, which is larger than the maximum display size of ${formatBytes(keyValueSizeLimitBytes)}.`
+              return keyInfo
+            }
+
+            switch (keyType.toLowerCase()) {
+              case "set":
+              case "hash":
+                return await getScanKeyInfo(client, keyInfo, commands)
+              case "list":
+                return await getPaginatedListInfo(client, keyInfo, commands)
+              case "stream":
+                return await getPaginatedStreamInfo(client, keyInfo, commands)
+              case "zset":
+                return await getPaginatedZSetInfo(client, keyInfo, commands)
+              case "rejson-rl":
+                return await getPaginatedJsonInfo(client, keyInfo, commands)
+              default:
+                return await getFullKeyInfo(client, keyInfo, commands)
+            }
+          } catch {
+            return { name: key, type: "unknown", ttl: -1, size: -1 }
+          }
+        }),
       ),
     )
 

--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -521,15 +521,21 @@ export async function getKeys(
     const allKeys = client instanceof GlideClusterClient ? await scanCluster(client, payload) : await scanStandalone(client, payload)
     const keyList = [...allKeys]
 
-    // Pipeline TYPE, TTL, MEMORY USAGE for all keys in one round trip
+    // Pipeline TYPE, TTL, MEMORY USAGE in chunks to avoid overwhelming the server
     const BatchClass = client instanceof GlideClusterClient ? ClusterBatch : Batch
-    const metadataBatch = new BatchClass(false)
-    for (const key of keyList) {
-      metadataBatch.customCommand(["TYPE", key])
-      metadataBatch.customCommand(["TTL", key])
-      metadataBatch.customCommand(["MEMORY", "USAGE", key])
+    const PIPELINE_CHUNK_SIZE = 500
+    const metadataResults: GlideReturnType[] = []
+    for (let i = 0; i < keyList.length; i += PIPELINE_CHUNK_SIZE) {
+      const chunk = keyList.slice(i, i + PIPELINE_CHUNK_SIZE)
+      const metadataBatch = new BatchClass(false)
+      for (const key of chunk) {
+        metadataBatch.customCommand(["TYPE", key])
+        metadataBatch.customCommand(["TTL", key])
+        metadataBatch.customCommand(["MEMORY", "USAGE", key])
+      }
+      const chunkResults = await client.exec(metadataBatch) as GlideReturnType[]
+      metadataResults.push(...chunkResults)
     }
-    const metadataResults = await client.exec(metadataBatch) as GlideReturnType[]
 
     // Build enriched keys with type-specific follow-ups
     const enrichedKeys = await Promise.all(

--- a/apps/server/src/keys-browser.ts
+++ b/apps/server/src/keys-browser.ts
@@ -351,7 +351,7 @@ async function fetchSingleKeyMetadata(client: GlideClient | GlideClusterClient, 
   return { type, ttl, size }
 }
 
-const PIPELINE_CHUNK_SIZE = 500
+const { PIPELINE_CHUNK_SIZE } = VALKEY_CLIENT
 
 async function fetchKeyMetadataBatch(client: GlideClient | GlideClusterClient, keys: string[]): Promise<KeyMetadata[]> {
   const BatchClass = client instanceof GlideClusterClient ? ClusterBatch : Batch

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -183,6 +183,8 @@ export const VALKEY_CLIENT = {
   // chunk size for paginating elements to avoid blocking due to keys with too many elements
   ELEMENT_PAGE_SIZE: 50, 
   KEY_VALUE_SIZE_LIMIT_BYTES: 2048, // 2KiB
+  // max keys per pipeline batch to avoid overwhelming the server
+  PIPELINE_CHUNK_SIZE: 500,
   MESSAGES: {
     NOT_READABLE: "Not human readable.",
   },


### PR DESCRIPTION
Performance enhancement that pipelines per-key Valkey commands instead of issuing them as individual round trips. Applied across three areas:

1. **Big Keys scan**:`MEMORY USAGE`, `TYPE`, `TTL`, and `OBJECT FREQ` are now pipelined per SCAN batch instead of sequentially per key. Default batch size increased from 100 to 500.

2. **Hot Keys enrichment**: `TTL` and `MEMORY USAGE` for hot key results are pipelined in a single batch instead of per-key `Promise.all` calls.

3. **Key Browser**: Metadata fetch (`TYPE`, `TTL`, `MEMORY USAGE`) for all scanned keys is pipelined upfront via `fetchKeyMetadataBatch`, then passed into `getKeyInfo` for type-specific follow-ups.

All pipelines are capped at 500 keys per batch to avoid overwhelming the server.

Closes #450