### PR TITLE
Fix/vulnerable deps

### DIFF
--- a/apps/metrics/Dockerfile
+++ b/apps/metrics/Dockerfile
@@ -19,4 +19,7 @@ ENV CONFIG_PATH=/app/config.yml
 ENV NODE_ENV=production
 
 EXPOSE 3000
+
+USER node
+
 CMD ["node", "src/index.js"]

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -54,8 +54,8 @@ COPY --from=builder /app/apps/metrics/dist ./apps/metrics/dist
 # Expose backend port
 EXPOSE 8080
 
-# Create data directory writable by node user
-RUN mkdir -p /app/data && chown -R node:node /app/data
+# Ensure all app files are writable by node user (metrics servers create data subdirs at runtime)
+RUN chown -R node:node /app
 
 # Run as non-root
 USER node

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -54,6 +54,9 @@ COPY --from=builder /app/apps/metrics/dist ./apps/metrics/dist
 # Expose backend port
 EXPOSE 8080
 
+# Create data directory writable by node user
+RUN mkdir -p /app/data && chown -R node:node /app/data
+
 # Run as non-root
 USER node
 

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -54,4 +54,7 @@ COPY --from=builder /app/apps/metrics/dist ./apps/metrics/dist
 # Expose backend port
 EXPOSE 8080
 
+# Run as non-root
+USER node
+
 CMD ["node", "apps/server/dist/index.js"]

--- a/docker/Dockerfile.metrics
+++ b/docker/Dockerfile.metrics
@@ -27,8 +27,10 @@ RUN npm ci --omit=dev
 COPY apps/metrics/config.yml /app/config.yml
 COPY --from=builder /app/apps/metrics/dist ./apps/metrics/dist
 
-RUN mkdir -p /app/data
+RUN mkdir -p /app/data && chown node:node /app/data
 
 EXPOSE 3000
+
+USER node
 
 CMD ["node", "apps/metrics/dist/index.cjs"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -32,7 +32,7 @@ COPY --from=builder /app/apps/frontend/dist ./apps/frontend/dist
 
 EXPOSE 8080
 
-RUN mkdir -p /app/data && chown -R node:node /app/data
+RUN chown -R node:node /app
 
 USER node
 

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -32,4 +32,6 @@ COPY --from=builder /app/apps/frontend/dist ./apps/frontend/dist
 
 EXPOSE 8080
 
+USER node
+
 CMD ["node", "apps/server/dist/index.js"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -32,6 +32,8 @@ COPY --from=builder /app/apps/frontend/dist ./apps/frontend/dist
 
 EXPOSE 8080
 
+RUN mkdir -p /app/data && chown -R node:node /app/data
+
 USER node
 
 CMD ["node", "apps/server/dist/index.js"]

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -5597,9 +5597,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5616,7 +5616,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -3892,9 +3892,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -5331,9 +5331,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12738,9 +12738,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -12757,7 +12757,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valkey-admin",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valkey-admin",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "workspaces": [
         "common",
         "apps/frontend",
@@ -10496,9 +10496,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -11093,9 +11093,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -12026,9 +12026,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Valkey Admin",
   "description": "A modern admin interface for Valkey databases",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Valkey Admin Team",
     "email": "admin@valkey.io"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Valkey Admin",
   "description": "A modern admin interface for Valkey databases",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.0",
   "author": {
     "name": "Valkey Admin Team",
     "email": "admin@valkey.io"


### PR DESCRIPTION

**Vulnerable dependencies updated:**

| Package | Before | After | Advisory |
|---|---|---|---|
| ip-address | 10.2.0 | 10.5.0 | CVE-2026-69192 (SSRF via IP parsing) |
| nanoid | 3.3.16 | 3.3.17+ | CVE-2026-67213 (infinite loop) |
| js-yaml | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj (quadratic CPU) |
| postcss | 8.5.22 | 8.5.26 | CVE-2026-69153 |

**Dockerfiles hardened:**

All four Dockerfiles (`Dockerfile.app`, `Dockerfile.server`, `Dockerfile.metrics`, `apps/metrics/Dockerfile`) now run as the `node` user instead of root.