### PR TITLE
chore(ci): pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request reviewers
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const maintainers = ['ravjotbrar', 'nassery318', 'ArgusLi'];

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 'latest'
     - name: Install dependencies

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 'latest'
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 'latest'
     - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Install, build, and upload your site
-        uses: withastro/action@v6
+        uses: withastro/action@e84f40bd8d2caa9e768ec82ad30dd81f0b280853 # v6
         with:
           path: ./docs-site # The root location of your Astro project inside the repository.
 
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,12 +13,12 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 'latest'
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v7
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 'latest'
     - name: Install dependencies

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 'latest'
     - name: Install dependencies
@@ -59,7 +59,7 @@ jobs:
       if: always()
       run: security delete-keychain "$RUNNER_TEMP/build.keychain-db" || true
     - name: Upload mac artifacts (${{ matrix.arch }})
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: mac-${{ matrix.arch }}-artifacts
         path: ./release/*.dmg
@@ -77,9 +77,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 'latest'
     - name: Install dependencies
@@ -93,7 +93,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     - name: Upload linux artifacts (${{ matrix.arch }})
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: linux-${{ matrix.arch }}-artifacts
         path: |
@@ -107,12 +107,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download all artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         path: ./release
         merge-multiple: true
     - name: 'Create Draft release'
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: ./release/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 'latest'
     - name: Install dependencies


### PR DESCRIPTION
## Summary

Supply-chain hardening: pin every GitHub Action to a full commit SHA. Previously all workflows except `docker-build.yml` referenced actions by mutable tags (`@v4`/`@v5`/`@v6`/`@v7`). A force-moved or compromised tag would run in CI with the job's token (and, in `release-draft.yml`, alongside signing secrets). SHA pinning removes that risk.

Format matches the style already used in `docker-build.yml`: `uses: owner/action@<sha> # vN`.

## Actions pinned

- actions/checkout -> d23441a48e516b6c34aea4fa41551a30e30af803 (v6) and 11d5960a326750d5838078e36cf38b85af677262 (v4)
- actions/setup-node -> 249970729cb0ef3589644e2896645e5dc5ba9c38 (v6)
- actions/upload-artifact -> ea165f8d65b6e75b540449e92b4886f43607fa02 (v4)
- actions/download-artifact -> d3f86a106a0bac45b974a628896c90dbdf5c8093 (v4)
- actions/deploy-pages -> cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 (v5)
- actions/github-script -> f28e40c7f34bde8b3046d885e986cb6290c5673b (v7)
- actions/labeler -> bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 (v7)
- github/codeql-action (init + analyze) -> db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 (v4)
- softprops/action-gh-release -> 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 (v2)
- withastro/action -> e84f40bd8d2caa9e768ec82ad30dd81f0b280853 (v6)

SHAs were resolved from the tag each ref currently points to via the GitHub API.

## Notes

- `docker-build.yml` was already SHA-pinned — unchanged.
- `actions/labeler` is pinned here for consistency; it will become moot if the labeler workflow is later migrated off `pull_request_target` (separate item).
- A commented-out example ref in `codeql.yml` was intentionally left as-is.

## Testing

- All 12 workflow YAML files parse cleanly (js-yaml).
- No mutable `@vN` refs remain (verified by grep).
