### PR TITLE
fix(server): default TLS certificate verification to on for env-configured deployments

### DIFF
--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -73,7 +73,9 @@ export const initialConnectionDetails: ConnectionDetails = {
   username: process.env.VALKEY_USERNAME,
   password: process.env.VALKEY_PASSWORD,
   tls: process.env.VALKEY_TLS === "true",
-  verifyTlsCertificate: process.env.VALKEY_VERIFY_CERT === "true",
+  // Default certificate verification ON. Only an explicit VALKEY_VERIFY_CERT=false disables it,
+  // so an unset variable never silently downgrades a TLS connection to insecure (see #445).
+  verifyTlsCertificate: process.env.VALKEY_VERIFY_CERT !== "false",
   endpointType,
   authType: process.env.VALKEY_AUTH_TYPE === "iam" ? "iam" : "password",
   awsRegion: process.env.VALKEY_AWS_REGION,

--- a/apps/server/src/valkey-client.ts
+++ b/apps/server/src/valkey-client.ts
@@ -19,26 +19,38 @@ const buildSharedOptions = ({
   useTLS,
   verifyTlsCertificate,
   databaseId,
-}: ClientOptions) => ({
-  addresses,
-  credentials,
-  useTLS,
-  // Only forward `databaseId` when it's a non-zero integer. Glide issues a
-  // `SELECT` on the connection whenever `databaseId` is set, and cluster
-  // nodes reject `SELECT` (even `SELECT 0`). DB 0 is the default at the
-  // server side, so omitting it here is equivalent for standalone and
-  // mandatory for cluster.
-  ...(typeof databaseId === "number" && databaseId > 0 && { databaseId }),
-  advancedConfiguration: {
-    ...(useTLS && verifyTlsCertificate === false && {
-      tlsAdvancedConfiguration: {
-        insecure: true,
-      },
-    }),
-    connectionTimeout: 30000,
-  },
-  requestTimeout: 5000,
-})
+}: ClientOptions) => {
+  // Surface any insecure TLS connection: disabling certificate validation exposes the
+  // connection to MITM, so it must never happen silently (see #445).
+  if (useTLS && verifyTlsCertificate === false) {
+    console.warn(
+      "WARNING: TLS certificate validation is DISABLED (insecure: true). "
+        + "The connection is vulnerable to man-in-the-middle attacks. "
+        + "Set VALKEY_VERIFY_CERT=true (or enable certificate verification) to secure it.",
+    )
+  }
+
+  return {
+    addresses,
+    credentials,
+    useTLS,
+    // Only forward `databaseId` when it's a non-zero integer. Glide issues a
+    // `SELECT` on the connection whenever `databaseId` is set, and cluster
+    // nodes reject `SELECT` (even `SELECT 0`). DB 0 is the default at the
+    // server side, so omitting it here is equivalent for standalone and
+    // mandatory for cluster.
+    ...(typeof databaseId === "number" && databaseId > 0 && { databaseId }),
+    advancedConfiguration: {
+      ...(useTLS && verifyTlsCertificate === false && {
+        tlsAdvancedConfiguration: {
+          insecure: true,
+        },
+      }),
+      connectionTimeout: 30000,
+    },
+    requestTimeout: 5000,
+  }
+}
 
 export const createStandaloneValkeyClient = ({
   ...options


### PR DESCRIPTION
## Summary

Fixes #445. For environment/preconfigured deployments, TLS certificate validation defaulted to **off**.

`initialConnectionDetails` in `metrics-orchestrator.ts` derived `verifyTlsCertificate` from `VALKEY_VERIFY_CERT === "true"`, which evaluates to `false` when the variable is **unset**,  while TLS could still be enabled via `VALKEY_TLS=true`. That flowed into `valkey-client.ts`, which sets `tlsAdvancedConfiguration.insecure = true` when `useTLS && verifyTlsCertificate === false`, resulting in a TLS connection with certificate validation silently disabled (MITM exposure).

## Behavior change

Deployments that run TLS **without** setting `VALKEY_VERIFY_CERT` and relied on the old insecure default (e.g. self-signed certs) will now fail to connect until they either use a valid/trusted certificate or explicitly set `VALKEY_VERIFY_CERT=false`. This is the intended security fix; calling it out for release notes.