### PR TITLE
Use subpath in websocket URL

### DIFF
--- a/apps/frontend/src/state/epics/wsEpics.ts
+++ b/apps/frontend/src/state/epics/wsEpics.ts
@@ -27,13 +27,13 @@ import {
 let socket$: WebSocketSubject<PayloadAction> | null = null
 
 const getWebsocketURL = () => {
-  const isElectron = window.location.protocol === "file:"
-  if (isElectron) {
+  // If it's an Electron deployment
+  if (window.location.protocol === "file:") {
     return "ws://localhost:8080"
   }
   
-  return (window.location.origin + window.location.pathname)
-    .replace(/^http/, 'ws')
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws"
+  return `${protocol}://${window.location.host}${window.location.pathname}`
 }
 
 const url =

--- a/apps/frontend/src/state/epics/wsEpics.ts
+++ b/apps/frontend/src/state/epics/wsEpics.ts
@@ -26,7 +26,7 @@ import {
 
 let socket$: WebSocketSubject<PayloadAction> | null = null
 
-const getWebsocketHost = () => {
+const getWebsocketURL = () => {
   const isElectron = window.location.protocol === "file:"
   if (isElectron) {
     return "ws://localhost:8080"
@@ -38,7 +38,7 @@ const getWebsocketHost = () => {
 
 const url =
   import.meta.env.VITE_VALKEY_ADMIN_WS_URL ||
-  getWebsocketHost()
+  getWebsocketURL()
 
 const connect = (store: Store) =>
   action$.pipe(

--- a/apps/frontend/src/state/epics/wsEpics.ts
+++ b/apps/frontend/src/state/epics/wsEpics.ts
@@ -26,14 +26,19 @@ import {
 
 let socket$: WebSocketSubject<PayloadAction> | null = null
 
-const isElectron = window.location.protocol === "file:"
-const isHttps = window.location.protocol === "https:"
+const getWebsocketHost = () => {
+  const isElectron = window.location.protocol === "file:"
+  if (isElectron) {
+    return "ws://localhost:8080"
+  }
+  
+  return (window.location.origin + window.location.pathname)
+    .replace(/^http/, 'ws')
+}
 
 const url =
   import.meta.env.VITE_VALKEY_ADMIN_WS_URL ||
-  (isElectron
-    ? "ws://localhost:8080"
-    : `${isHttps ? "wss" : "ws"}://${window.location.host}`)
+  getWebsocketHost()
 
 const connect = (store: Store) =>
   action$.pipe(


### PR DESCRIPTION
Slightly adjusts the websocket URL to use subpath. This allows us to support subpath deployments without having to rebuild the frontend:

- Normal deployment:
  - URL: `https://valkey.mywebsite.com/`
  - WS URL: `wss://valkey.mywebsite.com/`
- Subpath deployment:
  - URL: `https://mywebsite.com/valkey/`
  - WS URL: `wss://mywebsite.com/valkey/`

Currently we use `ws[s]://window.location.host`, which ignores the root path of our subpath deployment even with rewrite in reverse proxy (e.g. `https://mywebsite.com/valkey/` => `wss://https://mywebsite.com`).

We can instead derive the websocket URL from `window.location.origin + window.location.pathname`, which gives us the full path without hash part or search query.