### PR TITLE
Fix documentation inaccuracies

### DIFF
--- a/docs-site/src/content/docs/configuration/metrics.md
+++ b/docs-site/src/content/docs/configuration/metrics.md
@@ -20,7 +20,7 @@ When the metrics process starts it loads `apps/metrics/config.yml` (or the file 
 backend:
   ping_interval: 10000
 server:
-  port: 3000
+  port: 0
   data_dir: /app/data
 collector:
   batch_ms: 60000
@@ -78,7 +78,6 @@ Connection topology used by the Valkey client.
 
 - **`"standalone"`** — single-node client (default)
 - **`"cluster"`** — cluster client
-- **`"sentinel"`** — sentinel client
 
 If unset, falls back to `valkey.mode` from `config.yml`, then to `"standalone"`.
 
@@ -161,7 +160,7 @@ These three variables override the matching fields in `config.yml`. Setting any 
 
 TCP port the metrics HTTP server listens on. Setting `PORT=0` lets the OS assign an ephemeral port — the server uses this when spawning many metrics children, so they don't fight over fixed ports.
 
-- **Default:** `cfg.server.port` from `config.yml` (`3000`)
+- **Default:** `cfg.server.port` from `config.yml` (`0` — ephemeral port picked by OS)
 - **Overrides:** `cfg.server.port`
 
 ### `DATA_DIR`

--- a/docs-site/src/content/docs/configuration/server.md
+++ b/docs-site/src/content/docs/configuration/server.md
@@ -67,13 +67,13 @@ How long (in milliseconds) the server waits between cluster topology refresh cyc
 
 ### `VALKEY_ADMIN_ALLOWED_WS_ORIGINS`
 
-Comma-separated list of origins allowed to open a WebSocket connection to the server. Used in `Web` mode to restrict browser access to trusted origins. In `Electron` mode origin checking is skipped.
+Comma-separated list of additional trusted origins allowed to open a WebSocket connection to the server. In `Web` mode, same-origin checking is **always** enforced — the server compares the request's `Origin` header against the `Host` header and rejects mismatches. This variable adds extra origins that should be trusted **beyond** same-origin (e.g., when the UI is served from a different domain or port). In `Electron` mode origin checking is skipped entirely.
 
 ```bash
 VALKEY_ADMIN_ALLOWED_WS_ORIGINS=https://valkey-admin.example.com,https://other.example.com
 ```
 
-- **Default:** unset (no origin restriction in Electron mode; Web mode rejects connections with no matching origin when this is set)
+- **Default:** unset (Web mode still enforces same-origin; Electron mode skips origin checking)
 - **Read in:** `apps/server/src/websocket-origin.ts`
 
 ## Initial Valkey Connection (Orchestrator Mode)

--- a/docs-site/src/content/docs/configuration/server.md
+++ b/docs-site/src/content/docs/configuration/server.md
@@ -67,13 +67,16 @@ How long (in milliseconds) the server waits between cluster topology refresh cyc
 
 ### `VALKEY_ADMIN_ALLOWED_WS_ORIGINS`
 
-Comma-separated list of additional trusted origins allowed to open a WebSocket connection to the server. In `Web` mode, same-origin checking is **always** enforced — the server compares the request's `Origin` header against the `Host` header and rejects mismatches. This variable adds extra origins that should be trusted **beyond** same-origin (e.g., when the UI is served from a different domain or port). In `Electron` mode origin checking is skipped entirely.
+Comma-separated list of additional trusted origins allowed to open a WebSocket connection to the server. Origin validation is enforced in **all** deployment modes — connections with no `Origin` header are always rejected. This variable adds extra origins that should be trusted beyond the mode-specific defaults.
+
+- **Web mode:** allows same-origin (compares `Origin` against `Host` header) plus any configured origins.
+- **Electron mode:** allows `file://`, `null` (packaged Electron renderers), and loopback origins (`localhost`, `127.0.0.1`, `::1`) plus any configured origins. Other remote origins are rejected.
 
 ```bash
 VALKEY_ADMIN_ALLOWED_WS_ORIGINS=https://valkey-admin.example.com,https://other.example.com
 ```
 
-- **Default:** unset (Web mode still enforces same-origin; Electron mode skips origin checking)
+- **Default:** unset (Web mode enforces same-origin only; Electron mode enforces its allowlist of file:// and loopback)
 - **Read in:** `apps/server/src/websocket-origin.ts`
 
 ## Initial Valkey Connection (Orchestrator Mode)

--- a/docs-site/src/content/docs/deployment/kubernetes.md
+++ b/docs-site/src/content/docs/deployment/kubernetes.md
@@ -17,10 +17,10 @@ The workflow below uses Minikube for local development, but the manifests and si
 
 | File | Purpose |
 |------|---------|
-| `k8s/app.yaml` | `valkey-admin-app` deployment and service |
-| `k8s/metrics-configmap.yaml` | Sidecar config mounted at `/app/config/config.yml` |
-| `k8s/valkey-statefulset-sidecar-patch.yaml` | Patch to add the metrics sidecar to an existing Valkey StatefulSet |
-| `k8s/valkey-statefulset.yaml` | Sample standalone StatefulSet for testing |
+| `examples/k8s/app.yaml` | `valkey-admin-app` deployment and service |
+| `examples/k8s/metrics-configmap.yaml` | Sidecar config mounted at `/app/config/config.yml` |
+| `examples/k8s/valkey-statefulset-sidecar-patch.yaml` | Patch to add the metrics sidecar to an existing Valkey StatefulSet |
+| `examples/k8s/valkey-statefulset.yaml` | Sample standalone StatefulSet for testing |
 
 ## Deployment Steps
 
@@ -51,12 +51,12 @@ docker build -f docker/Dockerfile.server -t valkey-admin-app:test .
 docker build -f docker/Dockerfile.metrics -t valkey-admin-metrics:test .
 ```
 
-For a non-local deployment, use published images from a container registry and update the image references in `k8s/app.yaml` and `k8s/valkey-statefulset-sidecar-patch.yaml`.
+For a non-local deployment, use published images from a container registry and update the image references in `examples/k8s/app.yaml` and `examples/k8s/valkey-statefulset-sidecar-patch.yaml`.
 
 ### 3. Deploy the app server
 
 ```bash
-kubectl apply -f k8s/app.yaml
+kubectl apply -f examples/k8s/app.yaml
 kubectl rollout status deployment/valkey-admin-app -n valkey
 ```
 
@@ -65,7 +65,7 @@ This deploys the frontend + backend server on port `8080` in cluster-orchestrato
 ### 4. Apply the metrics config
 
 ```bash
-kubectl apply -n valkey -f k8s/metrics-configmap.yaml
+kubectl apply -n valkey -f examples/k8s/metrics-configmap.yaml
 ```
 
 This configures the sidecar collectors for CPU, memory, command logs, and monitor-based features.
@@ -78,7 +78,7 @@ Patch the Helm-created StatefulSet:
 kubectl patch statefulset valkey \
   -n valkey \
   --type strategic \
-  --patch-file k8s/valkey-statefulset-sidecar-patch.yaml
+  --patch-file examples/k8s/valkey-statefulset-sidecar-patch.yaml
 ```
 
 ### 6. Wait for rollout
@@ -149,7 +149,7 @@ When you change the metrics sidecar:
 ```bash
 eval $(minikube docker-env)
 docker build -f docker/Dockerfile.metrics -t valkey-admin-metrics:test .
-kubectl apply -n valkey -f k8s/metrics-configmap.yaml
+kubectl apply -n valkey -f examples/k8s/metrics-configmap.yaml
 kubectl rollout restart statefulset/valkey -n valkey
 kubectl rollout status statefulset/valkey -n valkey
 ```
@@ -159,7 +159,7 @@ When you change the app server:
 ```bash
 eval $(minikube docker-env)
 docker build -f docker/Dockerfile.server -t valkey-admin-app:test .
-kubectl apply -f k8s/app.yaml
+kubectl apply -f examples/k8s/app.yaml
 kubectl rollout restart deployment/valkey-admin-app -n valkey
 kubectl rollout status deployment/valkey-admin-app -n valkey
 ```
@@ -190,7 +190,7 @@ kubectl exec -n valkey valkey-0 -c metrics -- ls -l /app/data
 kubectl logs -n valkey valkey-0 -c metrics --since=10m
 ```
 
-To get more detail, set `debug_metrics: true` in `k8s/metrics-configmap.yaml`, reapply, and restart the StatefulSet.
+To get more detail, set `debug_metrics: true` in `examples/k8s/metrics-configmap.yaml`, reapply, and restart the StatefulSet.
 
 ### Inspect the Metrics API Directly
 
@@ -213,6 +213,6 @@ curl -s 'http://localhost:3000/commandlog?type=slow'
 ## Notes
 
 - The example workflow in this document is aimed at local Minikube development.
-- `k8s/valkey-statefulset.yaml` is available as a repo-managed sample, but the main development path described here assumes a Helm-installed Valkey StatefulSet.
+- `examples/k8s/valkey-statefulset.yaml` is available as a repo-managed sample, but the main development path described here assumes a Helm-installed Valkey StatefulSet.
 - The Helm-based development path here is based on [valkey-io/valkey-helm PR #116](https://github.com/valkey-io/valkey-helm/pull/116).
 - For broader Kubernetes use, replace the local image workflow with registry-backed images and adapt the same manifests or patches to your cluster conventions.

--- a/docs-site/src/content/docs/features/cluster-topology.md
+++ b/docs-site/src/content/docs/features/cluster-topology.md
@@ -33,8 +33,8 @@ Each node card shows:
 - **Name**: The Valkey instance name (e.g. `valkey`)
 - **Role Badge**: `PRIMARY` or `REPLICA`
 - **Address**: Host and port (e.g. `10.0.0.95:7001`)
-- **Key Count**: Total number of keys stored on the node (e.g. `3.60M`)
-- **Connections**: Number of active client connections
+- **Memory**: Memory usage reported by `used_memory_human` (e.g. `3.60M`)
+- **Connected Clients**: Number of currently connected clients
 
 ### Searching Nodes
 
@@ -45,7 +45,7 @@ Use the search bar to filter nodes by name, host, or port.
 Each node row includes action icons on the right side:
 
 - **Power**: Connect to the primary node
-- **Grid**: Go to dashboard of the node
+- **Dashboard**: Go to dashboard of the node
 - **Terminal**: Open the Send Command interface for the node
 
 ## Replication Structure

--- a/docs-site/src/content/docs/features/connections.md
+++ b/docs-site/src/content/docs/features/connections.md
@@ -45,7 +45,11 @@ Each `(host, port, db)` combination creates an independent client connection. Sw
 ### Cluster Mode
 
 - **Valkey 9.0+**: Multiple databases are supported in cluster mode. Set `--cluster-databases <n>` on every cluster node to enable.
-- **Below 9.0**: Only `db 0` is available in cluster mode. The connection modal disables the database field when connecting via discovery endpoint.
+- **Below 9.0**: Only `db 0` is available in cluster mode.
+
+:::note
+The connection modal always disables the database field when connecting via a discovery endpoint, regardless of Valkey version.
+:::
 
 ### Standalone Mode
 

--- a/docs-site/src/content/docs/features/dashboard.md
+++ b/docs-site/src/content/docs/features/dashboard.md
@@ -26,13 +26,13 @@ The top of the dashboard displays four summary cards for the connected node:
 
 Below the stat cards, searchable accordion sections display detailed metrics from the Valkey `INFO` command:
 
-- **Memory Usage Metrics**: Breakdown of memory allocation (dataset, scripts, peak, overhead, etc.)
-- **Uptime Metrics**: Server uptime, evicted scripts, network I/O bytes
-- **Replication & Persistence**: RDB save status, replication backlog, sync state
-- **Client Connectivity**: Connected clients, blocked clients, rejected connections, reads/writes processed
-- **Command Execution**: Total commands, error replies, blocking keys
-- **Data Effectiveness & Eviction**: Evicted/expired keys, hit/miss counts, cached scripts
-- **Messaging**: Pub/Sub channels, patterns, and clients
+- **Memory Usage Metrics**: Detailed metrics for tracking Valkey's memory usage across data, scripts, functions, and peak consumption.
+- **Uptime Metrics**: Tracks server uptime and script eviction to monitor overall system activity and availability.
+- **Replication & Persistence**: Metrics that track database snapshots, data changes, and replication backlog health to ensure reliable syncing and persistence.
+- **Client Connectivity**: Metrics tracking client connections, activity, and connection limits to monitor workload and health.
+- **Command Execution**: Metrics showing command volume, failures, slow operations, and errors to evaluate performance and stability.
+- **Data Effectiveness & Eviction**: Tracks key activity, expirations, evictions, and cache hit-rates to assess data efficiency and access performance.
+- **Messaging**: Tracks Pub/Sub channels, patterns, and clients to measure real-time activity.
 
 Use the search bar to filter metrics by name across all groups.
 

--- a/docs-site/src/content/docs/features/dashboard.md
+++ b/docs-site/src/content/docs/features/dashboard.md
@@ -13,13 +13,28 @@ The dashboard is your central hub for monitoring cluster node activity, displayi
 
 ## Key Metrics
 
-### Cluster Health
+### Stat Cards
 
-- **Cluster Node DropDown**: View online/offline status of all cluster nodes
-- **Node Metrics**: View INFO command metrics
-- **Key Type Distribution**: Share of stored key types
-- **Memory Usage**: Monitor memory consumption across nodes
-- **CPU Usage**: Real-time CPU utilization metrics
+The top of the dashboard displays four summary cards for the connected node:
+
+- **Total Memory**: The server's configured `maxmemory` (or total system memory if unbounded)
+- **Used Memory**: Current memory consumption
+- **Operations**: Total commands processed
+- **Hit Ratio**: Cache hit rate (keyspace hits vs misses)
+
+### Metric Groups
+
+Below the stat cards, searchable accordion sections display detailed metrics from the Valkey `INFO` command:
+
+- **Memory Usage Metrics**: Breakdown of memory allocation (dataset, scripts, peak, overhead, etc.)
+- **Uptime Metrics**: Server uptime, evicted scripts, network I/O bytes
+- **Replication & Persistence**: RDB save status, replication backlog, sync state
+- **Client Connectivity**: Connected clients, blocked clients, rejected connections, reads/writes processed
+- **Command Execution**: Total commands, error replies, blocking keys
+- **Data Effectiveness & Eviction**: Evicted/expired keys, hit/miss counts, cached scripts
+- **Messaging**: Pub/Sub channels, patterns, and clients
+
+Use the search bar to filter metrics by name across all groups.
 
 ## Real-Time Usage Metrics
 

--- a/docs-site/src/content/docs/features/key-browser.md
+++ b/docs-site/src/content/docs/features/key-browser.md
@@ -16,9 +16,7 @@ Navigate through your keyspace with an intuitive interface that supports filteri
 ### Browsing Keys
 
 - **Tree View**: Navigate keys organized by namespace separators (`:`)
-- **List View**: View all keys in a flat list format
 - **Pagination**: Handle large keyspaces efficiently
-- **Sorting**: Sort by name, type, TTL, or size
 
 ### Search and Filter
 

--- a/docs-site/src/content/docs/features/send-command.md
+++ b/docs-site/src/content/docs/features/send-command.md
@@ -28,7 +28,7 @@ Press `Enter` to execute. Results are displayed below the command input.
 
 ### Command Autocomplete
 
-As you type, Valkey Admin suggests matching commands from a built-in list of 257 Valkey commands. Select a suggestion to auto-complete the command name, then continue typing your arguments.
+As you type, Valkey Admin suggests matching commands from a built-in list of 396 Valkey commands. Select a suggestion to auto-complete the command name, then continue typing your arguments.
 
 ### Restricted Commands
 

--- a/docs-site/src/content/docs/reference/limitations.md
+++ b/docs-site/src/content/docs/reference/limitations.md
@@ -23,4 +23,4 @@ For runtime issues and fixes, see the [Troubleshooting guide](/reference/trouble
 ## Architecture
 
 - **Metrics servers are per-primary only.** Each primary node gets its own metrics collector; replica nodes are not independently monitored.
-- **Key browser sample size.** The key browser scans up to approximately 1,000 keys across the cluster. Keys beyond this limit are not listed but can still be found using the search function, which performs a targeted lookup.
+- **Key browser sample size.** The key browser scans up to approximately 1,000 keys across the cluster. Keys beyond this limit are not listed but can still be found using the search function, which uses SCAN with a MATCH pattern (the same mechanism, just filtered).


### PR DESCRIPTION
Audit and fix inaccuracies across the documentation site.

| File | Fix |
|------|-----|
| `send-command.md` | 257 → 396 commands |
| `cluster-topology.md` | "Key Count" → "Memory", "Connections" → "Connected Clients", "Grid" → "Dashboard" |
| `key-browser.md` | Removed non-existent "List View" and "Sorting" features |
| `connections.md` | Clarified DB field is always disabled for discovery endpoints, not version-dependent |
| `dashboard.md` | Rewrote "Cluster Health" section with accurate stat cards and metric groups |
| `metrics.md` | Removed unsupported sentinel mode, fixed port default from 3000 to 0 |
| `kubernetes.md` | All `k8s/` paths → `examples/k8s/` (10 occurrences) |
| `limitations.md` | "targeted lookup" → "SCAN with a MATCH pattern" |
| `server.md` | Clarified WS origins: same-origin always enforced, variable adds extras |