### PR TITLE
Cluster topology broadcast restriction

### DIFF
--- a/apps/server/src/__tests__/config.test.ts
+++ b/apps/server/src/__tests__/config.test.ts
@@ -7,7 +7,7 @@ import { describe, it, mock, beforeEach, afterEach } from "node:test"
 import assert from "node:assert"
 import { VALKEY } from "valkey-common"
 import { runConfigPushSession } from "../actions/config"
-import { ClusterRegistry } from "../metrics-orchestrator"
+import { ClusterNodeMap } from "../metrics-orchestrator"
 
 function createMockResponse(body: any, ok = true, status = 200) {
   return {
@@ -22,7 +22,7 @@ describe("config actions", () => {
   let messages: string[]
   let metricsServerMap: Map<string, any>
   let connectedNodesByCluster: Map<string, string[]>
-  let clusterNodesRegistry: ClusterRegistry
+  let clusterNodesRegistry: Map<string, ClusterNodeMap>
   let clients: Map<string, any>
   const originalFetch = globalThis.fetch
 
@@ -36,7 +36,7 @@ describe("config actions", () => {
     }
     metricsServerMap = new Map()
     connectedNodesByCluster = new Map()
-    clusterNodesRegistry = {}
+    clusterNodesRegistry = new Map()
     clients = new Map()
     // Fast backoff so retry tests run in milliseconds.
     process.env.CONFIG_RETRY_DELAYS_MS = "1,1,1"
@@ -61,12 +61,12 @@ describe("config actions", () => {
     ws: mockWs, metricsServerMap, connectedNodesByCluster, clients, connectionId: "", clusterNodesRegistry,
   } as any)
 
-  const twoNodeRegistry = (): ClusterRegistry => ({
-    "cluster-1": {
+  const twoNodeRegistry = (): Map<string, ClusterNodeMap> => new Map([
+    ["cluster-1", {
       "node-1": { host: "127.0.0.1", port: 7000, tls: false, verifyTlsCertificate: false },
       "node-2": { host: "127.0.0.1", port: 7001, tls: false, verifyTlsCertificate: false },
-    },
-  })
+    }],
+  ])
 
   // Parsed messages split into live status pushes vs aggregate replies.
   const parsed = () => messages.map((m: string) => JSON.parse(m))

--- a/apps/server/src/__tests__/connection.test.ts
+++ b/apps/server/src/__tests__/connection.test.ts
@@ -175,7 +175,7 @@ describe("connectToValkey", () => {
     _resetConnectInFlight()
   })
 
-  const ctx = () => ({ clients, connectedNodesByCluster, clusterNodesRegistry: {}, metricsServerMap })
+  const ctx = () => ({ clients, connectedNodesByCluster, clusterNodesRegistry: new Map(), metricsServerMap })
 
   it("should connect to standalone Valkey instance", async () => {
     const standalone = buildStandaloneMock()
@@ -903,7 +903,7 @@ describe("teardownConnection", () => {
     const metricsServerMap: MetricsServerMap = new Map()
 
     teardownConnection(
-      { clients, clusterNodesRegistry: {}, metricsServerMap },
+      { clients, clusterNodesRegistry: new Map(), metricsServerMap },
       "conn-1",
     )
 
@@ -919,7 +919,7 @@ describe("teardownConnection", () => {
     const metricsServerMap: MetricsServerMap = new Map()
 
     teardownConnection(
-      { clients, clusterNodesRegistry: {}, metricsServerMap },
+      { clients, clusterNodesRegistry: new Map(), metricsServerMap },
       "node-1",
     )
 
@@ -935,7 +935,7 @@ describe("teardownConnection", () => {
     clients.set("node-2", { client: sharedClient, clusterId: "c1" })
     const metricsServerMap: MetricsServerMap = new Map()
 
-    const ctx = { clients, clusterNodesRegistry: {}, metricsServerMap }
+    const ctx = { clients, clusterNodesRegistry: new Map(), metricsServerMap }
     teardownConnection(ctx, "node-1")
     teardownConnection(ctx, "node-2")
 
@@ -949,7 +949,7 @@ describe("teardownConnection", () => {
 
     assert.doesNotThrow(() => {
       teardownConnection(
-        { clients, clusterNodesRegistry: {}, metricsServerMap },
+        { clients, clusterNodesRegistry: new Map(), metricsServerMap },
         "unknown",
       )
     })

--- a/apps/server/src/__tests__/hotkeys-commandlogs.test.ts
+++ b/apps/server/src/__tests__/hotkeys-commandlogs.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert"
 import { VALKEY, COMMANDLOG_TYPE } from "valkey-common"
 import { hotKeysRequested } from "../actions/hotkeys"
 import { commandLogsRequested } from "../actions/commandLogs"
-import { ClusterRegistry } from "../metrics-orchestrator"
+import { ClusterNodeMap } from "../metrics-orchestrator"
 
 function createMockResponse(body: any, ok = true, status = 200) {
   return {
@@ -19,7 +19,7 @@ describe("hotKeysRequested reply shape", () => {
   let messages: string[]
   let metricsServerMap: Map<string, any>
   let connectedNodesByCluster: Map<string, string[]>
-  let clusterNodesRegistry: ClusterRegistry
+  let clusterNodesRegistry: Map<string, ClusterNodeMap>
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
@@ -27,7 +27,7 @@ describe("hotKeysRequested reply shape", () => {
     mockWs = { send: mock.fn((msg: string) => messages.push(msg)) }
     metricsServerMap = new Map()
     connectedNodesByCluster = new Map()
-    clusterNodesRegistry = {}
+    clusterNodesRegistry = new Map()
   })
 
   afterEach(() => {
@@ -88,12 +88,12 @@ describe("hotKeysRequested reply shape", () => {
   it("cluster hotKeysFulfilled carries { clusterId } and db-less nodeErrors[].nodeId", async () => {
     metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
     // node-2 has no metrics entry → surfaces as a nodeError with a db-less nodeId.
-    clusterNodesRegistry = {
-      "cluster-1": {
+    clusterNodesRegistry = new Map([
+      ["cluster-1", {
         "node-1": { host: "127.0.0.1", port: 7000, tls: false, verifyTlsCertificate: false },
         "node-2": { host: "127.0.0.1", port: 7001, tls: false, verifyTlsCertificate: false },
-      },
-    }
+      }],
+    ])
     mockFetch({ nodeId: "node-1", hotKeys: [], checkAt: 0, monitorRunning: true, lastCollectedAt: null })
 
     const action = {
@@ -120,7 +120,7 @@ describe("commandLogsRequested reply shape", () => {
   let messages: string[]
   let metricsServerMap: Map<string, any>
   let connectedNodesByCluster: Map<string, string[]>
-  let clusterNodesRegistry: ClusterRegistry
+  let clusterNodesRegistry: Map<string, ClusterNodeMap>
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
@@ -128,7 +128,7 @@ describe("commandLogsRequested reply shape", () => {
     mockWs = { send: mock.fn((msg: string) => messages.push(msg)) }
     metricsServerMap = new Map()
     connectedNodesByCluster = new Map()
-    clusterNodesRegistry = {}
+    clusterNodesRegistry = new Map()
   })
 
   afterEach(() => {
@@ -192,12 +192,12 @@ describe("commandLogsRequested reply shape", () => {
   it("cluster commandLogsFulfilled carries { clusterId } and db-less nodeErrors[].nodeId", async () => {
     metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
     // node-2 has no metrics entry → surfaces as a nodeError with a db-less nodeId.
-    clusterNodesRegistry = {
-      "cluster-1": {
+    clusterNodesRegistry = new Map([
+      ["cluster-1", {
         "node-1": { host: "127.0.0.1", port: 7000, tls: false, verifyTlsCertificate: false },
         "node-2": { host: "127.0.0.1", port: 7001, tls: false, verifyTlsCertificate: false },
-      },
-    }
+      }],
+    ])
     mockFetch({ nodeId: "node-1", rows: [], count: 0, checkAt: 0 })
 
     const action = {

--- a/apps/server/src/__tests__/metrics-orchestrator.test.ts
+++ b/apps/server/src/__tests__/metrics-orchestrator.test.ts
@@ -7,22 +7,23 @@ import {
   stopAllMetricsServers,
   reconcileClusterMetricsServers,
   clients,
+  clusterNodesRegistry,
   __test__,
   type ClusterNodeMap, 
   type MetricsServerMap 
 } from "../metrics-orchestrator"
 import type { ConnectionDetails } from "../actions/connection"
 
-const mockClusterNodesRegistry = {
-  "cluster-1": {
+const mockClusterNodesRegistry = new Map<string, ClusterNodeMap>([
+  ["cluster-1", {
     node1: {
       host: "127.0.0.1",
       port: 6379,
       tls: false,
       verifyTlsCertificate: false,
     },
-  },
-}
+  }],
+])
 
 describe("metrics-orchestrator", () => {
   describe("findDiff", () => {
@@ -240,24 +241,34 @@ describe("metrics-orchestrator", () => {
     })
     afterEach(() => {
       mock.restoreAll()
+      // The registry is a module global now, so a seeded cluster would leak
+      // into the next test.
+      clusterNodesRegistry.clear()
     })
 
     it("should early return if registry is empty", async () => {
-      const emptyRegistry = {}
-      await reconcileClusterMetricsServers(
-        emptyRegistry, metricsServerMap)
-      assert.strictEqual(Object.keys(emptyRegistry).length, 0)
+      const findDiff = mock.method(__test__, "findDiff", async () => ({ nodesToAdd: {}, nodesToRemove: [] }))
+      clusterNodesRegistry.clear()
+
+      await reconcileClusterMetricsServers(metricsServerMap)
+
+      // No clusters to reconcile, so the diff is never computed.
+      assert.strictEqual(findDiff.mock.callCount(), 0)
     })
 
     it("should early return if nothing changed", async () => {
-      // findDiff mock returns empty changes
-      mock.method(__test__, "findDiff", async () => ({ nodesToAdd: {}, nodesToRemove: [] }))
-      mockClusterNodesRegistry["cluster-1"] = {
+      const findDiff = mock.method(__test__, "findDiff", async () => ({ nodesToAdd: {}, nodesToRemove: [] }))
+      const updateMetricsServers = mock.method(__test__, "updateMetricsServers", async () => {})
+      clusterNodesRegistry.set("cluster-1", {
         node1: { host: "127.0.0.1", port: 6379, tls: false, verifyTlsCertificate: false },
-      }
-      await reconcileClusterMetricsServers(
-        mockClusterNodesRegistry,metricsServerMap)
-      // updateMetricsServers should not be called because nothing changed
+      })
+
+      await reconcileClusterMetricsServers(metricsServerMap)
+
+      // The cluster is inspected, but findDiff reports no changes, so no
+      // metrics servers are started or stopped.
+      assert.strictEqual(findDiff.mock.callCount(), 1)
+      assert.strictEqual(updateMetricsServers.mock.callCount(), 0)
     })
   })
 })

--- a/apps/server/src/__tests__/monitorAction.test.ts
+++ b/apps/server/src/__tests__/monitorAction.test.ts
@@ -5,7 +5,7 @@ import { VALKEY } from "valkey-common"
 import { monitorRequested } from "../actions/monitorAction"
 import { updateConfig } from "../actions/config"
 import { subscribe, _reset as resetNodeWatchers } from "../node-watchers"
-import { ClusterRegistry } from "../metrics-orchestrator"
+import { ClusterNodeMap } from "../metrics-orchestrator"
 
 function createMockResponse(body: any, ok = true, status = 200) {
   return {
@@ -20,7 +20,7 @@ describe("monitorAction", () => {
   let messages: string[]
   let metricsServerMap: Map<string, any>
   let connectedNodesByCluster: Map<string, string[]>
-  let clusterNodesRegistry: ClusterRegistry 
+  let clusterNodesRegistry: Map<string, ClusterNodeMap>
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
@@ -33,7 +33,7 @@ describe("monitorAction", () => {
     }
     metricsServerMap = new Map()
     connectedNodesByCluster = new Map()
-    clusterNodesRegistry = {}
+    clusterNodesRegistry = new Map()
     // Config pushes ride through the retry runner now; pin retries to 0 so
     // tests keep their exact single-attempt fetch counts.
     process.env.CONFIG_RETRY_MAX_RETRIES = "0"
@@ -216,8 +216,8 @@ describe("monitorAction", () => {
     it("should send requests to all cluster nodes", async () => {
       metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
       metricsServerMap.set("node-2", { metricsURI: "http://localhost:9002" })
-      clusterNodesRegistry = {
-        "cluster-1": {
+      clusterNodesRegistry = new Map([
+        ["cluster-1", {
           "node-1": {
             host: "127.0.0.1",
             port: 7000,
@@ -230,8 +230,8 @@ describe("monitorAction", () => {
             tls: false,
             verifyTlsCertificate: false,
           },
-        },
-      }
+        }],
+      ])
 
       const fetchCalls = mockFetch({ monitorRunning: true, checkAt: 55555 })
 
@@ -262,12 +262,12 @@ describe("monitorAction", () => {
     it("restricts the fan-out to targetNodeIds when provided (save-flow gating, Req 10.2)", async () => {
       metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
       metricsServerMap.set("node-2", { metricsURI: "http://localhost:9002" })
-      clusterNodesRegistry = {
-        "cluster-1": {
+      clusterNodesRegistry = new Map([
+        ["cluster-1", {
           "node-1": { host: "127.0.0.1", port: 7000, tls: false, verifyTlsCertificate: false },
           "node-2": { host: "127.0.0.1", port: 7001, tls: false, verifyTlsCertificate: false },
-        },
-      }
+        }],
+      ])
       const fetchCalls = mockFetch({ monitorRunning: true, checkAt: 55555 })
 
       const action = {
@@ -427,7 +427,7 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
   let messages: string[]
   let metricsServerMap: Map<string, any>
   let connectedNodesByCluster: Map<string, string[]>
-  let clusterNodesRegistry: ClusterRegistry
+  let clusterNodesRegistry: Map<string, ClusterNodeMap>
   const originalFetch = globalThis.fetch
 
   beforeEach(() => {
@@ -440,7 +440,7 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
     }
     metricsServerMap = new Map()
     connectedNodesByCluster = new Map()
-    clusterNodesRegistry = {}
+    clusterNodesRegistry = new Map()
     // Config pushes ride through the retry runner now; pin retries to 0 so
     // tests keep their exact single-attempt fetch counts.
     process.env.CONFIG_RETRY_MAX_RETRIES = "0"
@@ -588,8 +588,8 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
   it("should fan out across cluster nodes for both config and monitor", async () => {
     metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
     metricsServerMap.set("node-2", { metricsURI: "http://localhost:9002" })
-    clusterNodesRegistry = {
-      "cluster-1": {
+    clusterNodesRegistry = new Map([
+      ["cluster-1", {
         "node-1": {
           host: "127.0.0.1",
           port: 7000,
@@ -602,8 +602,8 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
           tls: false,
           verifyTlsCertificate: false,
         },
-      },
-    }
+      }],
+    ])
     const fetchCalls = mockFetchRouted({
       "/update-config": { body: { success: true, message: "", data: {} } },
       "/monitor": { body: { monitorRunning: true, checkAt: 55555 } },
@@ -638,12 +638,12 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
   it("aggregates cluster config to one failure reply when a node fails (first error)", async () => {
     metricsServerMap.set("node-1", { metricsURI: "http://localhost:9001" })
     metricsServerMap.set("node-2", { metricsURI: "http://localhost:9002" })
-    clusterNodesRegistry = {
-      "cluster-1": {
+    clusterNodesRegistry = new Map([
+      ["cluster-1", {
         "node-1": { host: "127.0.0.1", port: 7000, tls: false, verifyTlsCertificate: false },
         "node-2": { host: "127.0.0.1", port: 7001, tls: false, verifyTlsCertificate: false },
-      },
-    }
+      }],
+    ])
     // node-2 (9002) fails; node-1 succeeds.
     globalThis.fetch = (async (url: any) => {
       const urlStr = String(url)

--- a/apps/server/src/actions/bigkeys.ts
+++ b/apps/server/src/actions/bigkeys.ts
@@ -75,7 +75,7 @@ export const bigKeysRequested = withDeps<Deps, void>(
 
     const nodes =
       typeof clusterId === "string"
-        ? clusterNodesRegistry[clusterId]
+        ? clusterNodesRegistry.get(clusterId)
         : undefined
 
     const nodeIds = nodes ? Object.keys(nodes) : [toNodeId(connectionId)]

--- a/apps/server/src/actions/commandLogs.ts
+++ b/apps/server/src/actions/commandLogs.ts
@@ -103,7 +103,7 @@ export const commandLogsRequested = withDeps<Deps, void>(
     const commandLogType: CommandLogType = action.payload.commandLogType as CommandLogType
     const count = Number(action.payload.count) || Number(process.env.COMMAND_LOGS_COUNT) || 100
 
-    const nodes = typeof clusterId === "string" ? clusterNodesRegistry[clusterId] : undefined
+    const nodes = typeof clusterId === "string" ? clusterNodesRegistry.get(clusterId) : undefined
     const nodeIds = nodes ? Object.keys(nodes) : [toNodeId(connectionId)]
 
     const promises = nodeIds.map(async (nodeId: string) => {

--- a/apps/server/src/actions/config.ts
+++ b/apps/server/src/actions/config.ts
@@ -102,7 +102,7 @@ export const runConfigPushSession = withDeps<Deps, RetryRunResult>(
     const targetId = "clusterId" in replyId ? replyId.clusterId : replyId.nodeId
 
     const targetNodeIds =
-      typeof clusterId === "string" ? Object.keys(clusterNodesRegistry[clusterId] ?? {}) : [targetId]
+      typeof clusterId === "string" ? Object.keys(clusterNodesRegistry.get(clusterId) ?? {}) : [targetId]
     const targets = targetNodeIds.map((nodeId) => ({
       nodeId,
       metricsURI: metricsServerMap.get(nodeId)?.metricsURI,

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -58,7 +58,7 @@ export const hotKeysRequested = withDeps<Deps, void>(
 
     const nodes =
       typeof clusterId === "string" 
-        ? clusterNodesRegistry[clusterId] 
+        ? clusterNodesRegistry.get(clusterId)
         : undefined
 
     const nodeIds = nodes ? Object.keys(nodes) : [toNodeId(connectionId)]

--- a/apps/server/src/actions/monitorAction.ts
+++ b/apps/server/src/actions/monitorAction.ts
@@ -51,7 +51,7 @@ export const monitorRequested = withDeps<Deps, void>(
     const restrictToNodeIds = action.payload.targetNodeIds as string[] | undefined
 
     if (typeof clusterId === "string") {
-      const allNodeIds = Object.keys(clusterNodesRegistry[clusterId] ?? {})
+      const allNodeIds = Object.keys(clusterNodesRegistry.get(clusterId) ?? {})
       const targetNodeIds = restrictToNodeIds
         ? allNodeIds.filter((id) => restrictToNodeIds.includes(id))
         : allNodeIds

--- a/apps/server/src/actions/utils.ts
+++ b/apps/server/src/actions/utils.ts
@@ -1,6 +1,6 @@
 import { type GlideClient, type GlideClusterClient } from "@valkey/valkey-glide"
 import { FETCH_TIMEOUT_MS } from "valkey-common"
-import { ClusterRegistry, MetricsServerMap } from "../metrics-orchestrator"
+import { ClusterNodeMap, MetricsServerMap } from "../metrics-orchestrator"
 import type WebSocket from "ws"
 
 export type Deps = {
@@ -9,7 +9,7 @@ export type Deps = {
   connectionId: string,
   metricsServerMap: MetricsServerMap,
   connectedNodesByCluster: Map<string, string[]>,
-  clusterNodesRegistry: ClusterRegistry,
+  clusterNodesRegistry: Map<string, ClusterNodeMap>,
   sessionId?: string,
 }
 

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -15,7 +15,6 @@ import {
 import { checkJsonModuleAvailability } from "./check-json-module"
 import { type ConnectionDetails } from "./actions/connection"
 import { 
-  ClusterRegistry, 
   isWebMode, 
   MetricsServerMap, 
   startMetricsServer, 
@@ -30,7 +29,7 @@ import { createClusterValkeyClient, createStandaloneValkeyClient } from "./valke
 export type ConnectionContext = {
   clients: Map<string, { client: GlideClient | GlideClusterClient; clusterId?: string }>
   connectedNodesByCluster: Map<string, string[]>
-  clusterNodesRegistry: ClusterRegistry
+  clusterNodesRegistry: Map<string, ClusterNodeMap>
   metricsServerMap: MetricsServerMap
 }
 
@@ -221,7 +220,7 @@ async function connectToValkeyLocked(
         const clusterClient = existingConnection.client as GlideClusterClient
         const { clusterId } = existingConnection
         const discoveredClusterNodes =
-          clusterNodesRegistry[clusterId] ??
+          clusterNodesRegistry.get(clusterId) ??
           (await discoverCluster(clusterClient, payload)).discoveredClusterNodes
         return commitClusterConnection(ctx, ws, {
           clusterClient,
@@ -345,10 +344,10 @@ async function connectToValkeyLocked(
 
       try {
         clusterCredentials.set(clusterId, payload.connectionDetails.password)
-        clusterNodesRegistry[clusterId] = discoveredClusterNodes
+        clusterNodesRegistry.set(clusterId, discoveredClusterNodes)
 
         if (isWebMode) {
-          reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap)
+          reconcileClusterMetricsServers(metricsServerMap)
         }
 
         await commitClusterConnection(ctx, ws, {
@@ -561,7 +560,7 @@ async function commitClusterConnection(
     getDatabasesCount(clusterClient, ["cluster-databases", "databases"]),
   ])
 
-  clusterNodesRegistry[clusterId] = discoveredClusterNodes
+  clusterNodesRegistry.set(clusterId, discoveredClusterNodes)
   clients.set(connectionId, { client: clusterClient, clusterId })
 
   const nodes = connectedNodesByCluster.get(clusterId)
@@ -752,12 +751,12 @@ export function teardownConnection(
 
     if (connection.clusterId) {
       // Polling ends with the client; drop all CPU baselines so a reconnect starts fresh
-      Object.keys(clusterNodesRegistry[connection.clusterId] ?? {}).forEach(
+      Object.keys(clusterNodesRegistry.get(connection.clusterId) ?? {}).forEach(
         (nodeId) => clearCpuSamples(nodeId),
       )
 
       if (!isWebMode) {
-        delete clusterNodesRegistry[connection.clusterId]
+        clusterNodesRegistry.delete(connection.clusterId)
         clusterCredentials.delete(connection.clusterId)
       }
     }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -118,13 +118,9 @@ const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
 async function refreshAllClusterRegistries() {
   await Promise.all(
-    Object.entries(clusterNodesRegistry).map(async ([clusterId]) => {
+    [...clusterNodesRegistry].map(async ([clusterId, updatedNodes]) => {
       const clientEntry = [...clients.values()].find((e) => e.clusterId === clusterId)
       if (!clientEntry) return
-
-      const updatedNodes = clusterNodesRegistry[clusterId]
-      // Am I being too defensive here?
-      if (!updatedNodes) return
 
       wss.clients.forEach((ws) => {
         ws.send(JSON.stringify({
@@ -140,10 +136,11 @@ async function refreshAllClusterRegistriesLoop() {
   while (true) {
     try {
       await refreshAllClusterRegistries()
-      const refreshInterval = process.env.TOPOLOGY_REFRESH_INTERVAL
-      await delay( refreshInterval ? Number(refreshInterval) : 30000)
     } catch (err) {
       console.warn("Unable to refresh cluster topologies. ", err)
+    } finally {
+      const configured = Number(process.env.TOPOLOGY_REFRESH_INTERVAL)
+      await delay(Number.isFinite(configured) && configured > 0 ? configured : 30000)
     }
   }
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -28,7 +28,7 @@ import { monitorRequested } from "./actions/monitorAction"
 import { unsubscribeAll, getWatcherCount } from "./node-watchers"
 import { teardownConnection } from "./connection"
 import { isElectron } from "./metrics-orchestrator"
-import { Handler, ReduxAction, unknownHandler, type WsActionMessage } from "./actions/utils"
+import { Handler, ReduxAction, safeSend, unknownHandler, type WsActionMessage } from "./actions/utils"
 import {
   createMetricsOrchestratorRouter,
   startPreconfiguredMetricsServers,
@@ -116,26 +116,36 @@ const wss = new WebSocketServer({ noServer: true })
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
-async function refreshAllClusterRegistries() {
-  await Promise.all(
-    [...clusterNodesRegistry].map(async ([clusterId, updatedNodes]) => {
-      const clientEntry = [...clients.values()].find((e) => e.clusterId === clusterId)
-      if (!clientEntry) return
+function refreshAllClusterRegistries() {
+  const connectionIdsByCluster = new Map<string, string[]>()
+  for (const [connectionId, entry] of clients) {
+    if (!entry.clusterId) continue
+    const ids = connectionIdsByCluster.get(entry.clusterId) ?? []
+    ids.push(connectionId)
+    connectionIdsByCluster.set(entry.clusterId, ids)
+  }
 
-      wss.clients.forEach((ws) => {
-        ws.send(JSON.stringify({
-          type: VALKEY.CLUSTER.updateClusterInfo,
-          payload: { clusterId, clusterNodes: updatedNodes },
-        }))
-      })
-    }),
-  )
+  for (const [clusterId, clusterNodes] of clusterNodesRegistry) {
+    const connectionIds = connectionIdsByCluster.get(clusterId)
+    if (!connectionIds) continue
+  
+    const message = JSON.stringify({
+      type: VALKEY.CLUSTER.updateClusterInfo,
+      payload: { clusterId, clusterNodes },
+    })
+  
+    for (const ws of wss.clients) {
+      const { sessionId } = ws as AliveWebSocket
+      if (!connectionIds.some((id) => isConnectionAuthorized(sessionId, id))) continue
+      safeSend(ws, message)
+    }
+  }
 }
 
 async function refreshAllClusterRegistriesLoop() {
   while (true) {
     try {
-      await refreshAllClusterRegistries()
+      refreshAllClusterRegistries()
     } catch (err) {
       console.warn("Unable to refresh cluster topologies. ", err)
     } finally {

--- a/apps/server/src/metrics-orchestrator.ts
+++ b/apps/server/src/metrics-orchestrator.ts
@@ -46,13 +46,9 @@ type NodeInfo = {
 
 export type ClusterNodeMap = Record<string, NodeInfo>;
 
-export interface ClusterRegistry {
-  [clusterId: string]: ClusterNodeMap
-}
-
 export const clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId?: string}> = new Map()
 
-export const clusterNodesRegistry: ClusterRegistry = {}
+export const clusterNodesRegistry: Map<string, ClusterNodeMap> = new Map()
 
 export const clusterCredentials: Map<string, string | undefined> = new Map()
 
@@ -187,7 +183,7 @@ async function getClusterTopology(client: GlideClusterClient | GlideClient | nul
 export async function updateClusterNodeRegistry(client: GlideClusterClient | GlideClient | null, connectionDetails = initialConnectionDetails) {
   try {
     const { discoveredClusterNodes, clusterId } = await getClusterTopology(client, connectionDetails)
-    if (clusterId && discoveredClusterNodes) clusterNodesRegistry[clusterId] = discoveredClusterNodes 
+    if (clusterId && discoveredClusterNodes) clusterNodesRegistry.set(clusterId, discoveredClusterNodes)
   }
   catch (err) {
     if (err instanceof ConnectionError) {
@@ -346,16 +342,15 @@ async function stopMetricsServer(nodeToStop: string) {
 }
 
 export async function reconcileClusterMetricsServers(
-  clusterNodesRegistry: ClusterRegistry, 
   metricsServerMap: MetricsServerMap, 
 ) {
-  const clusterIds = Object.keys(clusterNodesRegistry)
+  const clusterIds = [...clusterNodesRegistry.keys()]
   if (clusterIds.length === 0) return
 
   await Promise.all(
     clusterIds.map(async (clusterId) => {
       try {
-        const { nodesToAdd, nodesToRemove } = await internals.findDiff(metricsServerMap, clusterNodesRegistry[clusterId])
+        const { nodesToAdd, nodesToRemove } = await internals.findDiff(metricsServerMap, clusterNodesRegistry.get(clusterId) ?? {})
         // Early return if nothing has changed
         if (Object.keys(nodesToAdd).length === 0 && nodesToRemove.length === 0) {
           console.debug("Cluster nodes and metrics servers are in sync")
@@ -380,7 +375,7 @@ export async function startPreconfiguredMetricsServers() {
     if (isWebMode) {
       const { discoveredClusterNodes, clusterId } = await internals.getClusterTopology(client, initialConnectionDetails)
       if (clusterId && discoveredClusterNodes) {
-        clusterNodesRegistry[clusterId] = discoveredClusterNodes
+        clusterNodesRegistry.set(clusterId, discoveredClusterNodes)
         if (!clusterCredentials.has(clusterId)) clusterCredentials.set(clusterId, initialConnectionDetails.password)
       }
       runReconcileLoop()
@@ -394,7 +389,7 @@ export async function runReconcileLoop() {
   const delay = (ms: number) => new Promise((res) => setTimeout(res, ms))
   while (true) {
     try {
-      await reconcileClusterMetricsServers(clusterNodesRegistry, metricsServerMap)
+      await reconcileClusterMetricsServers(metricsServerMap)
       await delay(10000)
     } catch (err) {
       console.error("Failed to reconcile metrics servers", err)


### PR DESCRIPTION
## Description

Cluster topology was being broadcast to all websocket clients. While it was being dropped in the frontend, this presents a security risk.

This fix restricts broadcast to authorized connectionIds using the ws.

In addition, I standardized the clusterNodesRegistry to match other registries. Changing it from an object to a map.