### PR TITLE
Bind to localhost in Electron mode to prevent LAN access

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -27,6 +27,7 @@ import { memoryUsageRequested } from "./actions/memoryUsage"
 import { monitorRequested } from "./actions/monitorAction"
 import { unsubscribeAll, getWatcherCount } from "./node-watchers"
 import { teardownConnection } from "./connection"
+import { isElectron } from "./metrics-orchestrator"
 import { Handler, ReduxAction, unknownHandler, type WsActionMessage } from "./actions/utils"
 import {
   createMetricsOrchestratorRouter,
@@ -151,8 +152,6 @@ async function updateRegistryforK8() {
   const client = await getInitialClient()
   updateClusterNodeRegistry(client, initialConnectionDetails)
 }
-
-import { isElectron } from "./metrics-orchestrator"
 
 // Electron: bind to localhost only — Origin headers are forgeable by non-browser clients,
 // so network-level isolation is the only reliable gate for a desktop app.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -152,7 +152,11 @@ async function updateRegistryforK8() {
   updateClusterNodeRegistry(client, initialConnectionDetails)
 }
 
-server.listen(port, () => {
+import { isElectron } from "./metrics-orchestrator"
+
+// Electron: bind to localhost only — Origin headers are forgeable by non-browser clients,
+// so network-level isolation is the only reliable gate for a desktop app.
+server.listen(port, isElectron ? "127.0.0.1" : undefined, () => {
   console.log(`Server running at http://localhost:${port}`)
   if (process.send) { // Check if process.send is available (i.e., if forked)
     process.send({ type: "websocket-ready" }) // Send a ready message to the parent process


### PR DESCRIPTION
In Electron mode, the server was binding to `0.0.0.0` (all interfaces), making it reachable from any device on the same network. The Origin header check is the only gate, but Origin is browser-enforced, which means a non-browser client (e.g. `wscat`) on the LAN can forge `Origin: http://localhost:8080` and gain full WebSocket access.

This change binds to `127.0.0.1` in Electron mode so the port is unreachable from the network regardless of header forgery. Web/K8s modes continue to bind to all interfaces as required for ALB health checks and pod networking.