### PR TITLE
first implementatoin of cluster node aggregation view

### DIFF
--- a/apps/frontend/src/components/cluster-topology/Cluster.tsx
+++ b/apps/frontend/src/components/cluster-topology/Cluster.tsx
@@ -21,10 +21,10 @@ import {
   selectCluster, selectClusterNodeRows, selectClusterMetrics
 } from "@/state/valkey-features/cluster/clusterSelectors"
 import { useAppDispatch } from "@/hooks/hooks"
-import { updateClusterData, stopClusterDataPolling } from "@/state/valkey-features/cluster/clusterSlice"
+import { updateClusterData, stopClusterDataPolling, type NodeRole } from "@/state/valkey-features/cluster/clusterSlice"
 import { selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
 
-type RoleFilter = "all" | "primary" | "replica"
+type RoleFilter = "all" | NodeRole
 type UtilizationFilter = "all" | UtilizationLevel
 
 export function Cluster() {
@@ -179,7 +179,7 @@ export function Cluster() {
               key={row.dataKey}
               nodeData={clusterData.data[row.dataKey]}
               port={row.port}
-              primary={row.primary}
+              primaryConfig={row.primary}
               role={row.role}
               utilization={clusterData.utilization?.[row.dataKey]}
             />

--- a/apps/frontend/src/components/cluster-topology/Cluster.tsx
+++ b/apps/frontend/src/components/cluster-topology/Cluster.tsx
@@ -6,7 +6,6 @@ import { MAX_CONNECTIONS } from "@common/src/constants.ts"
 import { truncateText } from "@common/src/truncate-text.ts"
 import { formatBytes } from "@common/src/bytes-conversion.ts"
 import { calculateHitRatio } from "@common/src/cache-hit-ratio.ts"
-import { sanitizeUrl } from "@common/src/url-utils.ts"
 import { AppHeader } from "../ui/app-header"
 import RouteContainer from "../ui/route-container"
 import { StatCard } from "../ui/stat-card"
@@ -16,25 +15,17 @@ import { Typography } from "../ui/typography"
 import { TableContainer } from "../ui/table-container"
 import { StaticTableHeader } from "../ui/sortable-table-header"
 import { ClusterNodeRow } from "./cluster-node-row"
-import { getUtilizationLevel, type UtilizationLevel } from "./node-metrics"
-import type { PrimaryNode } from "@/state/valkey-features/cluster/clusterSlice"
-import { selectCluster } from "@/state/valkey-features/cluster/clusterSelectors"
+import type { RootState } from "@/store.ts"
+import { getUtilizationLevel, type UtilizationLevel } from "@/state/valkey-features/cluster/clusterUtilization"
+import {
+  selectCluster, selectClusterNodeRows, selectClusterMetrics
+} from "@/state/valkey-features/cluster/clusterSelectors"
 import { useAppDispatch } from "@/hooks/hooks"
 import { updateClusterData, stopClusterDataPolling } from "@/state/valkey-features/cluster/clusterSlice"
 import { selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
 
 type RoleFilter = "all" | "primary" | "replica"
 type UtilizationFilter = "all" | UtilizationLevel
-
-interface NodeRow {
-  dataKey: string
-  searchKey: string
-  host: string
-  port: number
-  role: "primary" | "replica"
-  primary: PrimaryNode
-  isGroupEnd: boolean
-}
 
 export function Cluster() {
   const { id, clusterId } = useParams()
@@ -46,6 +37,8 @@ export function Cluster() {
     }
   }, [id, clusterId, dispatch])
   const clusterData = useSelector(selectCluster(clusterId!))
+  const nodeRows = useSelector((state: RootState) => selectClusterNodeRows(state, clusterId!))
+  const metrics = useSelector((state: RootState) => selectClusterMetrics(state, clusterId!))
   const [searchQuery, setSearchQuery] = useState("")
   const [roleFilter, setRoleFilter] = useState<RoleFilter>("all")
   const [utilizationFilter, setUtilizationFilter] = useState<UtilizationFilter>("all")
@@ -65,63 +58,17 @@ export function Cluster() {
     )
   }
 
-  const clusterEntries = Object.entries(clusterData.clusterNodes)
-
-  const nodeRows: NodeRow[] = clusterEntries.flatMap(([primaryKey, primary]) => [
-    {
-      dataKey: primaryKey,
-      searchKey: primaryKey,
-      host: primary.host,
-      port: primary.port,
-      role: "primary" as const,
-      primary,
-      isGroupEnd: primary.replicas.length === 0,
-    },
-    ...primary.replicas.map((replica, index) => ({
-      dataKey: sanitizeUrl(`${replica.host}-${replica.port}`),
-      searchKey: `${replica.host}:${replica.port}`,
-      host: replica.host,
-      port: replica.port,
-      role: "replica" as const,
-      primary,
-      isGroupEnd: index === primary.replicas.length - 1,
-    })),
-  ])
-
-  let usedMemorySum = 0
-  let memoryLimitSum = 0
-  let opsPerSecSum = 0
-  let hitsSum = 0
-  let missesSum = 0
-  let flaggedNodes = 0
-
-  for (const row of nodeRows) {
-    const nodeData = clusterData.data[row.dataKey]
-    const nodeUtilization = clusterData.utilization?.[row.dataKey]
-
-    usedMemorySum += nodeUtilization?.used_memory ?? (Number(nodeData?.used_memory) || 0)
-    memoryLimitSum += nodeUtilization?.memory_limit_bytes ?? 0
-    opsPerSecSum += Number(nodeData?.instantaneous_ops_per_sec) || 0
-    hitsSum += Number(nodeData?.keyspace_hits) || 0
-    missesSum += Number(nodeData?.keyspace_misses) || 0
-
-    // Badges render on primaries only, so replicas must not inflate the count.
-    if (row.role === "primary"
-      && getUtilizationLevel(nodeUtilization?.memory_utilization_percent, nodeUtilization?.cpu_utilization_percent) === "high") {
-      flaggedNodes += 1
-    }
-  }
-
-  const clusterMemoryValue = (
+  // Without a single reporting node the sums are zero by default, not by measurement.
+  const clusterMemoryValue = metrics.hasUtilization ? (
     <span className="flex flex-wrap items-baseline justify-center gap-x-1">
-      <span className="whitespace-nowrap">{formatBytes(usedMemorySum)}</span>
+      <span className="whitespace-nowrap">{formatBytes(metrics.usedMemory)}</span>
       <span className="text-base font-normal text-muted-foreground whitespace-nowrap">
-        / {memoryLimitSum > 0 ? formatBytes(memoryLimitSum) : "∞"}
+        / {metrics.memoryLimit > 0 ? formatBytes(metrics.memoryLimit) : "∞"}
       </span>
     </span>
-  )
-  const totalOpsPerSecValue = `${Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(opsPerSecSum)}/s`
-  const clusterHitRatioValue = calculateHitRatio(hitsSum, missesSum)
+  ) : "—"
+  const totalOpsPerSecValue = `${Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(metrics.opsPerSec)}/s`
+  const clusterHitRatioValue = calculateHitRatio(metrics.hits, metrics.misses)
 
   // filtering nodes based on search query, role, and utilization
   const filteredRows = nodeRows.filter((row) => {
@@ -156,7 +103,7 @@ export function Cluster() {
         <StatCard label="Cluster Memory" value={clusterMemoryValue} />
         <StatCard label="Total Ops/Sec" value={totalOpsPerSecValue} />
         <StatCard label="Cluster Hit Ratio" value={clusterHitRatioValue} />
-        <StatCard label="Nodes Flagged" value={flaggedNodes} />
+        <StatCard label="Nodes Flagged" value={metrics.flaggedNodes} />
       </div>
 
       {/* Search and filters */}

--- a/apps/frontend/src/components/cluster-topology/Cluster.tsx
+++ b/apps/frontend/src/components/cluster-topology/Cluster.tsx
@@ -1,39 +1,56 @@
 import { useEffect, useState } from "react"
 import { useSelector } from "react-redux"
-import { Server, CheckCircle2 } from "lucide-react"
+import { Server, ListFilter } from "lucide-react"
 import { useParams } from "react-router"
-import { CONNECTED, MAX_CONNECTIONS } from "@common/src/constants.ts"
-import { buildConnectionId } from "@common/src/connection-id.ts"
+import { MAX_CONNECTIONS } from "@common/src/constants.ts"
 import { truncateText } from "@common/src/truncate-text.ts"
+import { formatBytes } from "@common/src/bytes-conversion.ts"
+import { calculateHitRatio } from "@common/src/cache-hit-ratio.ts"
+import { sanitizeUrl } from "@common/src/url-utils.ts"
 import { AppHeader } from "../ui/app-header"
 import RouteContainer from "../ui/route-container"
 import { StatCard } from "../ui/stat-card"
 import { SearchInput } from "../ui/search-input"
-import { ClusterNode } from "./cluster-node"
-import { Panel } from "../ui/panel"
-import type { RootState } from "@/store.ts"
+import { Select } from "../ui/select"
+import { Typography } from "../ui/typography"
+import { TableContainer } from "../ui/table-container"
+import { StaticTableHeader } from "../ui/sortable-table-header"
+import { ClusterNodeRow } from "./cluster-node-row"
+import { getUtilizationLevel, type UtilizationLevel } from "./node-metrics"
+import type { PrimaryNode } from "@/state/valkey-features/cluster/clusterSlice"
 import { selectCluster } from "@/state/valkey-features/cluster/clusterSelectors"
 import { useAppDispatch } from "@/hooks/hooks"
-import { updateClusterData } from "@/state/valkey-features/cluster/clusterSlice"
-import { selectClusterAlias, selectClusterDb } from "@/state/valkey-features/connection/connectionSelectors"
+import { updateClusterData, stopClusterDataPolling } from "@/state/valkey-features/cluster/clusterSlice"
+import { selectClusterAlias } from "@/state/valkey-features/connection/connectionSelectors"
+
+type RoleFilter = "all" | "primary" | "replica"
+type UtilizationFilter = "all" | UtilizationLevel
+
+interface NodeRow {
+  dataKey: string
+  searchKey: string
+  host: string
+  port: number
+  role: "primary" | "replica"
+  primary: PrimaryNode
+  isGroupEnd: boolean
+}
 
 export function Cluster() {
   const { id, clusterId } = useParams()
   const dispatch = useAppDispatch()
   useEffect(() => {
     dispatch(updateClusterData({ connectionId: id!, clusterId: clusterId! }))
+    return () => {
+      dispatch(stopClusterDataPolling({ clusterId: clusterId! }))
+    }
   }, [id, clusterId, dispatch])
   const clusterData = useSelector(selectCluster(clusterId!))
   const [searchQuery, setSearchQuery] = useState("")
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>("all")
+  const [utilizationFilter, setUtilizationFilter] = useState<UtilizationFilter>("all")
 
-  const connectionStatuses = useSelector((state: RootState) =>
-    state.valkeyConnection?.connections || {},
-  )
   const clusterAlias = useSelector(selectClusterAlias(id!))
-  // The app reuses one shared cluster client per cluster (single databaseId), so
-  // every node connection uses the same db. Connections are stored under
-  // buildConnectionId(host, port, db), so resolve node status by that id.
-  const clusterDb = useSelector(selectClusterDb(clusterId!))
 
   if (!clusterData?.clusterNodes || !clusterData?.data) {
     return (
@@ -50,33 +67,76 @@ export function Cluster() {
 
   const clusterEntries = Object.entries(clusterData.clusterNodes)
 
-  // cluster stats
-  const totalNodes = clusterEntries.length
-  const connectedNodes = clusterEntries.filter(([, primary]) =>
-    connectionStatuses[buildConnectionId(primary.host, primary.port, clusterDb)]?.status === CONNECTED,
-  ).length
-  const totalReplicas = clusterEntries.reduce((sum, [, primary]) =>
-    sum + primary.replicas.length, 0,
-  )
-  const totalClusterNodes = totalNodes + totalReplicas
+  const nodeRows: NodeRow[] = clusterEntries.flatMap(([primaryKey, primary]) => [
+    {
+      dataKey: primaryKey,
+      searchKey: primaryKey,
+      host: primary.host,
+      port: primary.port,
+      role: "primary" as const,
+      primary,
+      isGroupEnd: primary.replicas.length === 0,
+    },
+    ...primary.replicas.map((replica, index) => ({
+      dataKey: sanitizeUrl(`${replica.host}-${replica.port}`),
+      searchKey: `${replica.host}:${replica.port}`,
+      host: replica.host,
+      port: replica.port,
+      role: "replica" as const,
+      primary,
+      isGroupEnd: index === primary.replicas.length - 1,
+    })),
+  ])
 
-  // filtering nodes based on search query
-  const filteredEntries = clusterEntries.filter(([primaryKey, primary]) => {
-    if (!searchQuery) return true
+  let usedMemorySum = 0
+  let memoryLimitSum = 0
+  let opsPerSecSum = 0
+  let hitsSum = 0
+  let missesSum = 0
+  let flaggedNodes = 0
 
-    // check primary node
-    if (clusterData.searchableText[primaryKey]?.includes(searchQuery)) {
-      return true
+  for (const row of nodeRows) {
+    const nodeData = clusterData.data[row.dataKey]
+    const nodeUtilization = clusterData.utilization?.[row.dataKey]
+
+    usedMemorySum += nodeUtilization?.used_memory ?? (Number(nodeData?.used_memory) || 0)
+    memoryLimitSum += nodeUtilization?.memory_limit_bytes ?? 0
+    opsPerSecSum += Number(nodeData?.instantaneous_ops_per_sec) || 0
+    hitsSum += Number(nodeData?.keyspace_hits) || 0
+    missesSum += Number(nodeData?.keyspace_misses) || 0
+
+    // Badges render on primaries only, so replicas must not inflate the count.
+    if (row.role === "primary"
+      && getUtilizationLevel(nodeUtilization?.memory_utilization_percent, nodeUtilization?.cpu_utilization_percent) === "high") {
+      flaggedNodes += 1
     }
+  }
 
-    // check replicas
-    return primary.replicas.some((replica) => {
-      const replicaKey = `${replica.host}:${replica.port}`
-      return clusterData.searchableText[replicaKey]?.includes(searchQuery)
-    })
+  const clusterMemoryValue = (
+    <span className="flex flex-wrap items-baseline justify-center gap-x-1">
+      <span className="whitespace-nowrap">{formatBytes(usedMemorySum)}</span>
+      <span className="text-base font-normal text-muted-foreground whitespace-nowrap">
+        / {memoryLimitSum > 0 ? formatBytes(memoryLimitSum) : "∞"}
+      </span>
+    </span>
+  )
+  const totalOpsPerSecValue = `${Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(opsPerSecSum)}/s`
+  const clusterHitRatioValue = calculateHitRatio(hitsSum, missesSum)
+
+  // filtering nodes based on search query, role, and utilization
+  const filteredRows = nodeRows.filter((row) => {
+    const matchesSearch = !searchQuery || clusterData.searchableText[row.searchKey]?.includes(searchQuery)
+    const matchesRole = roleFilter === "all" || row.role === roleFilter
+
+    const rowUtilization = clusterData.utilization?.[row.dataKey]
+    const level = getUtilizationLevel(rowUtilization?.memory_utilization_percent, rowUtilization?.cpu_utilization_percent)
+    const matchesUtilization = utilizationFilter === "all"
+      || (row.role === "primary" && level === utilizationFilter)
+
+    return matchesSearch && matchesRole && matchesUtilization
   })
 
-  const highlight = searchQuery && filteredEntries.length < MAX_CONNECTIONS ? searchQuery : ""
+  const highlight = searchQuery && filteredRows.length < MAX_CONNECTIONS ? searchQuery : ""
 
   return (
     <RouteContainer className="overflow-y-hidden" title="Cluster Topology">
@@ -91,60 +151,94 @@ export function Cluster() {
         title="Cluster Topology"
       />
       {/* Cluster Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard
-          icon={<Server className="text-primary" size={20} />}
-          label="Total Nodes"
-          value={totalClusterNodes}
-        />
-        <StatCard
-          icon={<Server className="text-primary" size={20} />}
-          label="Primary Nodes"
-          value={totalNodes}
-        />
-        <StatCard
-          icon={<Server className="text-primary" size={20} />}
-          label="Replicas"
-          value={totalReplicas}
-        />
-        <StatCard
-          icon={<CheckCircle2 className="text-green-500" size={20} />}
-          label="Connected"
-          value={connectedNodes}
-        />
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+        <StatCard label="Total Nodes" value={nodeRows.length} />
+        <StatCard label="Cluster Memory" value={clusterMemoryValue} />
+        <StatCard label="Total Ops/Sec" value={totalOpsPerSecValue} />
+        <StatCard label="Cluster Hit Ratio" value={clusterHitRatioValue} />
+        <StatCard label="Nodes Flagged" value={flaggedNodes} />
       </div>
 
-      {/* Search */}
-      <div className="">
+      {/* Search and filters */}
+      <div className="flex items-center gap-2">
         <SearchInput
           onChange={(e) => setSearchQuery(e.target.value.toLowerCase())}
           placeholder="Search nodes by name, host, or port..."
           value={searchQuery}
         />
+        <Select
+          aria-label="Filter by role"
+          className="w-40 shrink-0"
+          icon={<ListFilter size={14} />}
+          onChange={(e) => setRoleFilter(e.target.value as RoleFilter)}
+          value={roleFilter}
+        >
+          <option value="all">All roles</option>
+          <option value="primary">Primary</option>
+          <option value="replica">Replica</option>
+        </Select>
+        <Select
+          aria-label="Filter by utilization"
+          className="w-44 shrink-0"
+          icon={<ListFilter size={14} />}
+          onChange={(e) => setUtilizationFilter(e.target.value as UtilizationFilter)}
+          value={utilizationFilter}
+        >
+          <option value="all">All utilization</option>
+          <option value="low">Low</option>
+          <option value="normal">Normal</option>
+          <option value="high">High</option>
+        </Select>
+        <Typography className="shrink-0 whitespace-nowrap" variant="bodySm">
+          Showing {filteredRows.length} of {nodeRows.length} nodes
+        </Typography>
       </div>
 
-      {/* Cluster Topology List */}
-      <Panel className="space-y-2 overflow-y-auto p-3">
-        {filteredEntries.length === 0 ? (
-          <div className="text-center py-8 text-tw-dark-border">
-            No nodes found matching "{searchQuery}"
-          </div>
+      {/* Cluster Topology Table */}
+      <TableContainer
+        className="border border-input rounded-md shadow-xs"
+        header={
+          <>
+            <StaticTableHeader label="" width="w-10" />
+            <StaticTableHeader
+              icon={<Server className="text-primary" size={16} />}
+              label="Node"
+              width="flex-1"
+            />
+            <StaticTableHeader className="text-center" label="Utilization" width="w-[10%]" />
+            <StaticTableHeader label="Memory" width="w-[10%]" />
+            <StaticTableHeader className="text-center" label="CPU" width="w-[8%]" />
+            <StaticTableHeader className="text-center" label="Ops/Sec" width="w-[10%]" />
+            <StaticTableHeader className="text-center" label="Hit Ratio" width="w-[10%]" />
+            <StaticTableHeader className="text-center" label="Conns" width="w-[8%]" />
+            <StaticTableHeader className="text-center" label="Actions" width="w-[14%]" />
+          </>
+        }
+      >
+        {filteredRows.length === 0 ? (
+          <tr>
+            <td className="px-4 py-8 text-center text-tw-dark-border" colSpan={9}>
+              No nodes found matching "{searchQuery}"
+            </td>
+          </tr>
         ) : (
-          filteredEntries.map(([primaryKey, primary]) => {
-            const primaryData = clusterData.data[primaryKey]
-            return (
-              <ClusterNode
-                clusterId={clusterId!}
-                highlight={highlight}
-                key={primaryKey}
-                primary={primary}
-                primaryData={primaryData}
-                primaryKey={primaryKey}
-              />
-            )
-          })
+          filteredRows.map((row) => (
+            <ClusterNodeRow
+              clusterId={clusterId!}
+              displayName={clusterData.data[row.dataKey]?.server_name || `${row.host}:${row.port}`}
+              highlight={highlight}
+              host={row.host}
+              isGroupEnd={row.isGroupEnd}
+              key={row.dataKey}
+              nodeData={clusterData.data[row.dataKey]}
+              port={row.port}
+              primary={row.primary}
+              role={row.role}
+              utilization={clusterData.utilization?.[row.dataKey]}
+            />
+          ))
         )}
-      </Panel>
+      </TableContainer>
     </RouteContainer>
   )
 }

--- a/apps/frontend/src/components/cluster-topology/cluster-node-row.tsx
+++ b/apps/frontend/src/components/cluster-topology/cluster-node-row.tsx
@@ -14,9 +14,10 @@ import { Button } from "../ui/button"
 import { Typography } from "../ui/typography"
 import { HighlightSearchMatch } from "../ui/highlight-search-match"
 import { PasswordPromptModal } from "../ui/password-prompt-modal"
-import { getUtilizationLevel, formatRate, formatPercent, type UtilizationLevel } from "./node-metrics"
+import { formatRate, formatPercent } from "./node-metrics"
 import type { RootState } from "@/store.ts"
 import type { PrimaryNode, ParsedNodeInfo, NodeUtilization } from "@/state/valkey-features/cluster/clusterSlice"
+import { getUtilizationLevel, type UtilizationLevel } from "@/state/valkey-features/cluster/clusterUtilization"
 import { connectPending, type ConnectionDetails } from "@/state/valkey-features/connection/connectionSlice.ts"
 import { useAppDispatch } from "@/hooks/hooks"
 import {
@@ -135,8 +136,10 @@ export function ClusterNodeRow({
     }))
   }
 
-  const usedMemory = utilization?.used_memory ?? (Number(nodeData?.used_memory) || 0)
-  const memoryLimit = utilization?.memory_limit_bytes ?? 0
+  // memory_limit_bytes is null only when the node itself reported no limit.
+  const memoryLabel = utilization
+    ? `${nodeData?.used_memory_human ?? "—"} / ${utilization.memory_limit_bytes ? formatBytes(utilization.memory_limit_bytes) : "∞"}`
+    : "—"
   const isHostMemoryBasis = utilization?.memory_basis === "total_system_memory"
   const utilizationLevel = getUtilizationLevel(utilization?.memory_utilization_percent, utilization?.cpu_utilization_percent)
   const isFlagged = role === "primary" && utilizationLevel === "high"
@@ -201,7 +204,7 @@ export function ClusterNodeRow({
       <td className="px-2 py-3 w-[10%]">
         {role === "primary" && (
           <Typography variant="bodyXs">
-            {nodeData?.used_memory_human ?? formatBytes(usedMemory)} / {memoryLimit > 0 ? formatBytes(memoryLimit) : "∞"}
+            {memoryLabel}
           </Typography>
         )}
       </td>

--- a/apps/frontend/src/components/cluster-topology/cluster-node-row.tsx
+++ b/apps/frontend/src/components/cluster-topology/cluster-node-row.tsx
@@ -16,7 +16,7 @@ import { HighlightSearchMatch } from "../ui/highlight-search-match"
 import { PasswordPromptModal } from "../ui/password-prompt-modal"
 import { formatRate, formatPercent } from "./node-metrics"
 import type { RootState } from "@/store.ts"
-import type { PrimaryNode, ParsedNodeInfo, NodeUtilization } from "@/state/valkey-features/cluster/clusterSlice"
+import type { PrimaryNode, ParsedNodeInfo, NodeUtilization, NodeRole } from "@/state/valkey-features/cluster/clusterSlice"
 import { getUtilizationLevel, type UtilizationLevel } from "@/state/valkey-features/cluster/clusterUtilization"
 import { connectPending, type ConnectionDetails } from "@/state/valkey-features/connection/connectionSlice.ts"
 import { useAppDispatch } from "@/hooks/hooks"
@@ -35,9 +35,10 @@ const UTILIZATION_BADGE: Record<UtilizationLevel, { label: string, variant: "sec
 interface ClusterNodeRowProps {
   host: string
   port: number
-  role: "primary" | "replica"
+  role: NodeRole
   displayName: string
-  primary: PrimaryNode
+  // Connection settings live on the primary; replicas inherit them and are not connectable.
+  primaryConfig: PrimaryNode
   nodeData?: ParsedNodeInfo
   utilization?: NodeUtilization
   clusterId: string
@@ -50,7 +51,7 @@ export function ClusterNodeRow({
   port,
   role,
   displayName,
-  primary,
+  primaryConfig,
   nodeData,
   utilization,
   clusterId,
@@ -87,8 +88,8 @@ export function ClusterNodeRow({
   const baseDetails: ConnectionDetails = {
     host,
     port: port.toString(),
-    tls: primary.tls,
-    verifyTlsCertificate: primary.verifyTlsCertificate,
+    tls: primaryConfig.tls,
+    verifyTlsCertificate: primaryConfig.verifyTlsCertificate,
     endpointType: "node",
     db: clusterDb,
   }
@@ -96,16 +97,16 @@ export function ClusterNodeRow({
   const handleNodeConnect = () => {
     if (isConnected || isConnecting) return
 
-    if (primary.authType === "iam") {
+    if (primaryConfig.authType === "iam") {
       // IAM: all fields available from cluster state, no password needed
       dispatch(connectPending({
         connectionId,
         connectionDetails: {
           ...baseDetails,
-          username: primary.username ?? "",
+          username: primaryConfig.username ?? "",
           authType: "iam",
-          awsRegion: primary.awsRegion,
-          awsReplicationGroupId: primary.awsReplicationGroupId,
+          awsRegion: primaryConfig.awsRegion,
+          awsReplicationGroupId: primaryConfig.awsReplicationGroupId,
         },
       }))
     } else if (R.isNotNil(encryptedPassword)) {
@@ -114,7 +115,7 @@ export function ClusterNodeRow({
         connectionId,
         connectionDetails: {
           ...baseDetails,
-          username: primary.username ?? "",
+          username: primaryConfig.username ?? "",
           password: encryptedPassword,
         },
       }))
@@ -130,7 +131,7 @@ export function ClusterNodeRow({
       connectionId,
       connectionDetails: {
         ...baseDetails,
-        username: primary.username ?? "",
+        username: primaryConfig.username ?? "",
         password: encryptedPw,
       },
     }))

--- a/apps/frontend/src/components/cluster-topology/cluster-node-row.tsx
+++ b/apps/frontend/src/components/cluster-topology/cluster-node-row.tsx
@@ -1,10 +1,12 @@
 import * as R from "ramda"
 import { useState } from "react"
-import { LayoutDashboard, Terminal, PowerIcon, Server, MemoryStick, Users, Loader2 } from "lucide-react"
+import { LayoutDashboard, Terminal, PowerIcon, Loader2, Server } from "lucide-react"
 import { useNavigate } from "react-router"
 import { useSelector } from "react-redux"
 import { CONNECTED, CONNECTING, ERROR, MAX_CONNECTIONS } from "@common/src/constants.ts"
 import { buildConnectionId } from "@common/src/connection-id.ts"
+import { calculateHitRatio } from "@common/src/cache-hit-ratio.ts"
+import { formatBytes } from "@common/src/bytes-conversion.ts"
 import { TooltipProvider } from "@radix-ui/react-tooltip"
 import { Badge } from "../ui/badge"
 import { CustomTooltip } from "../ui/tooltip"
@@ -12,8 +14,9 @@ import { Button } from "../ui/button"
 import { Typography } from "../ui/typography"
 import { HighlightSearchMatch } from "../ui/highlight-search-match"
 import { PasswordPromptModal } from "../ui/password-prompt-modal"
+import { getUtilizationLevel, formatRate, formatPercent, type UtilizationLevel } from "./node-metrics"
 import type { RootState } from "@/store.ts"
-import type { PrimaryNode, ParsedNodeInfo } from "@/state/valkey-features/cluster/clusterSlice"
+import type { PrimaryNode, ParsedNodeInfo, NodeUtilization } from "@/state/valkey-features/cluster/clusterSlice"
 import { connectPending, type ConnectionDetails } from "@/state/valkey-features/connection/connectionSlice.ts"
 import { useAppDispatch } from "@/hooks/hooks"
 import {
@@ -22,21 +25,37 @@ import {
 import { secureStorage } from "@/utils/secureStorage.ts"
 import { cn } from "@/lib/utils"
 
-interface ClusterNodeProps {
-  primaryKey: string
-  primary: PrimaryNode
-  primaryData: ParsedNodeInfo
-  clusterId: string
-  highlight?: string
+const UTILIZATION_BADGE: Record<UtilizationLevel, { label: string, variant: "secondary" | "success" | "destructive" }> = {
+  low: { label: "Low", variant: "secondary" },
+  normal: { label: "Normal", variant: "success" },
+  high: { label: "High", variant: "destructive" },
 }
 
-export function ClusterNode({
-  primaryKey,
+interface ClusterNodeRowProps {
+  host: string
+  port: number
+  role: "primary" | "replica"
+  displayName: string
+  primary: PrimaryNode
+  nodeData?: ParsedNodeInfo
+  utilization?: NodeUtilization
+  clusterId: string
+  highlight?: string
+  isGroupEnd?: boolean
+}
+
+export function ClusterNodeRow({
+  host,
+  port,
+  role,
+  displayName,
   primary,
-  primaryData,
+  nodeData,
+  utilization,
   clusterId,
   highlight = "",
-}: ClusterNodeProps) {
+  isGroupEnd = true,
+}: ClusterNodeRowProps) {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
   // Inherit the parent cluster's Database_Index so node connections target the
@@ -46,7 +65,7 @@ export function ClusterNode({
   // Match the db-aware id scheme from buildConnectionId so the seed node
   // resolves to its status here, and node connects reuse that id
   // instead of creating a db id less duplicate.
-  const connectionId = buildConnectionId(primary.host, primary.port, clusterDb)
+  const connectionId = buildConnectionId(host, port, clusterDb)
 
   const connectionStatus = useSelector((state: RootState) =>
     state.valkeyConnection?.connections?.[connectionId]?.status,
@@ -65,8 +84,8 @@ export function ClusterNode({
   const [showPasswordModal, setShowPasswordModal] = useState(false)
 
   const baseDetails: ConnectionDetails = {
-    host: primary.host,
-    port: primary.port.toString(),
+    host,
+    port: port.toString(),
     tls: primary.tls,
     verifyTlsCertificate: primary.verifyTlsCertificate,
     endpointType: "node",
@@ -116,18 +135,20 @@ export function ClusterNode({
     }))
   }
 
-  const NodeDetails = ({ nodeData }: { nodeData: ParsedNodeInfo }) => (
-    <div className="flex items-center gap-2 text-xs">
-      <div className="flex items-center gap-1">
-        <MemoryStick className="text-primary" size={14} />
-        <Typography variant="bodyXs">{nodeData?.used_memory_human ?? "N/A"}</Typography>
-      </div>
-      <div className="flex items-center gap-1">
-        <Users className="text-primary" size={14} />
-        <Typography variant="bodyXs">{nodeData?.connected_clients ?? "N/A"}</Typography>
-      </div>
-    </div>
-  )
+  const usedMemory = utilization?.used_memory ?? (Number(nodeData?.used_memory) || 0)
+  const memoryLimit = utilization?.memory_limit_bytes ?? 0
+  const isHostMemoryBasis = utilization?.memory_basis === "total_system_memory"
+  const utilizationLevel = getUtilizationLevel(utilization?.memory_utilization_percent, utilization?.cpu_utilization_percent)
+  const isFlagged = role === "primary" && utilizationLevel === "high"
+
+  const memoryTooltip = isHostMemoryBasis
+    ? `${formatPercent(utilization?.memory_utilization_percent)} of host RAM — no maxmemory set`
+    : `${formatPercent(utilization?.memory_utilization_percent)} of configured maxmemory`
+  const utilizationTooltip = `Memory: ${memoryTooltip} · CPU: ${formatPercent(utilization?.cpu_utilization_percent)}`
+
+  const hitRatio = nodeData
+    ? calculateHitRatio(Number(nodeData.keyspace_hits) || 0, Number(nodeData.keyspace_misses) || 0)
+    : "—"
 
   const powerIconTooltip = isConnected   ? "Connected"
     : isConnecting ? "Connecting..."
@@ -136,54 +157,78 @@ export function ClusterNode({
           :                "Not Connected"
 
   return (
-    <div className="w-full">
-      <TooltipProvider>
-        <div className="px-4 py-3 border border-input rounded-md shadow-xs hover:border-primary/50">
-          <div className="flex items-stretch gap-4">
-            {/* Primary Node Section */}
-            <div className="flex items-center gap-3 min-w-0 flex-1">
-              <Server className="text-primary shrink-0" size={18} />
-              <div className="flex flex-col gap-1 min-w-0">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <Typography variant={"label"}>
-                    <HighlightSearchMatch query={highlight} text={primaryData?.server_name || primaryKey} />
-                  </Typography>
-                  <Badge className="text-xs px-2 py-0" variant={isConnected ? "success" : "secondary"}>
-                    PRIMARY
-                  </Badge>
-                </div>
-                <Typography variant="bodyXs"><HighlightSearchMatch query={highlight} text={`${primary.host}:${primary.port}`} /></Typography>
-                <NodeDetails nodeData={primaryData} />
-              </div>
+    <tr
+      className={cn(
+        "group transition-all duration-200",
+        isFlagged ? "bg-destructive/10 hover:bg-destructive/15" : "hover:bg-gray-50 dark:hover:bg-neutral-800/50",
+        isGroupEnd ? "border-b dark:border-tw-dark-border" : "border-b border-gray-100 dark:border-neutral-800/50",
+      )}
+    >
+      <td className="px-4 py-3 w-10">
+        {role === "primary" && <Server className="text-primary" size={16} />}
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex flex-col gap-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <Typography variant="label">
+                <HighlightSearchMatch query={highlight} text={displayName} />
+              </Typography>
+              <Badge className="text-[10px] px-2 py-0" variant={role === "primary" ? "default" : "secondary"}>
+                {role === "primary" ? "PRIMARY" : "REPLICA"}
+              </Badge>
             </div>
-
-            {/* Divider */}
-            {primary.replicas.length > 0 && (
-              <div className="w-px bg-tw-dark-border/30 shrink-0" />
-            )}
-
-            {/* Replicas Section */}
-            {primary.replicas.length > 0 && (
-              <div className="items-center gap-3 overflow-x-auto flex-1">
-                <Badge className="text-xs px-2 py-0 mb-2" variant="secondary">
-                  REPLICA{primary.replicas.length > 1 ? "S" : ""}
-                </Badge>
-                {primary.replicas.map((replica) => {
-                  const replicaKey = `${replica.host}:${replica.port}`
-                  return (
-                    <div className="flex items-center mb-2 gap-1" key={replicaKey}>
-                      <Server className="text-primary shrink-0" size={16} />
-                      <Typography className="underline" variant="bodyXs">
-                        <HighlightSearchMatch query={highlight} text={replicaKey} />
-                      </Typography>
-                    </div>
-                  )
-                })}
-              </div>
-            )}
-
-            {/* Actions */}
-            <div className="flex items-center gap-2 shrink-0">
+            <Typography variant="bodyXs">
+              <HighlightSearchMatch query={highlight} text={`${host}:${port}`} />
+            </Typography>
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-3 w-[10%] text-center">
+        {role === "primary" && utilizationLevel && (
+          <TooltipProvider>
+            <CustomTooltip content={utilizationTooltip}>
+              <Badge
+                className={cn("text-[10px] px-2 py-0", isHostMemoryBasis && "border-dashed")}
+                variant={UTILIZATION_BADGE[utilizationLevel].variant}
+              >
+                {UTILIZATION_BADGE[utilizationLevel].label}
+              </Badge>
+            </CustomTooltip>
+          </TooltipProvider>
+        )}
+      </td>
+      <td className="px-2 py-3 w-[10%]">
+        {role === "primary" && (
+          <Typography variant="bodyXs">
+            {nodeData?.used_memory_human ?? formatBytes(usedMemory)} / {memoryLimit > 0 ? formatBytes(memoryLimit) : "∞"}
+          </Typography>
+        )}
+      </td>
+      <td className="px-4 py-3 w-[8%] text-center">
+        {role === "primary" && (
+          <Typography variant="bodyXs">
+            {formatPercent(utilization?.cpu_utilization_percent)}
+          </Typography>
+        )}
+      </td>
+      <td className="px-4 py-3 w-[10%] text-center">
+        {role === "primary" && (
+          <Typography variant="bodyXs">
+            {nodeData?.instantaneous_ops_per_sec ? formatRate(Number(nodeData.instantaneous_ops_per_sec)) : "—"}
+          </Typography>
+        )}
+      </td>
+      <td className="px-4 py-3 w-[10%] text-center">
+        {role === "primary" && <Typography variant="bodyXs">{hitRatio}</Typography>}
+      </td>
+      <td className="px-4 py-3 w-[8%] text-center">
+        {role === "primary" && <Typography variant="bodyXs">{nodeData?.connected_clients ?? "—"}</Typography>}
+      </td>
+      <td className="px-4 py-3 w-[14%]">
+        {role === "primary" && (
+          <TooltipProvider>
+            <div className="flex items-center justify-center gap-2">
               <CustomTooltip content={powerIconTooltip}>
                 {isConnecting ? (
                   <Loader2
@@ -229,17 +274,19 @@ export function ClusterNode({
                 </Button>
               </CustomTooltip>
             </div>
-          </div>
-        </div>
-      </TooltipProvider>
-      <PasswordPromptModal
-        connectionLabel={`${primary.host}:${primary.port}`}
-        errorMessage={connectionStatus === ERROR ? "Connection failed. Check your password and try again." : undefined}
-        isConnecting={connectionStatus === CONNECTING}
-        onClose={() => setShowPasswordModal(false)}
-        onSubmit={handlePasswordSubmit}
-        open={showPasswordModal && connectionStatus !== CONNECTED}
-      />
-    </div>
+          </TooltipProvider>
+        )}
+      </td>
+      {role === "primary" && (
+        <PasswordPromptModal
+          connectionLabel={`${host}:${port}`}
+          errorMessage={connectionStatus === ERROR ? "Connection failed. Check your password and try again." : undefined}
+          isConnecting={connectionStatus === CONNECTING}
+          onClose={() => setShowPasswordModal(false)}
+          onSubmit={handlePasswordSubmit}
+          open={showPasswordModal && connectionStatus !== CONNECTED}
+        />
+      )}
+    </tr>
   )
 }

--- a/apps/frontend/src/components/cluster-topology/node-metrics.ts
+++ b/apps/frontend/src/components/cluster-topology/node-metrics.ts
@@ -1,0 +1,42 @@
+import { CPU_HIGH_THRESHOLD, CPU_NORMAL_THRESHOLD,
+  MEMORY_HIGH_THRESHOLD, MEMORY_NORMAL_THRESHOLD } from "@common/src/constants.ts"
+
+export type UtilizationLevel = "low" | "normal" | "high"
+
+const LEVEL_RANK: Record<UtilizationLevel, number> = { low: 0, normal: 1, high: 2 }
+
+// Memory and CPU get their own bands: a cache is meant to sit near its
+// memory limit, but a hot event loop is not meant to sit near one core.
+function levelFor(
+  percent: number | null | undefined,
+  normalThreshold: number,
+  highThreshold: number,
+): UtilizationLevel | null {
+  if (percent === null || percent === undefined) return null
+  if (percent >= highThreshold) return "high"
+  if (percent >= normalThreshold) return "normal"
+  return "low"
+}
+
+// Worst of the two, so 30% memory with 90% cpu is "high".
+export function getUtilizationLevel(
+  memoryPercent: number | null | undefined,
+  cpuPercent: number | null | undefined,
+): UtilizationLevel | null {
+  const levels = [
+    levelFor(memoryPercent, MEMORY_NORMAL_THRESHOLD, MEMORY_HIGH_THRESHOLD),
+    levelFor(cpuPercent, CPU_NORMAL_THRESHOLD, CPU_HIGH_THRESHOLD),
+  ].filter((level): level is UtilizationLevel => level !== null)
+
+  if (levels.length === 0) return null
+  return levels.reduce((worst, level) => (LEVEL_RANK[level] > LEVEL_RANK[worst] ? level : worst))
+}
+
+export function formatRate(value: number): string {
+  return `${Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(value)}/s`
+}
+
+export function formatPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—"
+  return `${value.toFixed(1)}%`
+}

--- a/apps/frontend/src/components/cluster-topology/node-metrics.ts
+++ b/apps/frontend/src/components/cluster-topology/node-metrics.ts
@@ -1,37 +1,3 @@
-import { CPU_HIGH_THRESHOLD, CPU_NORMAL_THRESHOLD,
-  MEMORY_HIGH_THRESHOLD, MEMORY_NORMAL_THRESHOLD } from "@common/src/constants.ts"
-
-export type UtilizationLevel = "low" | "normal" | "high"
-
-const LEVEL_RANK: Record<UtilizationLevel, number> = { low: 0, normal: 1, high: 2 }
-
-// Memory and CPU get their own bands: a cache is meant to sit near its
-// memory limit, but a hot event loop is not meant to sit near one core.
-function levelFor(
-  percent: number | null | undefined,
-  normalThreshold: number,
-  highThreshold: number,
-): UtilizationLevel | null {
-  if (percent === null || percent === undefined) return null
-  if (percent >= highThreshold) return "high"
-  if (percent >= normalThreshold) return "normal"
-  return "low"
-}
-
-// Worst of the two, so 30% memory with 90% cpu is "high".
-export function getUtilizationLevel(
-  memoryPercent: number | null | undefined,
-  cpuPercent: number | null | undefined,
-): UtilizationLevel | null {
-  const levels = [
-    levelFor(memoryPercent, MEMORY_NORMAL_THRESHOLD, MEMORY_HIGH_THRESHOLD),
-    levelFor(cpuPercent, CPU_NORMAL_THRESHOLD, CPU_HIGH_THRESHOLD),
-  ].filter((level): level is UtilizationLevel => level !== null)
-
-  if (levels.length === 0) return null
-  return levels.reduce((worst, level) => (LEVEL_RANK[level] > LEVEL_RANK[worst] ? level : worst))
-}
-
 export function formatRate(value: number): string {
   return `${Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(value)}/s`
 }

--- a/apps/frontend/src/components/ui/stat-card.tsx
+++ b/apps/frontend/src/components/ui/stat-card.tsx
@@ -3,7 +3,7 @@ import { Typography } from "./typography"
 import { cn } from "@/lib/utils"
 
 interface StatCardProps extends React.ComponentProps<"div"> {
-  value: string | number
+  value: React.ReactNode
   label: string
   icon?: React.ReactNode
   tooltip?: React.ReactNode
@@ -20,14 +20,14 @@ function StatCard({
   return (
     <div
       className={cn(
-        "h-20 p-4 rounded-md border border-input bg-white dark:bg-input/30",
-        "flex flex-col justify-center items-center",
+        "min-h-20 p-4 rounded-md border border-input bg-white dark:bg-input/30",
+        "flex flex-col justify-center items-center text-center",
         className,
       )}
       data-slot="stat-card"
       {...props}
     >
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 min-w-0">
         {icon}
         <Typography variant="heading">{value}</Typography>
       </div>

--- a/apps/frontend/src/state/epics/rootEpic.ts
+++ b/apps/frontend/src/state/epics/rootEpic.ts
@@ -17,7 +17,8 @@ import {
   getCpuUsageEpic,
   getMemoryUsageEpic,
   monitorEpic,
-  metricsReadinessRetryEpic
+  metricsReadinessRetryEpic,
+  clusterDataPollingEpic
 } from "./valkeyEpics"
 import { keyBrowserEpic } from "./keyBrowserEpic"
 import type { Store } from "@reduxjs/toolkit"
@@ -43,6 +44,7 @@ export const registerEpics = (store: Store) => {
     getMemoryUsageEpic(),
     monitorEpic(),
     metricsReadinessRetryEpic(store),
+    clusterDataPollingEpic(),
   ).subscribe({
     error: (err) => console.error("Epic error:", err),
   })

--- a/apps/frontend/src/state/epics/valkeyEpics.ts
+++ b/apps/frontend/src/state/epics/valkeyEpics.ts
@@ -4,7 +4,7 @@ import { ignoreElements, tap, delay, switchMap, mergeMap, exhaustMap, groupBy, t
 import * as R from "ramda"
 import { DISCONNECTED, LOCAL_STORAGE, NOT_CONNECTED, RETRY_CONFIG, retryDelay,
   METRICS_SERVER_NOT_READY, METRICS_MAX_RETRIES, METRICS_RETRY_INTERVAL_MS, SESSION_STORAGE,
-  VALKEY } from "@common/src/constants.ts"
+  CLUSTER_DATA_POLL_INTERVAL_MS, VALKEY } from "@common/src/constants.ts"
 import { toast } from "sonner"
 import { buildConnectionId } from "@common/src/connection-id"
 import { getSocket } from "./wsEpics"
@@ -37,7 +37,7 @@ import { hotKeysRequested } from "../valkey-features/hotkeys/hotKeysSlice.ts"
 import { bigKeysRequested } from "../valkey-features/bigkeys/bigKeysSlice.ts"
 import { commandLogsRequested } from "../valkey-features/commandlogs/commandLogsSlice.ts"
 import history, { wasRefreshedFrom } from "../../history.ts"
-import { setClusterData, updateClusterData } from "../valkey-features/cluster/clusterSlice.ts"
+import { setClusterData, updateClusterData, stopClusterDataPolling } from "../valkey-features/cluster/clusterSlice.ts"
 import { setConfig, updateConfig, updateConfigFulfilled } from "../valkey-features/config/configSlice.ts"
 import { cpuUsageRequested } from "../valkey-features/cpu/cpuSlice.ts"
 import { memoryUsageRequested } from "../valkey-features/memory/memorySlice.ts"
@@ -649,6 +649,31 @@ export const monitorEpic = () =>
       }
     }),
     ignoreElements(),
+  )
+
+// Epic to poll cluster data every 5 seconds for a given clusterId 
+export const clusterDataPollingEpic = () =>
+  action$.pipe(
+    select(updateClusterData),
+    groupBy((action) => action.payload.clusterId),
+    mergeMap((group$) =>
+      group$.pipe(
+        exhaustMap(({ payload: { connectionId, clusterId } }) =>
+          timer(CLUSTER_DATA_POLL_INTERVAL_MS, CLUSTER_DATA_POLL_INTERVAL_MS).pipe(
+            tap(() => {
+              getSocket().next({ type: setClusterData.type, payload: { clusterId, connectionId } })
+            }),
+            takeUntil(
+              action$.pipe(
+                select(stopClusterDataPolling),
+                filter((a) => a.payload.clusterId === clusterId),
+              ),
+            ),
+            ignoreElements(),
+          ),
+        ),
+      ),
+    ),
   )
 
 // metric server not ready retry epic for dashboad data

--- a/apps/frontend/src/state/valkey-features/cluster/clusterSelectors.ts
+++ b/apps/frontend/src/state/valkey-features/cluster/clusterSelectors.ts
@@ -1,6 +1,14 @@
+import { createSelector } from "@reduxjs/toolkit"
 import { VALKEY } from "@common/src/constants.ts"
+import { sanitizeUrl } from "@common/src/url-utils.ts"
 import * as R from "ramda"
+import { getUtilizationLevel } from "./clusterUtilization"
+import type { NodeRow, ParsedNodeInfo, NodeUtilization, PrimaryNode } from "./clusterSlice"
 import type { RootState } from "@/store.ts"
+
+type ClusterNodesMap = Record<string, PrimaryNode>
+type ClusterDataMap = Record<string, ParsedNodeInfo>
+type ClusterUtilizationMap = Record<string, NodeUtilization>
 
 export const selectAllClusters = (state: RootState) =>
   R.path<Record<string, { clusterNodes: Record<string, unknown> }>>([VALKEY.CLUSTER.name, "clusters"], state) ?? {}
@@ -8,8 +16,104 @@ export const selectAllClusters = (state: RootState) =>
 export const selectClusterData = (id: string) => (state: RootState) =>
   R.path([VALKEY.CLUSTER.name, "clusters", id, "data"], state)
 
-export const selectClusterNodes = (id: string) => (state: RootState) => 
+export const selectClusterNodes = (id: string) => (state: RootState) =>
   R.path([VALKEY.CLUSTER.name, "clusters", id, "clusterNodes"], state)
 
 export const selectCluster = (id: string) => (state: RootState) =>
   R.path([VALKEY.CLUSTER.name, "clusters", id], state)
+
+const clusterNodesAt = (state: RootState, id: string) =>
+  R.path<ClusterNodesMap>([VALKEY.CLUSTER.name, "clusters", id, "clusterNodes"], state)
+
+const clusterDataAt = (state: RootState, id: string) =>
+  R.path<ClusterDataMap>([VALKEY.CLUSTER.name, "clusters", id, "data"], state)
+
+const clusterUtilizationAt = (state: RootState, id: string) =>
+  R.path<ClusterUtilizationMap>([VALKEY.CLUSTER.name, "clusters", id, "utilization"], state)
+
+// One row per node, replicas following their primary so the table can group them.
+export const buildNodeRows = (clusterNodes: ClusterNodesMap = {}): NodeRow[] =>
+  Object.entries(clusterNodes).flatMap(([primaryKey, primary]) => [
+    {
+      dataKey: primaryKey,
+      searchKey: primaryKey,
+      host: primary.host,
+      port: primary.port,
+      role: "primary" as const,
+      primary,
+      isGroupEnd: primary.replicas.length === 0,
+    },
+    ...primary.replicas.map((replica, index) => ({
+      // INFO keys are sanitized host-port pairs, not Connection_Identifiers.
+      dataKey: sanitizeUrl(`${replica.host}-${replica.port}`),
+      searchKey: `${replica.host}:${replica.port}`,
+      host: replica.host,
+      port: replica.port,
+      role: "replica" as const,
+      primary,
+      isGroupEnd: index === primary.replicas.length - 1,
+    })),
+  ])
+
+export interface ClusterMetrics {
+  usedMemory: number
+  memoryLimit: number
+  opsPerSec: number
+  hits: number
+  misses: number
+  flaggedNodes: number
+  hasUtilization: boolean
+}
+
+// Totals are sums, not averages of percentages: a busy node counts for more
+// than a quiet one. Returns raw numbers so callers own the formatting.
+export const aggregateClusterMetrics = (
+  nodeRows: NodeRow[],
+  data: ClusterDataMap = {},
+  utilization: ClusterUtilizationMap = {},
+): ClusterMetrics => {
+  const metrics: ClusterMetrics = {
+    usedMemory: 0,
+    memoryLimit: 0,
+    opsPerSec: 0,
+    hits: 0,
+    misses: 0,
+    flaggedNodes: 0,
+    hasUtilization: false,
+  }
+
+  for (const row of nodeRows) {
+    const nodeData = data[row.dataKey]
+    const nodeUtilization = utilization[row.dataKey]
+
+    if (nodeUtilization) metrics.hasUtilization = true
+
+    metrics.usedMemory += nodeUtilization?.used_memory ?? 0
+    metrics.memoryLimit += nodeUtilization?.memory_limit_bytes ?? 0
+    metrics.opsPerSec += Number(nodeData?.instantaneous_ops_per_sec) || 0
+    metrics.hits += Number(nodeData?.keyspace_hits) || 0
+    metrics.misses += Number(nodeData?.keyspace_misses) || 0
+
+    // Badges render on primaries only, so replicas must not inflate the count.
+    if (row.role === "primary"
+      && getUtilizationLevel(
+        nodeUtilization?.memory_utilization_percent,
+        nodeUtilization?.cpu_utilization_percent,
+      ) === "high") {
+      metrics.flaggedNodes += 1
+    }
+  }
+
+  return metrics
+}
+
+// Memoized because it returns a new array; a plain selector would re-render on every dispatch.
+export const selectClusterNodeRows = createSelector(
+  [clusterNodesAt],
+  (clusterNodes) => buildNodeRows(clusterNodes),
+)
+
+export const selectClusterMetrics = createSelector(
+  [selectClusterNodeRows, clusterDataAt, clusterUtilizationAt],
+  aggregateClusterMetrics,
+)

--- a/apps/frontend/src/state/valkey-features/cluster/clusterSlice.ts
+++ b/apps/frontend/src/state/valkey-features/cluster/clusterSlice.ts
@@ -21,12 +21,14 @@ export interface PrimaryNode {
   awsReplicationGroupId?: string;
 }
 
+export type NodeRole = "primary" | "replica"
+
 export interface NodeRow {
   dataKey: string;
   searchKey: string;
   host: string;
   port: number;
-  role: "primary" | "replica";
+  role: NodeRole;
   primary: PrimaryNode;
   isGroupEnd: boolean;
 }

--- a/apps/frontend/src/state/valkey-features/cluster/clusterSlice.ts
+++ b/apps/frontend/src/state/valkey-features/cluster/clusterSlice.ts
@@ -21,6 +21,16 @@ export interface PrimaryNode {
   awsReplicationGroupId?: string;
 }
 
+export interface NodeRow {
+  dataKey: string;
+  searchKey: string;
+  host: string;
+  port: number;
+  role: "primary" | "replica";
+  primary: PrimaryNode;
+  isGroupEnd: boolean;
+}
+
 export interface ParsedNodeInfo {
   server_name: string | null;
   uptime_in_days: string | null;

--- a/apps/frontend/src/state/valkey-features/cluster/clusterSlice.ts
+++ b/apps/frontend/src/state/valkey-features/cluster/clusterSlice.ts
@@ -26,11 +26,28 @@ export interface ParsedNodeInfo {
   uptime_in_days: string | null;
   tcp_port: string | null;
   used_memory_human: string | null;
+  used_memory: string | null;
+  maxmemory: string | null;
   used_cpu_sys: string | null;
   instantaneous_ops_per_sec: string | null;
   total_commands_processed: string | null;
   role: string | null;
   connected_clients: string | null;
+  keyspace_hits: string | null;
+  keyspace_misses: string | null;
+}
+
+export type MemoryBasis = "maxmemory" | "total_system_memory" | "none"
+
+export interface NodeUtilization {
+  nodeId: string;
+  memory_utilization_percent: number | null;
+  memory_basis: MemoryBasis;
+  used_memory: number | null;
+  memory_limit_bytes: number | null;
+  cpu_utilization_percent: number | null;
+  cpu_sample_interval_seconds: number | null;
+  warnings: string[];
 }
 
 interface ClusterState {
@@ -38,6 +55,9 @@ interface ClusterState {
     clusterNodes: Record<string, PrimaryNode>;
     data: {
       [nodeAddress: string]: ParsedNodeInfo;
+    };
+    utilization: {
+      [nodeAddress: string]: NodeUtilization;
     };
     searchableText: {
       [nodeAddress: string]: string;
@@ -47,6 +67,7 @@ interface ClusterState {
 const initialClusterState: ClusterState = {}
 
 export const updateClusterData = createAction<{connectionId: string, clusterId: string}>("updateClusterData")
+export const stopClusterDataPolling = createAction<{clusterId: string}>("stopClusterDataPolling")
 
 const clusterSlice = createSlice({
   name: "valkeyCluster",
@@ -60,6 +81,7 @@ const clusterSlice = createSlice({
         state.clusters[clusterId] = {
           clusterNodes: {},
           data: {},
+          utilization: {},
           searchableText: {},
         }
       }
@@ -75,7 +97,7 @@ const clusterSlice = createSlice({
       delete state.clusters[action.payload.clusterId]
     },
     setClusterData: (state, action) => {
-      const { clusterId, info } = action.payload
+      const { clusterId, info, utilization } = action.payload
 
       if (!state.clusters[clusterId]) return
 
@@ -84,11 +106,15 @@ const clusterSlice = createSlice({
         uptime_in_days: R.path(["Server", "uptime_in_days"]),
         tcp_port: R.path(["Server", "tcp_port"]),
         used_memory_human: R.path(["Memory", "used_memory_human"]),
+        used_memory: R.path(["Memory", "used_memory"]),
+        maxmemory: R.path(["Memory", "maxmemory"]),
         used_cpu_sys: R.path(["CPU", "used_cpu_sys"]),
         instantaneous_ops_per_sec: R.path(["Stats", "instantaneous_ops_per_sec"]),
         total_commands_processed: R.path(["Stats", "total_commands_processed"]),
         role: R.path(["Replication", "role"]),
         connected_clients: R.path(["Clients", "connected_clients"]),
+        keyspace_hits: R.path(["Stats", "keyspace_hits"]),
+        keyspace_misses: R.path(["Stats", "keyspace_misses"]),
       })
 
       const result: ClusterState[string]["data"] = {}
@@ -97,6 +123,7 @@ const clusterSlice = createSlice({
         result[nodeAddress] = parseNodeInfo(nodeInfo) as ParsedNodeInfo
       }
       state.clusters[clusterId].data = result
+      state.clusters[clusterId].utilization = utilization ?? {}
 
       // Precompute searchable text for both primaries and replicas
       const searchableText: Record<string, string> = {}

--- a/apps/frontend/src/state/valkey-features/cluster/clusterUtilization.ts
+++ b/apps/frontend/src/state/valkey-features/cluster/clusterUtilization.ts
@@ -1,5 +1,6 @@
 import { CPU_HIGH_THRESHOLD, CPU_NORMAL_THRESHOLD,
   MEMORY_HIGH_THRESHOLD, MEMORY_NORMAL_THRESHOLD } from "@common/src/constants.ts"
+import * as R from "ramda"
 
 export type UtilizationLevel = "low" | "normal" | "high"
 
@@ -7,12 +8,12 @@ const LEVEL_RANK: Record<UtilizationLevel, number> = { low: 0, normal: 1, high: 
 
 // Memory and CPU get their own bands: a cache is meant to sit near its
 // memory limit, but a hot event loop is not meant to sit near one core.
-function levelFor(
+function getLevelFor(
   percent: number | null | undefined,
   normalThreshold: number,
   highThreshold: number,
 ): UtilizationLevel | null {
-  if (percent === null || percent === undefined) return null
+  if (R.isNil(percent)) return null
   if (percent >= highThreshold) return "high"
   if (percent >= normalThreshold) return "normal"
   return "low"
@@ -24,8 +25,8 @@ export function getUtilizationLevel(
   cpuPercent: number | null | undefined,
 ): UtilizationLevel | null {
   const levels = [
-    levelFor(memoryPercent, MEMORY_NORMAL_THRESHOLD, MEMORY_HIGH_THRESHOLD),
-    levelFor(cpuPercent, CPU_NORMAL_THRESHOLD, CPU_HIGH_THRESHOLD),
+    getLevelFor(memoryPercent, MEMORY_NORMAL_THRESHOLD, MEMORY_HIGH_THRESHOLD),
+    getLevelFor(cpuPercent, CPU_NORMAL_THRESHOLD, CPU_HIGH_THRESHOLD),
   ].filter((level): level is UtilizationLevel => level !== null)
 
   if (levels.length === 0) return null

--- a/apps/frontend/src/state/valkey-features/cluster/clusterUtilization.ts
+++ b/apps/frontend/src/state/valkey-features/cluster/clusterUtilization.ts
@@ -1,0 +1,33 @@
+import { CPU_HIGH_THRESHOLD, CPU_NORMAL_THRESHOLD,
+  MEMORY_HIGH_THRESHOLD, MEMORY_NORMAL_THRESHOLD } from "@common/src/constants.ts"
+
+export type UtilizationLevel = "low" | "normal" | "high"
+
+const LEVEL_RANK: Record<UtilizationLevel, number> = { low: 0, normal: 1, high: 2 }
+
+// Memory and CPU get their own bands: a cache is meant to sit near its
+// memory limit, but a hot event loop is not meant to sit near one core.
+function levelFor(
+  percent: number | null | undefined,
+  normalThreshold: number,
+  highThreshold: number,
+): UtilizationLevel | null {
+  if (percent === null || percent === undefined) return null
+  if (percent >= highThreshold) return "high"
+  if (percent >= normalThreshold) return "normal"
+  return "low"
+}
+
+// Worst of the two, so 30% memory with 90% cpu is "high".
+export function getUtilizationLevel(
+  memoryPercent: number | null | undefined,
+  cpuPercent: number | null | undefined,
+): UtilizationLevel | null {
+  const levels = [
+    levelFor(memoryPercent, MEMORY_NORMAL_THRESHOLD, MEMORY_HIGH_THRESHOLD),
+    levelFor(cpuPercent, CPU_NORMAL_THRESHOLD, CPU_HIGH_THRESHOLD),
+  ].filter((level): level is UtilizationLevel => level !== null)
+
+  if (levels.length === 0) return null
+  return levels.reduce((worst, level) => (LEVEL_RANK[level] > LEVEL_RANK[worst] ? level : worst))
+}

--- a/apps/frontend/src/state/valkey-features/connection/connectionSlice.ts
+++ b/apps/frontend/src/state/valkey-features/connection/connectionSlice.ts
@@ -13,12 +13,12 @@ import {
   type EndpointType
 } from "@common/src/constants"
 import * as R from "ramda"
+import type { NodeRole } from "@/state/valkey-features/cluster/clusterSlice"
 import { secureStorage } from "@/utils/secureStorage"
 
 type ConnectionStatus =
   | typeof NOT_CONNECTED | typeof CONNECTED | typeof CONNECTING | typeof RECONNECTING
   | typeof ERROR | typeof DISCONNECTED | typeof DISCONNECTING
-type Role = "primary" | "replica";
 
 export interface ConnectionDetails {
   host: string;
@@ -30,7 +30,7 @@ export interface ConnectionDetails {
   //TODO: Add handling and UI for uploading cert
   caCertPath?: string
   alias?: string;
-  role?: Role;
+  role?: NodeRole;
   clusterId?: string;
   // Eviction policy required for getting hot keys using hot slots
   keyEvictionPolicy?: KeyEvictionPolicy;

--- a/apps/server/src/__tests__/connection-id-ownership.test.ts
+++ b/apps/server/src/__tests__/connection-id-ownership.test.ts
@@ -49,6 +49,9 @@ const ALLOW_LIST: ReadonlySet<string> = new Set([
   "apps/server/src/utils.ts",
   // Cluster topology node IDs (not a Connection_Identifier)
   "apps/server/src/metrics-orchestrator.ts",
+  // Replica row key in the cluster topology table: must match the INFO host
+  // keys produced by `parseClusterInfo`, not a Connection_Identifier
+  "apps/frontend/src/components/cluster-topology/Cluster.tsx",
   // Metrics process self-identifies as a topology node, not a Connection_Identifier:
   // its registration nodeId must match `clusterNodesRegistry` keys in
   // `apps/server/src/metrics-orchestrator.ts`, which use `sanitizeUrl(host-port)`.

--- a/apps/server/src/__tests__/connection-id-ownership.test.ts
+++ b/apps/server/src/__tests__/connection-id-ownership.test.ts
@@ -51,7 +51,7 @@ const ALLOW_LIST: ReadonlySet<string> = new Set([
   "apps/server/src/metrics-orchestrator.ts",
   // Replica row key in the cluster topology table: must match the INFO host
   // keys produced by `parseClusterInfo`, not a Connection_Identifier
-  "apps/frontend/src/components/cluster-topology/Cluster.tsx",
+  "apps/frontend/src/state/valkey-features/cluster/clusterSelectors.ts",
   // Metrics process self-identifies as a topology node, not a Connection_Identifier:
   // its registration nodeId must match `clusterNodesRegistry` keys in
   // `apps/server/src/metrics-orchestrator.ts`, which use `sanitizeUrl(host-port)`.

--- a/apps/server/src/__tests__/node-utilization.test.ts
+++ b/apps/server/src/__tests__/node-utilization.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, beforeEach } from "node:test"
+import assert from "node:assert"
+import {
+  calculateMemoryUtilization,
+  readCpuSample,
+  computeNodeUtilization,
+  clearCpuSamples,
+  type InfoSections
+} from "../node-utilization"
+
+const GIB = 1024 * 1024 * 1024
+
+const mainThreadCpu = (sys: number, user: number) => ({
+  used_cpu_sys_main_thread: String(sys),
+  used_cpu_user_main_thread: String(user),
+})
+
+const sections = (memory: Record<string, string>, cpu: Record<string, string> = {}): InfoSections => ({
+  Memory: memory,
+  CPU: cpu,
+})
+
+beforeEach(() => clearCpuSamples())
+
+describe("memory basis", () => {
+  it("measures against maxmemory when one is configured", () => {
+    const result = calculateMemoryUtilization({
+      used_memory: String(GIB),
+      maxmemory: String(2 * GIB),
+      total_system_memory: String(16 * GIB),
+    })
+
+    assert.strictEqual(result.memory_utilization_percent, 50)
+    assert.strictEqual(result.memory_basis, "maxmemory")
+    assert.strictEqual(result.memory_limit_bytes, 2 * GIB)
+  })
+
+  it("falls back to host RAM when maxmemory is 0", () => {
+    const result = calculateMemoryUtilization({
+      used_memory: String(4 * GIB),
+      maxmemory: "0",
+      total_system_memory: String(16 * GIB),
+    })
+
+    assert.strictEqual(result.memory_utilization_percent, 25)
+    assert.strictEqual(result.memory_basis, "total_system_memory")
+  })
+
+  it("produces no percent when the node reports neither limit", () => {
+    const result = calculateMemoryUtilization({ used_memory: String(GIB), maxmemory: "0" })
+
+    assert.strictEqual(result.memory_utilization_percent, null)
+    assert.strictEqual(result.memory_basis, "none")
+    assert.strictEqual(result.memory_limit_bytes, null)
+  })
+})
+
+describe("cpu derivation", () => {
+  it("prefers the main thread counters, which are bounded by one core", () => {
+    const sample = readCpuSample({
+      ...mainThreadCpu(1, 2),
+      used_cpu_sys: "100",
+      used_cpu_user: "200",
+    }, 1000)
+
+    assert.deepStrictEqual(sample, { ts: 1000, totalCpuSeconds: 3 })
+  })
+
+  it("reports cpu time as a share of one core, and nothing on the first poll", () => {
+    const memory = { used_memory: String(GIB), maxmemory: String(2 * GIB) }
+
+    const first = computeNodeUtilization("node-1", sections(memory, mainThreadCpu(1, 1)), 0)
+    assert.strictEqual(first.cpu_utilization_percent, null)
+
+    const second = computeNodeUtilization("node-1", sections(memory, mainThreadCpu(1.5, 1.5)), 2000)
+    assert.strictEqual(second.cpu_utilization_percent, 50)
+    assert.strictEqual(second.cpu_sample_interval_seconds, 2)
+  })
+
+  it("keeps the older baseline when a poll arrives too soon to diff", () => {
+    const memory = { used_memory: String(GIB), maxmemory: String(2 * GIB) }
+    computeNodeUtilization("node-1", sections(memory, mainThreadCpu(1, 1)), 0)
+
+    const tooSoon = computeNodeUtilization("node-1", sections(memory, mainThreadCpu(1, 1.4)), 500)
+    assert.strictEqual(tooSoon.cpu_utilization_percent, null)
+
+    // Diffed against t=0, not the rejected t=500: 1 cpu second over 2 seconds.
+    const later = computeNodeUtilization("node-1", sections(memory, mainThreadCpu(1.5, 1.5)), 2000)
+    assert.strictEqual(later.cpu_utilization_percent, 50)
+  })
+
+  it("produces no reading when the counters go backwards after a restart", () => {
+    const memory = { used_memory: String(GIB), maxmemory: String(2 * GIB) }
+    computeNodeUtilization("node-1", sections(memory, mainThreadCpu(50, 50)), 0)
+
+    const afterRestart = computeNodeUtilization("node-1", sections(memory, mainThreadCpu(0, 1)), 2000)
+
+    assert.strictEqual(afterRestart.cpu_utilization_percent, null)
+    assert.ok(afterRestart.warnings.some((w) => w.includes("went backwards")))
+  })
+})

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -743,12 +743,6 @@ export function teardownConnection(
   const connection = clients.get(connectionId)
   clients.delete(connectionId)
 
-  // Samples are keyed per node, so keep them while any other db shares this node.
-  const nodeId = toNodeId(connectionId)
-  if (![...clients.keys()].some((id) => toNodeId(id) === nodeId)) {
-    clearCpuSamples(nodeId)
-  }
-
   if (connection && ![...clients.values()].some((c) => c.client === connection.client)) {
     try {
       connection.client.close()
@@ -756,9 +750,17 @@ export function teardownConnection(
       console.error(`Error closing connection ${connectionId}:`, error)
     }
 
-    if (connection.clusterId && !isWebMode) {
-      delete clusterNodesRegistry[connection.clusterId]
-      clusterCredentials.delete(connection.clusterId)
+    if (connection.clusterId) {
+      // Polling ends with the client; drop all CPU baselines so a reconnect starts fresh
+      clearCpuSamples(toNodeId(connectionId))
+      Object.keys(clusterNodesRegistry[connection.clusterId] ?? {}).forEach(
+        (nodeId) => clearCpuSamples(nodeId),
+      )
+
+      if (!isWebMode) {
+        delete clusterNodesRegistry[connection.clusterId]
+        clusterCredentials.delete(connection.clusterId)
+      }
     }
   }
 }

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -24,6 +24,7 @@ import {
   isKubernetes, 
   ClusterNodeMap } from "./metrics-orchestrator"
 import { subscribe } from "./node-watchers"
+import { clearCpuSamples } from "./node-utilization"
 import { createClusterValkeyClient, createStandaloneValkeyClient } from "./valkey-client"
 
 export type ConnectionContext = {
@@ -741,6 +742,12 @@ export function teardownConnection(
 
   const connection = clients.get(connectionId)
   clients.delete(connectionId)
+
+  // Samples are keyed per node, so keep them while any other db shares this node.
+  const nodeId = toNodeId(connectionId)
+  if (![...clients.keys()].some((id) => toNodeId(id) === nodeId)) {
+    clearCpuSamples(nodeId)
+  }
 
   if (connection && ![...clients.values()].some((c) => c.client === connection.client)) {
     try {

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -752,7 +752,6 @@ export function teardownConnection(
 
     if (connection.clusterId) {
       // Polling ends with the client; drop all CPU baselines so a reconnect starts fresh
-      clearCpuSamples(toNodeId(connectionId))
       Object.keys(clusterNodesRegistry[connection.clusterId] ?? {}).forEach(
         (nodeId) => clearCpuSamples(nodeId),
       )

--- a/apps/server/src/node-utilization.ts
+++ b/apps/server/src/node-utilization.ts
@@ -1,0 +1,216 @@
+import * as R from "ramda"
+import { type ParsedClusterInfo } from "./utils"
+
+export type MemoryBasis = "maxmemory" | "total_system_memory" | "none"
+
+export type InfoFields = Record<string, string>
+
+export type InfoSections = Record<string, InfoFields>
+
+export type CpuSample = {
+  ts: number
+  totalCpuSeconds: number
+}
+
+export type NodeUtilization = {
+  nodeId: string
+  memory_utilization_percent: number | null
+  memory_basis: MemoryBasis
+  used_memory: number | null
+  memory_limit_bytes: number | null
+  cpu_utilization_percent: number | null
+  cpu_sample_interval_seconds: number | null
+  warnings: string[]
+}
+
+type MemoryUtilization = Pick<
+  NodeUtilization,
+  "memory_utilization_percent" | "memory_basis" | "used_memory" | "memory_limit_bytes"
+> & { warnings: string[] }
+
+type CpuUtilization = Pick<
+  NodeUtilization,
+  "cpu_utilization_percent" | "cpu_sample_interval_seconds"
+> & { warnings: string[] }
+
+type FieldRead =
+  | { status: "ok"; value: number }
+  | { status: "missing" }
+  | { status: "unparseable" }
+
+const STALE_CPU_SAMPLE_MS = 5 * 60 * 1000
+
+// Concurrent pollers share this map, so ignore diffs taken too close together.
+const MIN_CPU_SAMPLE_MS = 1000
+
+const MEMORY_SECTION = "Memory"
+const CPU_SECTION = "CPU"
+
+const cpuSamples: Map<string, CpuSample> = new Map()
+
+// Drop retained samples so a reconnecting node re-baselines.
+export const clearCpuSamples = (nodeId?: string): void => {
+  if (nodeId === undefined) cpuSamples.clear()
+  else cpuSamples.delete(nodeId)
+}
+
+// Two-decimal rounding for percentages.
+export const round2 = (value: number): number => Math.round(value * 100) / 100
+
+// Read one INFO field, separating absent from non-numeric.
+const readNumericField = (fields: InfoFields, key: string): FieldRead => {
+  const raw = fields[key]
+  if (raw === undefined) return { status: "missing" }
+
+  const value = Number(raw.trim())
+  return Number.isFinite(value) ? { status: "ok", value } : { status: "unparseable" }
+}
+
+// Describe a failed read as a warning string.
+const describeFieldIssue = (key: string, read: FieldRead): string | null => {
+  if (read.status === "missing") return `${key} missing from INFO`
+  if (read.status === "unparseable") return `${key} is not numeric`
+  return null
+}
+
+// Unwrap a read, falling back when unusable.
+const valueOr = (read: FieldRead, fallback: number): number =>
+  read.status === "ok" ? read.value : fallback
+
+// Memory used against maxmemory, or host RAM when unset.
+export const calculateMemoryUtilization = (fields: InfoFields): MemoryUtilization => {
+  const usedRead = readNumericField(fields, "used_memory")
+  const maxRead = readNumericField(fields, "maxmemory")
+  const systemRead = readNumericField(fields, "total_system_memory")
+
+  const warnings = [
+    describeFieldIssue("used_memory", usedRead),
+    describeFieldIssue("maxmemory", maxRead),
+  ].filter((warning): warning is string => warning !== null)
+
+  const usedMemory = usedRead.status === "ok" ? usedRead.value : null
+  const maxMemory = valueOr(maxRead, 0)
+  const systemMemory = valueOr(systemRead, 0)
+
+  const [basis, limit]: [MemoryBasis, number | null] =
+    maxMemory > 0
+      ? ["maxmemory", maxMemory]
+      : systemMemory > 0
+        ? ["total_system_memory", systemMemory]
+        : ["none", null]
+
+  if (basis === "none") {
+    warnings.push("no memory limit reported; utilization percent unavailable")
+  }
+
+  return {
+    memory_utilization_percent:
+      usedMemory !== null && limit !== null ? round2((usedMemory / limit) * 100) : null,
+    memory_basis: basis,
+    used_memory: usedMemory,
+    memory_limit_bytes: limit,
+    warnings,
+  }
+}
+
+// Sum a pair of cumulative CPU counters into a timestamped sample.
+const readCpuCounters = (
+  fields: InfoFields,
+  sysKey: string,
+  userKey: string,
+  now: number,
+): CpuSample | null => {
+  const sysRead = readNumericField(fields, sysKey)
+  const userRead = readNumericField(fields, userKey)
+
+  if (sysRead.status !== "ok" || userRead.status !== "ok") return null
+
+  return { ts: now, totalCpuSeconds: sysRead.value + userRead.value }
+}
+
+// Prefer the main thread counters: command execution is single threaded, so
+// they are bounded by one core. The process wide totals include io and
+// background threads, which inflates the percentage past 100 on idle nodes.
+export const readCpuSample = (fields: InfoFields, now: number): CpuSample | null =>
+  readCpuCounters(fields, "used_cpu_sys_main_thread", "used_cpu_user_main_thread", now) ??
+  readCpuCounters(fields, "used_cpu_sys", "used_cpu_user", now)
+
+// Empty CPU result carrying why no percentage exists.
+const noCpuUtilization = (warnings: string[]): CpuUtilization => ({
+  cpu_utilization_percent: null,
+  cpu_sample_interval_seconds: null,
+  warnings,
+})
+
+// Diff two samples into percent of one core; reject stale or reset counters.
+export const calculateCpuUtilization = (
+  previous: CpuSample | null,
+  next: CpuSample,
+): CpuUtilization => {
+  if (previous === null) return noCpuUtilization([])
+
+  const elapsedMs = next.ts - previous.ts
+  if (elapsedMs <= 0) return noCpuUtilization(["cpu samples share a timestamp"])
+  if (elapsedMs < MIN_CPU_SAMPLE_MS) return noCpuUtilization([])
+  if (elapsedMs > STALE_CPU_SAMPLE_MS) {
+    return noCpuUtilization(["previous cpu sample too old to compare against"])
+  }
+
+  const cpuSecondsElapsed = next.totalCpuSeconds - previous.totalCpuSeconds
+  if (cpuSecondsElapsed < 0) {
+    return noCpuUtilization(["cpu counters went backwards; server likely restarted"])
+  }
+
+  const intervalSeconds = elapsedMs / 1000
+
+  return {
+    cpu_utilization_percent: round2((cpuSecondsElapsed / intervalSeconds) * 100),
+    cpu_sample_interval_seconds: round2(intervalSeconds),
+    warnings: [],
+  }
+}
+
+// Memory plus CPU for one node, retaining this sample for the next poll.
+export const computeNodeUtilization = (
+  nodeId: string,
+  sections: InfoSections,
+  now: number = Date.now(),
+): NodeUtilization => {
+  const memory = calculateMemoryUtilization(sections[MEMORY_SECTION] ?? {})
+  const nextSample = readCpuSample(sections[CPU_SECTION] ?? {}, now)
+  const previousSample = cpuSamples.get(nodeId) ?? null
+
+  const cpu =
+    nextSample === null
+      ? noCpuUtilization(["cpu counters missing from INFO"])
+      : calculateCpuUtilization(previousSample, nextSample)
+
+  // Keep the older baseline when the diff was rejected for being too recent.
+  const isTooSoon =
+    previousSample !== null &&
+    nextSample !== null &&
+    nextSample.ts - previousSample.ts < MIN_CPU_SAMPLE_MS
+
+  if (nextSample !== null && !isTooSoon) cpuSamples.set(nodeId, nextSample)
+
+  return {
+    nodeId,
+    memory_utilization_percent: memory.memory_utilization_percent,
+    memory_basis: memory.memory_basis,
+    used_memory: memory.used_memory,
+    memory_limit_bytes: memory.memory_limit_bytes,
+    cpu_utilization_percent: cpu.cpu_utilization_percent,
+    cpu_sample_interval_seconds: cpu.cpu_sample_interval_seconds,
+    warnings: [...memory.warnings, ...cpu.warnings],
+  }
+}
+
+// Utilization for every node in a parsed cluster INFO response.
+export const computeClusterUtilization = (
+  clusterInfo: ParsedClusterInfo,
+  now: number = Date.now(),
+): Record<string, NodeUtilization> =>
+  R.mapObjIndexed(
+    (sections, nodeId) => computeNodeUtilization(nodeId, sections, now),
+    clusterInfo,
+  )

--- a/apps/server/src/set-dashboard-data.ts
+++ b/apps/server/src/set-dashboard-data.ts
@@ -1,7 +1,8 @@
 import { GlideClusterClient, ConnectionError, ClosingError, TimeoutError } from "@valkey/valkey-glide"
 import WebSocket from "ws"
 import { VALKEY, METRICS_SERVER_NOT_READY } from "valkey-common"
-import { parseClusterInfo } from "./utils"
+import { type ParsedClusterInfo, parseClusterInfo } from "./utils"
+import { computeClusterUtilization, type NodeUtilization } from "./node-utilization"
 import { fetchWithTimeout } from "./actions/utils"
 
 type DashboardInfo = {
@@ -68,6 +69,18 @@ export async function setDashboardData(
   }
 }
 
+// Never let utilization math break the dashboard payload.
+const safeComputeClusterUtilization = (
+  clusterInfo: ParsedClusterInfo,
+): Record<string, NodeUtilization> => {
+  try {
+    return computeClusterUtilization(clusterInfo)
+  } catch (error) {
+    console.error("Unable to compute cluster utilization:", error)
+    return {}
+  }
+}
+
 export async function setClusterDashboardData(
   clusterId: string,
   client: GlideClusterClient,
@@ -77,13 +90,14 @@ export async function setClusterDashboardData(
   try {
     const rawInfo = await client.info()
     const clusterInfo = parseClusterInfo(rawInfo)
-  
+
     ws.send(
       JSON.stringify({
         type: VALKEY.CLUSTER.setClusterData,
         payload: {
           clusterId,
           info: clusterInfo,
+          utilization: safeComputeClusterUtilization(clusterInfo),
         },
       }),
     )

--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -14,7 +14,7 @@ export const dns = {
   reverse,
 }
 
-type ParsedClusterInfo = {
+export type ParsedClusterInfo = {
   [host: string]: {
     [section: string]: {
       [key: string]: string

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -117,6 +117,16 @@ export const METRICS_SERVER_NOT_READY = "METRICS_SERVER_NOT_READY"
 export const METRICS_RETRY_INTERVAL_MS = 1000
 export const METRICS_MAX_RETRIES = 10
 
+// Compare CPU samples collected roughly 5 seconds apart
+export const CLUSTER_DATA_POLL_INTERVAL_MS = 5000
+
+// Utilization bands for cluster topology node metrics.
+// Memory is a share of the node's limit; CPU is a share of one core.
+export const MEMORY_HIGH_THRESHOLD = 90
+export const MEMORY_NORMAL_THRESHOLD = 70
+export const CPU_HIGH_THRESHOLD = 85
+export const CPU_NORMAL_THRESHOLD = 60
+
 export const CONNECTED = "Connected"
 export const CONNECTING = "Connecting"
 export const ERROR = "Error"


### PR DESCRIPTION
## Description

Merging cluster-wide metrics into the existing Cluster Topology route, so topology and utilization are one screen instead of visiting each node.

Include a summary of the change.

- Add a stat card row: Total Nodes, Cluster Memory, Total Ops/Sec, Cluster Hit Ratio, and Nodes Flagged.
- Replace the nested primary/replica list with a flat table — one row per node, showing role, utilization, memory, CPU, ops/sec, hit ratio and connections.
- Add a utilization badge (Low / Normal / High) per primary, based on whichever of memory or CPU is worse.
- Add role and utilization filters alongside the existing search.
- Compute per-node utilization on the server from the existing INFO fan-out, and send it with the cluster payload.
- Derive CPU as a live rate by diffing the main-thread CPU counters between polls, falling back to process-wide counters where those are not reported.
- Measure memory against `maxmemory`, falling back to host RAM when no limit is set (shown with a dashed badge). - Poll cluster data every 5s while the route is mounted, and stop on unmount.

### Change Visualization

BEFORE:

<img width="1914" height="962" alt="image" src="https://github.com/user-attachments/assets/cca30fb6-c73b-418f-9f1f-a1025dfd2499" />


AFTER:

<img width="1914" height="962" alt="image" src="https://github.com/user-attachments/assets/b009d102-9d58-4c58-b8b5-8b976cb0aab2" />


Include a screenshot/video of before and after the change.
