### PR TITLE
Fix auto-labeler for external PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Label PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:
@@ -12,6 +12,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The labeler wasn't running on PRs from forks because `pull_request` events from forks don't get write access to the target repo. Switched to `pull_request_target` which runs in the base repo context. Also upgraded from labeler v5 to v7.