### PR TITLE
Scope Valkey client reuse to the owning session

### DIFF
--- a/apps/server/src/__tests__/connection.test.ts
+++ b/apps/server/src/__tests__/connection.test.ts
@@ -15,6 +15,8 @@ import { checkJsonModuleAvailability } from "../check-json-module"
 import { ConnectionDetails } from "../actions/connection"
 import { type MetricsServerMap } from "../metrics-orchestrator"
 import { _reset as resetNodeWatchers } from "../node-watchers"
+import { ensureSession, authorizeConnection, _resetSessions } from "../session"
+import type { IncomingMessage } from "http"
 
 const DEFAULT_PAYLOAD = {
   connectionDetails: {
@@ -28,6 +30,7 @@ const DEFAULT_PAYLOAD = {
     db: 0,
   } as ConnectionDetails,
   connectionId: "",
+  sessionId: "test-session",
 }
 
 const SLOTS_RESPONSE = [
@@ -144,6 +147,7 @@ describe("connectToValkey", () => {
   let clients: Map<string, any>
   let connectedNodesByCluster: Map<string, string[]>
   let metricsServerMap: MetricsServerMap
+  let testSessionId: string
   beforeEach(() => {
     messages = []
     mockWs = {
@@ -152,6 +156,11 @@ describe("connectToValkey", () => {
     clients = new Map()
     connectedNodesByCluster = new Map()
     metricsServerMap = new Map()
+    // Seed a real session and point the default payload at it so that reuse tests,
+    // which now require the session to own the reused connection, can authorize it.
+    _resetSessions()
+    testSessionId = ensureSession({ headers: {}, socket: {} } as unknown as IncomingMessage).sessionId
+    DEFAULT_PAYLOAD.sessionId = testSessionId
     // metricsServerMap is keyed by metrics-node-id; the empty Connection_Identifier
     // strips to the empty string, which matches the empty connectionId used by
     // the default payload in these tests.
@@ -254,6 +263,10 @@ describe("connectToValkey", () => {
 
     await withMockedClients(standalone, null, async () => {
       const payload = { ...DEFAULT_PAYLOAD, connectionId: "conn-shared" }
+      // The session owns the connection it is (re)connecting to; the handler authorizes
+      // it on connect. Simulate that here so the concurrent duplicate reuses rather than
+      // creating a second client.
+      authorizeConnection(testSessionId, "conn-shared")
       const [a, b] = await Promise.all([
         connectToValkey(ctx(), mockWs, payload),
         connectToValkey(ctx(), mockWs, payload),
@@ -279,6 +292,10 @@ describe("connectToValkey", () => {
       const first = await connectToValkey(ctx(), mockWs, payload)
       assert.strictEqual(first, cluster)
       assert.strictEqual((GlideClusterClient.createClient as any).mock.calls.length, 1)
+
+      // The handler authorizes the connection after a successful connect; simulate that
+      // here (this test bypasses the handler) so the session owns the connection it reuses.
+      authorizeConnection(testSessionId, "conn-Z")
 
       messages.length = 0
 
@@ -355,6 +372,7 @@ describe("connectToValkey", () => {
   it("should use correct client configuration", async () => {
     const standalone = buildStandaloneMock()
     const altPayload = {
+      sessionId: "test-session",
       connectionDetails: {
         host: "192.168.1.1",
         port: "7000",
@@ -456,6 +474,7 @@ describe("connectToValkey", () => {
 
       await withMockedClients(newStandalone, newCluster, async () => {
         await connectToValkey(ctx(), mockWs, {
+          sessionId: "test-session",
           connectionId,
           connectionDetails: { ...DEFAULT_PAYLOAD.connectionDetails, ...tc.overrides },
           isRetry: true,
@@ -478,6 +497,7 @@ describe("connectToValkey", () => {
     await withMockedClients(buildStandaloneMock({ databases: undefined }), null, async () => {
       const connectionId = buildConnectionId("127.0.0.1", "6379", 15)
       await connectToValkey(ctx(), mockWs, {
+        sessionId: "test-session",
         connectionId,
         connectionDetails: { ...DEFAULT_PAYLOAD.connectionDetails, db: 15 },
       })
@@ -505,6 +525,7 @@ describe("connectToValkey", () => {
     await withMockedClients(buildStandaloneMock({ databases: undefined }), null, async () => {
       const connectionId = buildConnectionId("127.0.0.1", "6379", 16)
       await connectToValkey(ctx(), mockWs, {
+        sessionId: "test-session",
         connectionId,
         connectionDetails: { ...DEFAULT_PAYLOAD.connectionDetails, db: 16 },
       })
@@ -532,6 +553,7 @@ describe("connectToValkey", () => {
     await withMockedClients(buildStandaloneMock({ databases: "32" }), null, async () => {
       const connectionId = buildConnectionId("127.0.0.1", "6379", 31)
       await connectToValkey(ctx(), mockWs, {
+        sessionId: "test-session",
         connectionId,
         connectionDetails: { ...DEFAULT_PAYLOAD.connectionDetails, db: 31 },
       })
@@ -570,6 +592,7 @@ describe("connectToValkey", () => {
     await withMockedClients(buildStandaloneMock({ configGetError: true }), null, async () => {
       const connectionId = buildConnectionId("127.0.0.1", "6379", 20)
       await connectToValkey(ctx(), mockWs, {
+        sessionId: "test-session",
         connectionId,
         connectionDetails: { ...DEFAULT_PAYLOAD.connectionDetails, db: 20 },
       })
@@ -607,6 +630,7 @@ describe("connectToValkey", () => {
     await withMockedClients(standaloneFactory, null, async () => {
       const connectionId = buildConnectionId("127.0.0.1", "6379", 5)
       await connectToValkey(ctx(), mockWs, {
+        sessionId: "test-session",
         connectionId,
         connectionDetails: { ...DEFAULT_PAYLOAD.connectionDetails, db: 5 },
       })
@@ -635,6 +659,7 @@ describe("connectToValkey", () => {
     await withMockedClients(standalone, cluster, async () => {
       const connectionId = buildConnectionId("127.0.0.1", "6379", 8)
       await connectToValkey(ctx(), mockWs, {
+        sessionId: "test-session",
         connectionId,
         connectionDetails: { ...DEFAULT_PAYLOAD.connectionDetails, db: 8 },
       })
@@ -667,6 +692,7 @@ describe("connectToValkey", () => {
     await withMockedClients(standalone, cluster, async () => {
       const connectionId = buildConnectionId("127.0.0.1", "6379", 2)
       await connectToValkey(ctx(), mockWs, {
+        sessionId: "test-session",
         connectionId,
         connectionDetails: { ...DEFAULT_PAYLOAD.connectionDetails, db: 2 },
       })
@@ -726,6 +752,7 @@ describe("connectToValkey", () => {
       await withMockedClients(standalone, cluster, async () => {
         const connectionId = buildConnectionId("127.0.0.1", "6379", 1)
         await connectToValkey(ctx(), mockWs, {
+          sessionId: "test-session",
           connectionId,
           connectionDetails: { ...DEFAULT_PAYLOAD.connectionDetails, db: 1 },
         })
@@ -802,8 +829,11 @@ describe("resolveHostnameOrIpAddress", () => {
 })
 
 describe("getExistingConnection", () => {
+  let unitSessionId: string
   beforeEach(() => {
     mock.restoreAll()
+    _resetSessions()
+    unitSessionId = ensureSession({ headers: {}, socket: {} } as unknown as IncomingMessage).sessionId
   })
 
   it("returns the existing connection when host:port resolves to one already in clients", async () => {
@@ -814,9 +844,12 @@ describe("getExistingConnection", () => {
     const existingClient = {} as any
     const clients = new Map()
     clients.set(buildConnectionId("10.0.0.1", "6379", 0), { client: existingClient })
+    // Session must own the matched id for reuse to be returned.
+    authorizeConnection(unitSessionId, buildConnectionId("10.0.0.1", "6379", 0))
 
     const result = await getExistingConnection(
       {
+        sessionId: unitSessionId,
         connectionId: "abc123",
         connectionDetails: {
           host: "my-host", port: "6379", tls: false, verifyTlsCertificate: false, endpointType: "node",
@@ -838,6 +871,7 @@ describe("getExistingConnection", () => {
 
     const result = await getExistingConnection(
       {
+        sessionId: unitSessionId,
         connectionId: "abc123",
         connectionDetails: {
           host: "my-host", port: "6379", tls: false, verifyTlsCertificate: false, endpointType: "node",
@@ -859,6 +893,7 @@ describe("getExistingConnection", () => {
 
     const result = await getExistingConnection(
       {
+        sessionId: unitSessionId,
         connectionId: "abc123",
         isRetry: true,
         connectionDetails: {
@@ -879,9 +914,12 @@ describe("getExistingConnection", () => {
     const directClient = {} as any
     const clients = new Map()
     clients.set("abc123", { client: directClient })
+    // Session must own the matched id for reuse to be returned.
+    authorizeConnection(unitSessionId, "abc123")
 
     const result = await getExistingConnection(
       {
+        sessionId: unitSessionId,
         connectionId: "abc123",
         connectionDetails: {
           host: "my-host", port: "6379", tls: false, verifyTlsCertificate: false, endpointType: "node",
@@ -892,6 +930,35 @@ describe("getExistingConnection", () => {
 
     assert.ok(result)
     assert.strictEqual(result.client, directClient)
+  })
+
+  it("does NOT return another session's client when this session is not authorized", async () => {
+    // Credential-blind reuse regression: a different session must not inherit a client
+    // it never authenticated. The match exists but this session does not own it.
+    mock.method(dns, "lookup", async () => [
+      { address: "10.0.0.1", family: 4 },
+    ])
+
+    const victimClient = {} as any
+    const clients = new Map()
+    const matchedId = buildConnectionId("10.0.0.1", "6379", 0)
+    clients.set(matchedId, { client: victimClient })
+    // Authorize the id for a DIFFERENT session (the victim), not ours.
+    const victimSession = ensureSession({ headers: {}, socket: {} } as unknown as IncomingMessage).sessionId
+    authorizeConnection(victimSession, matchedId)
+
+    const result = await getExistingConnection(
+      {
+        sessionId: unitSessionId, // our session — never authorized for matchedId
+        connectionId: "abc123",
+        connectionDetails: {
+          host: "my-host", port: "6379", tls: false, verifyTlsCertificate: false, endpointType: "node",
+        } as any,
+      },
+      clients,
+    )
+
+    assert.strictEqual(result, undefined, "must not hand back a client this session does not own")
   })
 })
 

--- a/apps/server/src/__tests__/utils.test.ts
+++ b/apps/server/src/__tests__/utils.test.ts
@@ -1,7 +1,50 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it } from "node:test"
+import { describe, it, beforeEach } from "node:test"
 import assert from "node:assert"
-import { parseInfo, parseResponse, parseClusterInfo } from "../utils"
+import { GlideClusterClient } from "@valkey/valkey-glide"
+import { parseInfo, parseResponse, parseClusterInfo, getExistingClusterClient } from "../utils"
+import { ensureSession, authorizeConnection, _resetSessions } from "../session"
+import type { IncomingMessage } from "http"
+
+describe("getExistingClusterClient (session-scoped reuse)", () => {
+  let sessionId: string
+  const makeClusterEntry = () => ({
+    // Satisfies isClusterClientEntry's `instanceof GlideClusterClient` check without a real client.
+    client: Object.create(GlideClusterClient.prototype) as GlideClusterClient,
+    clusterId: "cluster-1",
+  })
+
+  beforeEach(() => {
+    _resetSessions()
+    sessionId = ensureSession({ headers: {}, socket: {} } as unknown as IncomingMessage).sessionId
+  })
+
+  it("reuses the shared cluster client when the session owns the matched sibling node", async () => {
+    const entry = makeClusterEntry()
+    const clients = new Map([["node-A", entry]])
+    // Session connected to node-A earlier -> owns it.
+    authorizeConnection(sessionId, "node-A")
+
+    // Connecting to node-B of the same cluster: discovery surfaces node-A as an existing entry.
+    const discovered = { "node-A": {} as never, "node-B": {} as never }
+    const result = await getExistingClusterClient(discovered, clients, sessionId)
+
+    assert.strictEqual(result?.client, entry.client, "should reuse the owned cluster's client for the new node")
+  })
+
+  it("does NOT reuse when the session does not own the matched node", async () => {
+    const entry = makeClusterEntry()
+    const clients = new Map([["node-A", entry]])
+    // node-A belongs to a DIFFERENT session.
+    const otherSession = ensureSession({ headers: {}, socket: {} } as unknown as IncomingMessage).sessionId
+    authorizeConnection(otherSession, "node-A")
+
+    const discovered = { "node-A": {} as never }
+    const result = await getExistingClusterClient(discovered, clients, sessionId)
+
+    assert.strictEqual(result, undefined, "must not inherit another session's cluster client")
+  })
+})
 
 describe("parseInfo", () => {
   it("should parse INFO response string into key-value pairs", () => {

--- a/apps/server/src/actions/connection.ts
+++ b/apps/server/src/actions/connection.ts
@@ -38,6 +38,18 @@ export const connectPending = withDeps<Deps, void>(
     const payload = action.payload as ConnectPayload
     const { connectionId } = payload
 
+    // ws.sessionId is assigned for every upgrade (ensureSession), so this is a defensive
+    // invariant, not the expiry path (expiry is handled by isConnectionAuthorized returning
+    // false because the session record is gone). Fail closed rather than connect without a
+    // session to scope client reuse to.
+    if (!sessionId) {
+      ws.send(JSON.stringify({
+        type: VALKEY.CONNECTION.connectRejected,
+        payload: { connectionId, errorMessage: "Unable to establish a session. Please reload and try again.", requiresAuth: true },
+      }))
+      return
+    }
+
     // if connection is being resumed, check if the session is still valid and if the connection exists
     if (payload.isResume && (!isConnectionAuthorized(sessionId, connectionId) || !clients.has(connectionId))) {
       ws.send(JSON.stringify({
@@ -50,7 +62,7 @@ export const connectPending = withDeps<Deps, void>(
     const client = await connectToValkey(
       { clients, connectedNodesByCluster, clusterNodesRegistry, metricsServerMap },
       ws,
-      payload,
+      { ...payload, sessionId },
     )
 
     if (client) {

--- a/apps/server/src/actions/connection.ts
+++ b/apps/server/src/actions/connection.ts
@@ -59,6 +59,19 @@ export const connectPending = withDeps<Deps, void>(
       return
     }
 
+    // A retry reconnects an existing connection and (for clusters) closes + repoints the shared
+    // client, so require ownership — same rule as resume. The frontend only retries connections it
+    // previously established, so this never rejects a legitimate retry; it prevents one session's
+    // retry from closing or repointing a connection another session owns (e.g. a same-endpoint
+    // collision on a shared instance).
+    if (payload.isRetry && !isConnectionAuthorized(sessionId, connectionId)) {
+      ws.send(JSON.stringify({
+        type: VALKEY.CONNECTION.connectRejected,
+        payload: { connectionId, errorMessage: "Session expired. Please sign in again.", requiresAuth: true },
+      }))
+      return
+    }
+
     const client = await connectToValkey(
       { clients, connectedNodesByCluster, clusterNodesRegistry, metricsServerMap },
       ws,

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -690,11 +690,8 @@ export async function getExistingConnection(
   // could inherit another session's authenticated client by supplying a matching
   // endpoint with the wrong/blank credentials (credential-blind reuse). The matched id
   // is the exact node being (re)connected to; owning it is required to reuse its client.
-  const isMatchAuthorized = (matchedId: string): boolean =>
-    isConnectionAuthorized(sessionId, matchedId)
-
   if (clients.has(connectionId)) {
-    return isMatchAuthorized(connectionId) ? clients.get(connectionId) : undefined
+    return isConnectionAuthorized(sessionId, connectionId) ? clients.get(connectionId) : undefined
   }
 
   const db = connectionDetails.db
@@ -703,7 +700,7 @@ export async function getExistingConnection(
     .find((key) => clients.has(key))
 
   if (!existingConnectionId) return undefined
-  return isMatchAuthorized(existingConnectionId) ? clients.get(existingConnectionId) : undefined
+  return isConnectionAuthorized(sessionId, existingConnectionId) ? clients.get(existingConnectionId) : undefined
 }
 
 export async function closeMetricsServer(

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -26,6 +26,7 @@ import {
 import { subscribe } from "./node-watchers"
 import { clearCpuSamples } from "./node-utilization"
 import { createClusterValkeyClient, createStandaloneValkeyClient } from "./valkey-client"
+import { isConnectionAuthorized } from "./session"
 
 export type ConnectionContext = {
   clients: Map<string, { client: GlideClient | GlideClusterClient; clusterId?: string }>
@@ -138,6 +139,7 @@ export async function connectToValkey(
     connectionDetails: ConnectionDetails
     connectionId: string
     isRetry?: boolean
+    sessionId: string
   },
 ) {
   const { connectionId } = payload
@@ -163,6 +165,7 @@ async function connectToValkeyLocked(
     connectionDetails: ConnectionDetails
     connectionId: string
     isRetry?: boolean
+    sessionId: string
   },
 ) {
   const { clients, clusterNodesRegistry, metricsServerMap } = ctx
@@ -312,7 +315,7 @@ async function connectToValkeyLocked(
       const { discoveredClusterNodes, clusterId } = await discoverCluster(standaloneClient, payload)
       standaloneClient.close()
 
-      const existingClusterConnection = await getExistingClusterClient(discoveredClusterNodes, clients)
+      const existingClusterConnection = await getExistingClusterClient(discoveredClusterNodes, clients, payload.sessionId)
       let clusterClient: GlideClusterClient
       if (existingClusterConnection && !payload.isRetry) {
         clusterClient = existingClusterConnection.client
@@ -668,29 +671,39 @@ function sendClusterConnectFulfilled(ws: WebSocket, payload: ClusterConnectFulfi
 }
 
 export async function getExistingConnection(
-  payload:{connectionId: string, connectionDetails: ConnectionDetails, isRetry?: boolean}, 
+  payload:{connectionId: string, connectionDetails: ConnectionDetails, isRetry?: boolean, sessionId: string},
   clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId?: string}>,
 ) : Promise<{ client: GlideClient | GlideClusterClient; clusterId?: string | undefined; } | undefined>
 {
-  const { connectionId, connectionDetails, isRetry } = payload
+  const { connectionId, connectionDetails, isRetry, sessionId } = payload
   // If the frontend is retrying a broken connection, it's not a duplicate
   if (isRetry) {
     return undefined
   }
 
   const resolvedAddresses = (await resolveHostnameOrIpAddress(connectionDetails.host)).addresses
-  // Prevent duplicate connections: 
+  // Prevent duplicate connections:
   // 1) True if any resolved host:port:db is already connected
   // 2) Or if this connectionId already exists as a standalone connection
 
-  if (clients.has(connectionId)) return clients.get(connectionId)
+  // Only reuse a cached client this session is authorized for. Otherwise a session
+  // could inherit another session's authenticated client by supplying a matching
+  // endpoint with the wrong/blank credentials (credential-blind reuse). The matched id
+  // is the exact node being (re)connected to; owning it is required to reuse its client.
+  const ownsMatch = (matchedId: string): boolean =>
+    isConnectionAuthorized(sessionId, matchedId)
+
+  if (clients.has(connectionId)) {
+    return ownsMatch(connectionId) ? clients.get(connectionId) : undefined
+  }
 
   const db = connectionDetails.db
   const existingConnectionId = resolvedAddresses
     .map((address) => buildConnectionId(address, connectionDetails.port, db))
     .find((key) => clients.has(key))
 
-  return existingConnectionId ? clients.get(existingConnectionId) : undefined
+  if (!existingConnectionId) return undefined
+  return ownsMatch(existingConnectionId) ? clients.get(existingConnectionId) : undefined
 }
 
 export async function closeMetricsServer(

--- a/apps/server/src/connection.ts
+++ b/apps/server/src/connection.ts
@@ -690,11 +690,11 @@ export async function getExistingConnection(
   // could inherit another session's authenticated client by supplying a matching
   // endpoint with the wrong/blank credentials (credential-blind reuse). The matched id
   // is the exact node being (re)connected to; owning it is required to reuse its client.
-  const ownsMatch = (matchedId: string): boolean =>
+  const isMatchAuthorized = (matchedId: string): boolean =>
     isConnectionAuthorized(sessionId, matchedId)
 
   if (clients.has(connectionId)) {
-    return ownsMatch(connectionId) ? clients.get(connectionId) : undefined
+    return isMatchAuthorized(connectionId) ? clients.get(connectionId) : undefined
   }
 
   const db = connectionDetails.db
@@ -703,7 +703,7 @@ export async function getExistingConnection(
     .find((key) => clients.has(key))
 
   if (!existingConnectionId) return undefined
-  return ownsMatch(existingConnectionId) ? clients.get(existingConnectionId) : undefined
+  return isMatchAuthorized(existingConnectionId) ? clients.get(existingConnectionId) : undefined
 }
 
 export async function closeMetricsServer(

--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -9,6 +9,7 @@ import * as R from "ramda"
 import { lookup, reverse } from "node:dns/promises"
 import { KEY_EVICTION_POLICY, KeyEvictionPolicy, sanitizeUrl } from "valkey-common"
 import { ClusterNodeMap } from "./metrics-orchestrator"
+import { isConnectionAuthorized } from "./session"
 export const dns = {
   lookup,
   reverse,
@@ -157,11 +158,19 @@ function isClusterClientEntry(
 export async function getExistingClusterClient(
   discoveredClusterNodes: ClusterNodeMap, 
   clients: Map<string, {client: GlideClient | GlideClusterClient, clusterId?: string}>,
+  sessionId: string,
 ) {
   // Check if we've already connected to this cluster before 
   const existingKey = Object.keys(discoveredClusterNodes).find(
     (key) => isClusterClientEntry(clients.get(key)),
   )
+
+  // Only reuse the shared cluster client if the calling session owns the matched
+  // sibling node (e.g. the node it connected to earlier). Otherwise a different
+  // session could inherit this cluster's authenticated client without authenticating.
+  if (existingKey && !isConnectionAuthorized(sessionId, existingKey)) {
+    return undefined
+  }
 
   const existingConnection = existingKey
     ? clients.get(existingKey) as { client: GlideClusterClient; clusterId?: string }


### PR DESCRIPTION
## Summary

Connection reuse (`getExistingConnection` / `getExistingClusterClient`) matched a cached Valkey client purely by resolved `host:port:db` (or cluster membership), so a session could be handed a client that a *different* session established, just by connecting to the same endpoint. This scopes client reuse — and connection retry — to the session that owns the connection.

## Details

- `getExistingConnection` — only returns a cached client when the session owns the matched connection id (`isConnectionAuthorized`).
- `getExistingClusterClient` — only reuses the shared cluster client when the session owns the matched sibling node. This preserves connecting to another node of a cluster you already connected to (owning any node authorizes reuse of the shared client), while a session that never connected to the cluster gets its own fresh client.
- **Retry** (`isRetry`) is now gated on ownership too, mirroring the existing `isResume` check. Retry reconnects an existing connection and, for clusters, closes + repoints the shared client — so one session's retry must not be able to close or repoint a connection another session owns (e.g. a same-endpoint collision on a shared instance). The frontend only retries connections it previously established, so no legitimate retry is rejected.
- `sessionId` is now a required part of the connect path (threaded through `connectToValkey` → `connectToValkeyLocked` → the reuse helpers); the connect handler fails closed if it is somehow absent.

Same-session, same-cluster node browsing is unchanged: the session owns its nodes after connecting, so it keeps reusing its own cluster client (no extra re-authentication per node).

## Testing

- `npm test --workspace=server` — 205 pass
- `npm run build` — server + frontend
- `npx eslint .` — clean

Regression tests: `getExistingConnection` does not return a client the calling session is not authorized for; `getExistingClusterClient` reuses for an owned sibling node and denies an unowned one; existing reuse/dedup tests updated to set up an authorized session.
