### PR TITLE
Add scan button for Big Keys, revamp Start Monitor button

### DIFF
--- a/apps/frontend/src/components/activity-view/ActivityView.tsx
+++ b/apps/frontend/src/components/activity-view/ActivityView.tsx
@@ -257,8 +257,9 @@ export const ActivityView = () => {
                 <Settings className="hover:text-primary" size={15} />
               </Button>
             )}
-            {!useHotSlots && !monitorRunning && (
+            {!useHotSlots && (
               <Button
+                disabled={monitorRunning}
                 onClick={() => setConfigOpen(true)}
                 size={"sm"}
                 variant={"default"}

--- a/apps/frontend/src/components/activity-view/ActivityView.tsx
+++ b/apps/frontend/src/components/activity-view/ActivityView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { useSelector } from "react-redux"
-import { Activity, RefreshCcw, ScanSearch, Settings } from "lucide-react"
+import { Activity, Play, RefreshCcw, ScanSearch, Settings } from "lucide-react"
 import { useParams } from "react-router"
 import { COMMANDLOG_TYPE, PENDING } from "@common/src/constants"
 import { truncateText } from "@common/src/truncate-text"
@@ -264,6 +264,16 @@ export const ActivityView = () => {
             >
               <RefreshCcw className="hover:text-primary" size={15} />
             </Button>
+            {!useHotSlots && !monitorRunning && (
+              <Button
+                onClick={() => setConfigOpen(true)}
+                size={"sm"}
+                variant={"default"}
+              >
+                <Play size={15} />
+                Start Monitor
+              </Button>
+            )}
           </div>
         )}
 

--- a/apps/frontend/src/components/activity-view/ActivityView.tsx
+++ b/apps/frontend/src/components/activity-view/ActivityView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { useSelector } from "react-redux"
-import { Activity, RefreshCcw, Settings } from "lucide-react"
+import { Activity, RefreshCcw, ScanSearch, Settings } from "lucide-react"
 import { useParams } from "react-router"
 import { COMMANDLOG_TYPE, PENDING } from "@common/src/constants"
 import { truncateText } from "@common/src/truncate-text"
@@ -299,12 +299,13 @@ export const ActivityView = () => {
               disabled={bigKeysStatus === PENDING}
               onClick={refreshBigKeys}
               size={"sm"}
-              variant={"outline"}
+              variant={"default"}
             >
-              <RefreshCcw
-                className={`hover:text-primary ${bigKeysStatus === PENDING ? "animate-spin" : ""}`}
+              <ScanSearch
+                className={bigKeysStatus === PENDING ? "animate-pulse" : ""}
                 size={15}
               />
+              {bigKeysStatus === PENDING ? "Scanning…" : "Scan"}
             </Button>
           </div>
         )}

--- a/apps/frontend/src/components/activity-view/ActivityView.tsx
+++ b/apps/frontend/src/components/activity-view/ActivityView.tsx
@@ -257,13 +257,6 @@ export const ActivityView = () => {
                 <Settings className="hover:text-primary" size={15} />
               </Button>
             )}
-            <Button
-              onClick={refreshHotKeys}
-              size={"sm"}
-              variant={"outline"}
-            >
-              <RefreshCcw className="hover:text-primary" size={15} />
-            </Button>
             {!useHotSlots && !monitorRunning && (
               <Button
                 onClick={() => setConfigOpen(true)}
@@ -274,6 +267,13 @@ export const ActivityView = () => {
                 Start Monitor
               </Button>
             )}
+            <Button
+              onClick={refreshHotKeys}
+              size={"sm"}
+              variant={"outline"}
+            >
+              <RefreshCcw className="hover:text-primary" size={15} />
+            </Button>
           </div>
         )}
 

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-banners.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-banners.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useRef, useState } from "react"
-import { AlertCircle, ChevronDown, ChevronUp, Play } from "lucide-react"
+import { AlertCircle, ChevronDown, ChevronUp } from "lucide-react"
 import { Alert, AlertDescription } from "../../ui/alert"
 import { Typography } from "../../ui/typography"
-import { Button } from "../../ui/button"
 
 interface NodeErrorsBannerProps {
   nodeErrors: { nodeId: string; error: string }[]
@@ -60,11 +59,10 @@ export function NodeErrorsBanner({ nodeErrors, label = "Hot keys" }: NodeErrorsB
 }
 
 interface MonitorNotRunningBannerProps {
-  onStartMonitoring: () => void
   error?: string | null
 }
 
-export function MonitorNotRunningBanner({ onStartMonitoring, error }: MonitorNotRunningBannerProps) {
+export function MonitorNotRunningBanner({ error }: MonitorNotRunningBannerProps) {
   return (
     <div className="m-3 p-3 bg-red-50 dark:bg-red-900/20 rounded-md border
       border-red-200 dark:border-red-700 flex items-center gap-2">
@@ -72,21 +70,9 @@ export function MonitorNotRunningBanner({ onStartMonitoring, error }: MonitorNot
       {error ? (
         <Typography variant="bodySm">Monitor failed: {error}</Typography>
       ) : (
-        <>
-          <Typography variant="bodySm">
-            Monitor is not running. Showing last known data.
-          </Typography>
-          <Button
-            className="shrink-0"
-            onClick={onStartMonitoring}
-            size="sm"
-            type="button"
-            variant="default"
-          >
-            <Play size={14} />
-            Start Monitor
-          </Button>
-        </>
+        <Typography variant="bodySm">
+          Monitor is not running. Showing last known data.
+        </Typography>
       )}
     </div>
   )

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-banners.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-banners.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react"
 import { AlertCircle, ChevronDown, ChevronUp } from "lucide-react"
 import { Alert, AlertDescription } from "../../ui/alert"
 import { Typography } from "../../ui/typography"
+import { Button } from "../../ui/button"
 
 interface NodeErrorsBannerProps {
   nodeErrors: { nodeId: string; error: string }[]
@@ -66,22 +67,26 @@ interface MonitorNotRunningBannerProps {
 export function MonitorNotRunningBanner({ onStartMonitoring, error }: MonitorNotRunningBannerProps) {
   return (
     <div className="m-3 p-3 bg-red-50 dark:bg-red-900/20 rounded-md border
-      border-red-200 dark:border-red-700 flex items-start gap-2">
-      <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
-      <Typography variant="bodySm">
-        {error
-          ? <>Monitor failed: {error}</>
-          : <>Monitor is not running. Showing last known data.{" "}
-            <button
-              className="text-primary underline hover:opacity-80"
-              onClick={onStartMonitoring}
-              type="button"
-            >
-              Start MONITOR
-            </button>
-          </>
-        }
-      </Typography>
+      border-red-200 dark:border-red-700 flex items-center gap-2">
+      <AlertCircle className="w-4 h-4 text-red-500 shrink-0" />
+      {error ? (
+        <Typography variant="bodySm">Monitor failed: {error}</Typography>
+      ) : (
+        <>
+          <Typography variant="bodySm">
+            Monitor is not running. Showing last known data.
+          </Typography>
+          <Button
+            className="shrink-0"
+            onClick={onStartMonitoring}
+            size="sm"
+            type="button"
+            variant="default"
+          >
+            Start Monitor
+          </Button>
+        </>
+      )}
     </div>
   )
 }

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-banners.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-banners.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { AlertCircle, ChevronDown, ChevronUp } from "lucide-react"
+import { AlertCircle, ChevronDown, ChevronUp, Play } from "lucide-react"
 import { Alert, AlertDescription } from "../../ui/alert"
 import { Typography } from "../../ui/typography"
 import { Button } from "../../ui/button"
@@ -83,6 +83,7 @@ export function MonitorNotRunningBanner({ onStartMonitoring, error }: MonitorNot
             type="button"
             variant="default"
           >
+            <Play size={14} />
             Start Monitor
           </Button>
         </>

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
@@ -4,6 +4,7 @@ import * as R from "ramda"
 import { EmptyState } from "../../ui/empty-state"
 import { LoadingState } from "../../ui/loading-state"
 import { Typography } from "../../ui/typography"
+import { Button } from "../../ui/button"
 import { type SortOrder } from "../../ui/sortable-table-header"
 import { HotKeysHeatmapModal } from "./hot-keys-heatmap"
 import { MonitorNotRunningBanner, NodeErrorsBanner } from "./hot-keys-banners"
@@ -78,24 +79,24 @@ export function HotKeys({
         <EmptyState
           action={
             (errorMessage || (!monitorRunning && onStartMonitoring)) && (
-              <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 rounded-md flex items-start gap-2">
-                <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
-                <Typography variant="bodySm">
-                  {!monitorRunning && onStartMonitoring ? (
-                    <>
-                      Monitor is not running.{" "}
-                      <button
-                        className="text-primary underline hover:opacity-80"
-                        onClick={onStartMonitoring}
-                        type="button"
-                      >
-                        Start MONITOR
-                      </button>
-                    </>
-                  ) : (
-                    errorMessage
-                  )}
-                </Typography>
+              <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 rounded-md flex items-center gap-2">
+                <AlertCircle className="w-4 h-4 text-red-500 shrink-0" />
+                {!monitorRunning && onStartMonitoring ? (
+                  <>
+                    <Typography variant="bodySm">Monitor is not running.</Typography>
+                    <Button
+                      className="shrink-0"
+                      onClick={onStartMonitoring}
+                      size="sm"
+                      type="button"
+                      variant="default"
+                    >
+                      Start Monitor
+                    </Button>
+                  </>
+                ) : (
+                  <Typography variant="bodySm">{errorMessage}</Typography>
+                )}
               </div>
             )
           }

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
@@ -4,7 +4,6 @@ import * as R from "ramda"
 import { EmptyState } from "../../ui/empty-state"
 import { LoadingState } from "../../ui/loading-state"
 import { Typography } from "../../ui/typography"
-import { Button } from "../../ui/button"
 import { type SortOrder } from "../../ui/sortable-table-header"
 import { HotKeysHeatmapModal } from "./hot-keys-heatmap"
 import { MonitorNotRunningBanner, NodeErrorsBanner } from "./hot-keys-banners"
@@ -78,25 +77,10 @@ export function HotKeys({
         {banners}
         <EmptyState
           action={
-            (errorMessage || (!monitorRunning && onStartMonitoring)) && (
+            errorMessage && (
               <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 rounded-md flex items-center gap-2">
                 <AlertCircle className="w-4 h-4 text-red-500 shrink-0" />
-                {!monitorRunning && onStartMonitoring ? (
-                  <>
-                    <Typography variant="bodySm">Monitor is not running.</Typography>
-                    <Button
-                      className="shrink-0"
-                      onClick={onStartMonitoring}
-                      size="sm"
-                      type="button"
-                      variant="default"
-                    >
-                      Start Monitor
-                    </Button>
-                  </>
-                ) : (
-                  <Typography variant="bodySm">{errorMessage}</Typography>
-                )}
+                <Typography variant="bodySm">{errorMessage}</Typography>
               </div>
             )
           }

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
@@ -63,7 +63,7 @@ export function HotKeys({
   const banners = (
     <>
       {!monitorRunning && onStartMonitoring && (
-        <MonitorNotRunningBanner error={monitorError} onStartMonitoring={onStartMonitoring} />
+        <MonitorNotRunningBanner error={monitorError} />
       )}
       {nodeErrors && nodeErrors.length > 0 && (
         <NodeErrorsBanner nodeErrors={nodeErrors} />

--- a/apps/frontend/src/components/connection/ClusterConnectionGroup.tsx
+++ b/apps/frontend/src/components/connection/ClusterConnectionGroup.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux"
 import {
   ChevronDown,
   ChevronRight,
+  CircleChevronRight,
   Network,
   PencilIcon,
   CheckIcon,
@@ -21,6 +22,7 @@ import {
   connectPending
 } from "@/state/valkey-features/connection/connectionSlice"
 import { useAppDispatch } from "@/hooks/hooks.ts"
+import history from "@/history.ts"
 import { Button } from "@/components/ui/button.tsx"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip.tsx"
 import { Typography } from "@/components/ui/typography.tsx"
@@ -221,6 +223,17 @@ export const ClusterConnectionGroup = ({ clusterId, connections, highlight = "",
         </div>
 
         <div className="flex items-center text-sm gap-2">
+          {hasConnectedInstance && (
+            <Button
+              className="flex items-center gap-1 mr-4 hover:border-primary"
+              onClick={() => history.navigate(`/${clusterId}/${firstConnectedConnection.connectionId}/cluster-topology`)}
+              size="sm"
+              variant="outline"
+            >
+              <CircleChevronRight size={16} />
+              Open
+            </Button>
+          )}
           {
             !hasConnectedInstance && lastOpenedNode ? (
               <Tooltip>
@@ -263,7 +276,6 @@ export const ClusterConnectionGroup = ({ clusterId, connections, highlight = "",
                 clusterId={clusterId}
                 connection={connection}
                 connectionId={connectionId}
-                hideOpenButton={true}
                 highlight={highlight}
                 isNested={true}
                 key={connectionId}

--- a/apps/frontend/src/components/connection/ConnectionEntry.tsx
+++ b/apps/frontend/src/components/connection/ConnectionEntry.tsx
@@ -104,14 +104,27 @@ export const ConnectionEntry = ({
             )}
           </div>
           {/* action buttons */}
-          <ConnectionActionButtons
-            isConnected={isConnected}
-            isConnecting={isConnecting}
-            onConnect={handleConnect}
-            onDelete={handleDelete}
-            onDisconnect={handleDisconnect}
-            onEdit={handleEdit}
-          />
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {isConnected && !hideOpenButton && (
+              <Button
+                className="flex items-center gap-1 hover:border-primary"
+                onClick={() => history.navigate(clusterId ? clusterPath(connectionId) : `/${connectionId}/dashboard`)}
+                size="sm"
+                variant="outline"
+              >
+                <CircleChevronRight size={16} />
+                Open
+              </Button>
+            )}
+            <ConnectionActionButtons
+              isConnected={isConnected}
+              isConnecting={isConnecting}
+              onConnect={handleConnect}
+              onDelete={handleDelete}
+              onDisconnect={handleDisconnect}
+              onEdit={handleEdit}
+            />
+          </div>
         </div>
       </div>
     )

--- a/apps/frontend/src/components/ui/tab-group.tsx
+++ b/apps/frontend/src/components/ui/tab-group.tsx
@@ -1,5 +1,5 @@
-import { Button } from "./button"
 import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
 
 export interface TabOption<T extends string = string> {
   id: T
@@ -20,19 +20,23 @@ export function TabGroup<T extends string = string>({
   className = "",
 }: TabGroupProps<T>) {
   return (
-    <nav className={`flex gap-2 ${className}`}>
+    <nav className={cn("flex gap-4 border-b border-input", className)}>
       {tabs.map((tab) => {
         const isActive = activeTab === tab.id
         return (
-          <Button
+          <button
+            className={cn(
+              "px-1 py-2 -mb-px text-sm font-medium border-b-2 transition-colors cursor-pointer",
+              isActive
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/40",
+            )}
             key={tab.id}
             onClick={() => onChange(tab.id)}
-            size={"sm"}
             type="button"
-            variant={isActive ? "default" : "outline"}
           >
             {tab.label}
-          </Button>
+          </button>
         )
       })}
     </nav>


### PR DESCRIPTION
Closes #447

- Big Keys: replaced the icon-only refresh button with a prominent, labeled "Scan" button
- Hot Keys: replaced the underlined text-link "Start MONITOR" with an actual Button component (both instances — the banner and the empty-state variant)

Also added/fixed while in this area:
- Cluster connection group header now shows an "Open" button when connected (matching standalone connections), navigating to the cluster topology view
- Individual node connections within an expanded cluster group also get an "Open" button, navigating to that node's dashboard
- Redesigned `TabGroup` (Hot Keys / Big Keys / Command Logs) as underline-style tabs instead of button pills — the previous pill style made action buttons using the same `default` variant (like Start Monitor) look like an extra tab
- Removed a duplicate "Start Monitor" button that rendered twice (banner + empty state) when Hot Keys had no data and monitor wasn't running 

<img width="1279" height="470" alt="Screenshot 2026-08-14 at 5 53 46 PM" src="https://github.com/user-attachments/assets/29385cca-e29e-45fa-a578-0f77e4d43887" />

<img width="1372" height="363" alt="Screenshot 2026-08-14 at 5 54 26 PM" src="https://github.com/user-attachments/assets/b9dc1629-f5f6-454b-9da1-65c98ed9f28d" />

<img width="999" height="645" alt="Screenshot 2026-08-14 at 5 52 37 PM" src="https://github.com/user-attachments/assets/4b1ba297-c274-4f8a-878d-d671b107f07d" />

