### PR TITLE
Parse cluster INFO into null-prototype objects; bump nanoid to 3.3.18

### DIFF
--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -95,7 +95,7 @@ export const parseClusterInfo = (rawInfo: ClusterResponse<string>): ParsedCluste
               if (trimmed.startsWith("# ")) {
                 const section = trimmed.slice(2).trim()
                 state.currentSection = section
-                state.hostData[section] = state.hostData[section] || {}
+                state.hostData[section] = state.hostData[section] || Object.create(null)
                 return state
               }
   
@@ -107,11 +107,11 @@ export const parseClusterInfo = (rawInfo: ClusterResponse<string>): ParsedCluste
               const key = line.slice(0, idx)
               const value = line.slice(idx + 1)
   
-              state.hostData[state.currentSection] = state.hostData[state.currentSection] || {}
+              state.hostData[state.currentSection] = state.hostData[state.currentSection] || Object.create(null)
               state.hostData[state.currentSection]![key] = value
               return state
             },
-            { currentSection: null, hostData: {} },
+            { currentSection: null, hostData: Object.create(null) },
           ),
           (s: { hostData: ParsedClusterInfo[string] }) => s.hostData,
         )(infoString as string),

--- a/package-lock.json
+++ b/package-lock.json
@@ -12026,9 +12026,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Two small, independent changes to `parseClusterInfo` and a dependency:

### Cluster INFO parser uses null-prototype objects

`parseClusterInfo` built its section/host accumulators with plain object literals (`{}`). Section names come from `# <name>` lines and keys from the `key:value` lines of INFO output, so a section or key named `__proto__` (or `constructor`) was interpreted against `Object.prototype` rather than being stored as an ordinary property. Switching the accumulator and each section object to `Object.create(null)` makes the parsed result a plain map with no prototype chain, so those names are stored as normal keys.

Changed at all three construction sites in the reduce (`apps/server/src/utils.ts`): the section-header branch, the key-write branch, and the accumulator seed.

### Bump nanoid 3.3.17 -> 3.3.18

Transitive dependency (pulled in by `postcss`, which requires `^3.3.17` — 3.3.18 satisfies that range). Lockfile-only change.

## Testing

- `npm run build --workspace=server` — passes
- `npx eslint apps/server/src/utils.ts` — clean
- `npm test --workspace=server` — 195/195 pass (confirms downstream consumers of the parsed INFO — which use `Object.entries`/`R.path`/`JSON.stringify`, not prototype methods — are unaffected by the null-prototype objects)
