### PR TITLE
Fix premature cluster map clearing and improve graceful shutdown

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -307,7 +307,6 @@ wss.on("connection", (ws: AliveWebSocket) => {
   ws.on("close", (code, reason) => {
     abortConfigSessionsForSocket(ws)
     const removedIds = unsubscribeAll(ws)
-    connectedNodesByCluster.clear()
     console.log("Client disconnected. Reason:", code, reason.toString())
 
     const scheduled = new Set(removedIds)
@@ -336,19 +335,28 @@ wss.on("connection", (ws: AliveWebSocket) => {
 function shutdown() {
   console.log("Shutdown signal received")
   clearInterval(interval)
-  // Close websocket clients
-  wss.clients.forEach((ws) => {
-    try {
-      ws.close()
-    } catch (err) {
-      console.error("Error closing WebSocket client", err)
-    }
-  })
 
-  server.close(() => {
+  // Force exit if graceful shutdown takes too long
+  const forceExitTimeout = setTimeout(() => {
+    console.error("Graceful shutdown timed out, forcing exit")
+    process.exit(1)
+  }, 10000)
+  forceExitTimeout.unref()
+
+  // Close all Valkey clients (releases connections on the Valkey side)
+  for (const [, { client }] of clients) {
+    try {
+      client.close()
+    } catch (err) {
+      console.error("Error closing Valkey client:", err)
+    }
+  }
+
+  // Release port 8080
+  server.close(async () => {
     console.log("HTTP server closed")
     try {
-      cleanupOrchestratorResources()
+      await cleanupOrchestratorResources()
     } catch (err) {
       console.error("Error during orchestrator resource cleanup", err)
     }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -336,24 +336,15 @@ function shutdown() {
   console.log("Shutdown signal received")
   clearInterval(interval)
 
-  // Force exit if graceful shutdown takes too long
   const forceExitTimeout = setTimeout(() => {
     console.error("Graceful shutdown timed out, forcing exit")
     process.exit(1)
   }, 10000)
   forceExitTimeout.unref()
 
-  // Close all Valkey clients (releases connections on the Valkey side)
-  for (const [, { client }] of clients) {
-    try {
-      client.close()
-    } catch (err) {
-      console.error("Error closing Valkey client:", err)
-    }
-  }
-
-  // Release port 8080
+  // Step 1: Stop accepting new connections (non-blocking, sets up drain callback)
   server.close(async () => {
+    // Step 4: All connections drained — kill metrics servers and exit
     console.log("HTTP server closed")
     try {
       await cleanupOrchestratorResources()
@@ -362,6 +353,24 @@ function shutdown() {
     }
     process.exit(0)
   })
+
+  // Step 2: Close all WebSocket clients (triggers drain so server.close callback can fire)
+  wss.clients.forEach((ws) => {
+    try {
+      ws.close()
+    } catch (err) {
+      console.error("Error closing WebSocket client:", err)
+    }
+  })
+
+  // Step 3: Close all Valkey clients (releases connections on the Valkey side)
+  for (const [, { client }] of clients) {
+    try {
+      client.close()
+    } catch (err) {
+      console.error("Error closing Valkey client:", err)
+    }
+  }
 }
 // Not sure if this will impact kubernetes use case
 process.on("SIGINT", shutdown)

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -403,11 +403,6 @@ export async function runReconcileLoop() {
 export function cleanupOrchestratorResources() {
   initialClient?.close()
   stopAllMetricsServers(metricsServerMap)
-  metricsServerMap.clear()
-
-  for (const key in clusterNodesRegistry) {
-    delete clusterNodesRegistry[key]
-  }
 }
 
 // To help mock internal methods in tests


### PR DESCRIPTION
Two fixes to server lifecycle management:

**1. Remove premature `connectedNodesByCluster.clear()` on WebSocket close**

Previously, any WebSocket disconnect wiped the entire cluster membership map, breaking memory/CPU fan-out for other connected users in multi-user Web deployments. The map now persists until connections are actually torn down.

**2. Improve graceful shutdown**

- Close all Valkey clients on SIGTERM (releases `connected_clients` on the Valkey side immediately instead of waiting for TCP timeout)
- Remove unnecessary in-memory map clearing that dies with the process anyway
- Add a 10-second force-exit timeout as a safety net
- Properly `await` metrics server cleanup

Tested locally against a 3-node cluster: all Valkey connections released, all child processes killed, zero orphans after shutdown.

Closes #468