### PR TITLE
fixed unknown route blank page issue with a NOT Found page  and the e…

### DIFF
--- a/apps/frontend/menu.js
+++ b/apps/frontend/menu.js
@@ -15,7 +15,7 @@ function createApplicationMenu() {
         { label: "Connections", accelerator: isMac ? "Cmd+1" : "Ctrl+1", click: () => sendNavigationEvent("connect") },
         { label: "Dashboard", accelerator: isMac ? "Cmd+2" : "Ctrl+2", click: () => sendNavigationEvent("dashboard") },
         { label: "Key Browser", accelerator: isMac ? "Cmd+3" : "Ctrl+3", click: () => sendNavigationEvent("browse") },
-        { label: "Monitoring", accelerator: isMac ? "Cmd+4" : "Ctrl+4", click: () => sendNavigationEvent("monitoring") },
+        { label: "Activity", accelerator: isMac ? "Cmd+4" : "Ctrl+4", click: () => sendNavigationEvent("activity") },
         { label: "Send Command", accelerator: isMac ? "Cmd+5" : "Ctrl+5", click: () => sendNavigationEvent("sendcommand") },
         { label: "Cluster Topology", accelerator: isMac ? "Cmd+6" : "Ctrl+6", click: () => sendNavigationEvent("cluster-topology") },
         { label: "Settings", accelerator: isMac ? "Cmd+7" : "Ctrl+7", click: () => sendNavigationEvent("settings") },

--- a/apps/frontend/src/components/not-found/NotFound.tsx
+++ b/apps/frontend/src/components/not-found/NotFound.tsx
@@ -1,0 +1,23 @@
+import { ArrowLeft } from "lucide-react"
+import { Link, useLocation } from "react-router"
+import RouteContainer from "../ui/route-container"
+import { Typography } from "../ui/typography"
+import { Button } from "../ui/button"
+
+export default function NotFound() {
+  const location = useLocation()
+
+  return (
+    <RouteContainer title="Page Not Found">
+      <div className="flex flex-col flex-1 items-center justify-center gap-4">
+        <Typography variant="display">Page Not Found</Typography>
+        <Typography className="text-muted-foreground" variant="bodySm">
+          No page matches <Typography className="text-code" variant="code">{location.pathname}</Typography>
+        </Typography>
+        <Button asChild variant="default">
+          <Link to="/connect"> <ArrowLeft/>Go to Connections</Link>
+        </Button>
+      </div>
+    </RouteContainer>
+  )
+}

--- a/apps/frontend/src/components/ui/app-sidebar.tsx
+++ b/apps/frontend/src/components/ui/app-sidebar.tsx
@@ -134,7 +134,7 @@ export function AppSidebar() {
                   isExternal: true,
                 },
                 {
-                  to: `${id}/learnmore`,
+                  to: clusterId ? `/${clusterId}/${id}/learnmore` : `${id}/learnmore`,
                   title: "Learn More",
                   icon: CircleQuestionMark,
                 },

--- a/apps/frontend/src/hooks/useShortcutNavigation.ts
+++ b/apps/frontend/src/hooks/useShortcutNavigation.ts
@@ -21,7 +21,7 @@ export const useShortcutNavigation = () => {
           sendcommand: clusterId ? `/${clusterId}/${id}/sendcommand` : `/${id}/sendcommand`,
           "cluster-topology": clusterId ? `/${clusterId}/${id}/cluster-topology` : "",
           settings: clusterId ? `/${clusterId}/${id}/settings` : `/${id}/settings`,
-          learnmore: `/${id}/learnmore`,
+          learnmore: clusterId ? `/${clusterId}/${id}/learnmore` : `/${id}/learnmore`,
         }
         : {
           connect: "/connect",
@@ -35,6 +35,6 @@ export const useShortcutNavigation = () => {
       }
     }
 
-    window.electronNavigation.onNavigate(handleNavigate)
+    return window.electronNavigation.onNavigate(handleNavigate)
   }, [navigate, id, clusterId, isConnected])
 }

--- a/apps/frontend/src/hooks/useShortcutNavigation.ts
+++ b/apps/frontend/src/hooks/useShortcutNavigation.ts
@@ -17,11 +17,11 @@ export const useShortcutNavigation = () => {
           connect: clusterId ? `/${clusterId}/${id}/connect` : `/${id}/connect`,
           dashboard: clusterId ? `/${clusterId}/${id}/dashboard` : `/${id}/dashboard`,
           browse: clusterId ? `/${clusterId}/${id}/browse` : `/${id}/browse`,
-          monitoring: clusterId ? `/${clusterId}/${id}/monitoring` : `/${id}/monitoring`,
+          activity: clusterId ? `/${clusterId}/${id}/activity` : `/${id}/activity`,
           sendcommand: clusterId ? `/${clusterId}/${id}/sendcommand` : `/${id}/sendcommand`,
           "cluster-topology": clusterId ? `/${clusterId}/${id}/cluster-topology` : "",
           settings: clusterId ? `/${clusterId}/${id}/settings` : `/${id}/settings`,
-          learnmore: clusterId ? `/${clusterId}/${id}/learnmore` : `/${id}/learnmore`,
+          learnmore: `/${id}/learnmore`,
         }
         : {
           connect: "/connect",

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -9,6 +9,7 @@ import history from "./history.ts"
 import RequireConnection from "./components/RequireConnection.tsx"
 import Settings from "./components/settings/Settings.tsx"
 import LearnMore from "./components/learn-more/LearnMore.tsx"
+import NotFound from "./components/not-found/NotFound.tsx"
 import { KeyBrowser } from "./components/key-browser/KeyBrowser.tsx"
 import { Cluster } from "./components/cluster-topology/Cluster.tsx"
 import { WebSocketReconnect } from "./components/WebSocketReconnect.tsx"
@@ -61,6 +62,8 @@ const AppWithHistory = () => {
           <Route element={<Settings />} path="/:id/settings" />
           <Route element={<LearnMore />} path="/:id/learnmore" />
         </Route>
+
+        <Route element={<NotFound />} path="*" />
       </Route>
     </Routes>
   )

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -50,6 +50,7 @@ const AppWithHistory = () => {
           <Route element={<Cluster />} path="/:clusterId/:id/cluster-topology" />
           <Route element={<ActivityView />} path="/:clusterId/:id/activity" />
           <Route element={<Settings />} path="/:clusterId/:id/settings" />
+          <Route element={<LearnMore />} path="/:clusterId/:id/learnmore" />
         </Route>
 
         {/* Routes without clusterId */}


### PR DESCRIPTION
…lectron shortcut

## Description

This PR adds a Not Found page for unknown routes and fixes keyboard shortcut navigation for Electron build. 

Include a summary of the change.

  - **Unknown routes rendered a blank page.** There was no catch-all route, so
    anything unmatched (e.g. `#/typo`) rendered nothing at all. Added a `NotFound`
    page inside the app layout, so it keeps the sidebar and shows the unmatched
    path with a link back to Connections.
- **Cmd/Ctrl+4 did nothing.** The menu sends the `activity` route key, but the
    renderer's shortcut map still had a stale `monitoring` entry pointing at
    `/:id/monitoring`, a route that doesn't exist. Mapped it to the real
    `/:clusterId/:id/activity` and `/:id/activity` routes, so it now works for both
    cluster and standalone connections.


Why a Not Found Page instead of the redirect to the /connect ?
A redirect hides the mistake - you just end up on Connections with no idea why. The 404 Not Found page tells you the address was wrong, so you can fix it.

### Change Visualization

<img width="1911" height="1004" alt="image" src="https://github.com/user-attachments/assets/b55b3ebf-c1b8-4c28-af9a-1b048e66adbf" />


Include a screenshot/video of before and after the change.
