### PR TITLE
metric server binds to 127.0.0.1 for all modes except K8

### DIFF
--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -291,6 +291,7 @@ export async function startMetricsServer(nodeToStart: NodeInfo, nodeId: string) 
       VALKEY_REPLICATION_GROUP_ID: nodeToStart.awsReplicationGroupId,
       SERVER_HOST: process.env.SERVER_HOST ?? "localhost",
       SERVER_PORT: process.env.SERVER_PORT ?? "8080",
+      METRICS_BIND_HOST: process.env.METRICS_BIND_HOST ?? (isKubernetes ? "0.0.0.0" : "127.0.0.1"),
       DATA_DIR: `${data_dir}/${nodeId}`,
       CONFIG_PATH: configPath,
     },

--- a/docs-site/src/content/docs/configuration/metrics.md
+++ b/docs-site/src/content/docs/configuration/metrics.md
@@ -134,9 +134,11 @@ Port of the Valkey Admin server.
 
 ### `METRICS_BIND_HOST`
 
-Network interface the metrics HTTP server binds to. In a container you almost always want `0.0.0.0`; on a developer machine you might prefer `127.0.0.1`.
+Network interface the metrics HTTP server binds to. The metrics endpoints have no auth, so keep them on loopback unless the server must reach them from another host — which is the Kubernetes sidecar case.
 
-- **Default:** `0.0.0.0`
+- **Default:** `127.0.0.1`; `0.0.0.0` for the Kubernetes sidecar
+
+If you set a routable `METRICS_ADVERTISE_HOST`, set this to match.
 
 ### `METRICS_ADVERTISE_HOST`
 

--- a/docs-site/src/content/docs/configuration/metrics.md
+++ b/docs-site/src/content/docs/configuration/metrics.md
@@ -138,7 +138,7 @@ Network interface the metrics HTTP server binds to. The metrics endpoints have n
 
 - **Default:** `127.0.0.1`; `0.0.0.0` for the Kubernetes sidecar
 
-If you set a routable `METRICS_ADVERTISE_HOST`, set this to match.
+If you set a routable `METRICS_ADVERTISE_HOST`, set this to match it.
 
 ### `METRICS_ADVERTISE_HOST`
 

--- a/docs-site/src/content/docs/configuration/metrics.md
+++ b/docs-site/src/content/docs/configuration/metrics.md
@@ -138,8 +138,6 @@ Network interface the metrics HTTP server binds to. The metrics endpoints have n
 
 - **Default:** `127.0.0.1`; `0.0.0.0` for the Kubernetes sidecar
 
-If you set a routable `METRICS_ADVERTISE_HOST`, set this to match it.
-
 ### `METRICS_ADVERTISE_HOST`
 
 Host the metrics process advertises to the server in its registration payload — this is the host the orchestrator will actually dial back. Use it to bridge bind-vs-advertise differences in containers.


### PR DESCRIPTION
## Description

Metrics processes bind on `0.0.0.0` with no auth on any endpoint, so anyone on the LAN can hit `/monitor`, `/commandlog` and `POST /update-config` directly. #466 fixed this on the main server but not on the metrics children.

Include a summary of the change.

The server now spawns them with `METRICS_BIND_HOST=127.0.0.1`. It already reaches them over
loopback (they advertise `127.0.0.1` by default), so nothing changes functionally.

### Change Visualization

Include a screenshot/video of before and after the change.
