### PR TITLE
Refactor config to harden update-config

### DIFF
--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-params-modal.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-params-modal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { useSelector } from "react-redux"
 import { AlertTriangle } from "lucide-react"
 import { TooltipProvider } from "@radix-ui/react-tooltip"
-import { MONITOR_ACTION } from "@common/src/constants"
+import { MONITOR_ACTION, EPIC_FIELD_BOUNDS } from "@common/src/constants"
 import { toNodeId } from "@common/src/connection-id.ts"
 import { ChartModal } from "../../ui/chart-modal"
 import { Button } from "../../ui/button"
@@ -65,9 +65,13 @@ export function HotKeysParamsModal({ open, onClose, connectionId, clusterId }: H
         connectionId,
         clusterId,
         config: {
-          epic: {
-            name: "monitor", monitoringDuration: monitorDuration,
-            monitoringInterval: monitorInterval, maxCommandsPerRun, cutoffFrequency,
+          epics: {
+            monitor: {
+              monitoringDuration: monitorDuration,
+              monitoringInterval: monitorInterval,
+              maxCommandsPerRun,
+              cutoffFrequency,
+            },
           },
         },
         monitorAction: MONITOR_ACTION.START,
@@ -119,7 +123,8 @@ export function HotKeysParamsModal({ open, onClose, connectionId, clusterId }: H
             </div>
             <NumberInput
               aria-label="Monitor Duration"
-              min={1}
+              max={EPIC_FIELD_BOUNDS.monitoringDuration.max}
+              min={EPIC_FIELD_BOUNDS.monitoringDuration.min}
               onChange={setMonitorDuration}
               step={1000}
               style={{ width: "100px" }}
@@ -134,7 +139,8 @@ export function HotKeysParamsModal({ open, onClose, connectionId, clusterId }: H
             </div>
             <NumberInput
               aria-label="Monitor Interval"
-              min={1}
+              max={EPIC_FIELD_BOUNDS.monitoringInterval.max}
+              min={EPIC_FIELD_BOUNDS.monitoringInterval.min}
               onChange={setMonitorInterval}
               step={1000}
               style={{ width: "100px" }}
@@ -153,7 +159,8 @@ export function HotKeysParamsModal({ open, onClose, connectionId, clusterId }: H
             </div>
             <NumberInput
               aria-label="Max Commands Per Run"
-              min={1}
+              max={EPIC_FIELD_BOUNDS.maxCommandsPerRun.max}
+              min={EPIC_FIELD_BOUNDS.maxCommandsPerRun.min}
               onChange={setMaxCommandsPerRun}
               step={100000}
               style={{ width: "140px" }}
@@ -172,7 +179,8 @@ export function HotKeysParamsModal({ open, onClose, connectionId, clusterId }: H
             </div>
             <NumberInput
               aria-label="Cutoff Frequency"
-              min={1}
+              max={EPIC_FIELD_BOUNDS.cutoffFrequency.max}
+              min={EPIC_FIELD_BOUNDS.cutoffFrequency.min}
               onChange={setCutoffFrequency}
               step={10}
               style={{ width: "100px" }}

--- a/apps/frontend/src/state/valkey-features/config/configSlice.test.ts
+++ b/apps/frontend/src/state/valkey-features/config/configSlice.test.ts
@@ -108,7 +108,7 @@ describe("configSlice", () => {
           clusterId: "cluster-1",
           outcome: "fulfilled",
           nodeResults: [{ nodeId: "node-1", success: true, message: "ok" }],
-          appliedConfig: { epic: { name: "monitor", monitoringDuration: 5000, monitoringInterval: 7000 } },
+          appliedConfig: { epics: { monitor: { monitoringDuration: 5000, monitoringInterval: 7000 } } },
         }),
       )
 
@@ -125,7 +125,7 @@ describe("configSlice", () => {
           nodeId: "host-6379",
           outcome: "fulfilled",
           nodeResults: [{ nodeId: "host-6379", success: true, message: "ok" }],
-          appliedConfig: { epic: { name: "monitor", monitoringDuration: 1234 } },
+          appliedConfig: { epics: { monitor: { monitoringDuration: 1234 } } },
         }),
       )
 
@@ -163,7 +163,7 @@ describe("configSlice", () => {
             { nodeId: "node-1", success: true, message: "ok" },
             { nodeId: "node-2", success: false, message: "boom" },
           ],
-          appliedConfig: { epic: { name: "monitor", monitoringDuration: 5000, monitoringInterval: 7000 } },
+          appliedConfig: { epics: { monitor: { monitoringDuration: 5000, monitoringInterval: 7000 } } },
         }),
       )
 
@@ -188,7 +188,7 @@ describe("configSlice", () => {
             { nodeId: "node-1", success: false, message: "boom" },
             { nodeId: "node-2", success: false, message: "also boom" },
           ],
-          appliedConfig: { epic: { name: "monitor", monitoringDuration: 5000 } },
+          appliedConfig: { epics: { monitor: { monitoringDuration: 5000 } } },
         }),
       )
 
@@ -277,7 +277,7 @@ describe("configSlice", () => {
   })
 
   describe("config/updateConfig (optimistic session reset)", () => {
-    const config = { epic: { name: "monitor" } }
+    const config = { epics: { monitor: { monitoringDuration: 5000 } } }
 
     it("keys by clusterId when present", () => {
       const state = configReducer(
@@ -396,7 +396,7 @@ describe("configSlice", () => {
         updateConfig({
           connectionId: "node-1-db0",
           clusterId: "cluster-1",
-          config: { epic: { name: "monitor" } },
+          config: { epics: { monitor: { monitoringDuration: 5000 } } },
         }),
       )
 
@@ -499,7 +499,7 @@ describe("configSlice", () => {
 
       const updating = configReducer(
         initialState,
-        updateConfig({ connectionId: "host-6379-db0", config: { epic: { name: "monitor" } } }),
+        updateConfig({ connectionId: "host-6379-db0", config: { epics: { monitor: { monitoringDuration: 5000 } } } }),
       )
       expect(updating["host-6379"].kind).toBe("standalone")
     })

--- a/apps/frontend/src/state/valkey-features/config/configSlice.ts
+++ b/apps/frontend/src/state/valkey-features/config/configSlice.ts
@@ -137,14 +137,18 @@ const reconcileNodeStatuses = (
 }
 
 /**
- * Merge the monitoring fields of a reply's appliedConfig into the entry. 
+ * Merge the monitoring fields of a reply's appliedConfig into the entry.
+ *
+ * `appliedConfig` mirrors the request: `{ epics: { <epicName>: { ...fields } } }`.
+ * Only the `monitor` epic carries the settings this slice tracks.
  */
 const applyMonitoringConfig = (entry: ConfigEntry, appliedConfig: unknown): void => {
-  const epic = (appliedConfig as { epic?: Record<string, unknown> } | undefined)?.epic
-  if (!epic) return
+  const epics = (appliedConfig as { epics?: Record<string, Record<string, unknown>> } | undefined)?.epics
+  const monitorEpic = epics?.monitor
+  if (!monitorEpic) return
   const updatedMonitoringConfig = R.pick(
     Object.keys(defaultConfig().monitoring),
-    epic,
+    monitorEpic,
   )
   entry.monitoring = {
     ...entry.monitoring,

--- a/apps/metrics/api-requests.http
+++ b/apps/metrics/api-requests.http
@@ -152,17 +152,21 @@ Accept: application/json
 # UPDATE CONFIG
 #####################################################################
 
-### Update config (example payload)
+### Update epic settings (example payload)
 POST {{baseUrl}}/update-config
 Content-Type: application/json
 Accept: application/json
 
 {
-  "server": {
-    "port": 3000,
-    "data_dir": "./data"
-  },
-  "valkey": {
-    "url": "valkey://localhost:6379"
+  "epics": {
+    "monitor": {
+      "monitoringDuration": 15000,
+      "monitoringInterval": 5000,
+      "maxCommandsPerRun": 1000000,
+      "cutoffFrequency": 100
+    },
+    "cpu": {
+      "poll_ms": 10000
+    }
   }
 }

--- a/apps/metrics/config.yml
+++ b/apps/metrics/config.yml
@@ -9,6 +9,11 @@ collector:
   batch_ms: 60000
   batch_max: 500
 
+# Each epic is one collection stream. Its `name` is the only identifier: it
+# selects the collector implementation and prefixes the .ndjson files it writes.
+# Valid names: memory, cpu, slowlog_len, commandlog_slow,
+# commandlog_large_reply, commandlog_large_request, monitor.
+#
 # Each epic controls its own storage retention:
 #   data_retention_mb   – max disk space (MB) for this epic's .ndjson files.
 #                         Oldest files are evicted when the budget is exceeded.
@@ -16,53 +21,39 @@ collector:
 #                         during the daily cleanup sweep.
 epics:
   - name: "memory"
-    type: "memory_stats"
     poll_ms: 5000
-    file_prefix: "memory"
     data_retention_mb: 15
     data_retention_days: 5
 
   - name: "cpu"
-    type: "info_cpu"
     poll_ms: 5000
-    file_prefix: "cpu"
     data_retention_mb: 5
     data_retention_days: 5
 
   - name: "commandlog_large_reply"
-    type: "commandlog_large_reply"
     poll_ms: 10000
-    file_prefix: "commandlog_large_reply"
     data_retention_mb: 5
     data_retention_days: 5
 
   - name: "commandlog_large_request"
-    type: "commandlog_large_request"
     poll_ms: 10000
-    file_prefix: "commandlog_large_request"
     data_retention_mb: 5
     data_retention_days: 5
 
   - name: "commandlog_slow"
-    type: "commandlog_slow"
     poll_ms: 10000
-    file_prefix: "commandlog_slow"
     data_retention_mb: 5
     data_retention_days: 5
 
   - name: "slowlog_len"
-    type: "slowlog_len"
     poll_ms: 60000
-    file_prefix: "slowlog_len"
     data_retention_mb: 3
     data_retention_days: 5
 
   - name: "monitor"
-    type: "monitor"
     monitoringDuration: 10000
     monitoringInterval: 10000
     maxCommandsPerRun: 1000000
     cutoffFrequency: 100
-    file_prefix: "monitor"
     data_retention_mb: 12
     data_retention_days: 5

--- a/apps/metrics/src/config-persistence.test.js
+++ b/apps/metrics/src/config-persistence.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import YAML from "yaml"
+
+/**
+ * Persistence of `POST /update-config`, exercised against a real filesystem
+ * and a real YAML parser.
+ *
+ * `config.test.js` mocks both to assert call shapes; these tests instead prove
+ * what an operator gets: which bytes of their file change, which do not, and
+ * that an unwritable file costs durability rather than the update.
+ */
+describe("config persistence", () => {
+  let tmpDir
+  let cfgPath
+  let cleanup
+
+  const CONFIG_YML = `# Collection streams. Comments here are the operator's.
+server:
+  port: 0
+  data_dir: "/app/data"
+
+epics:
+  # sampling settings for the MONITOR-based hot keys path
+  - name: "monitor"
+    monitoringDuration: 10000
+    monitoringInterval: 10000
+    cutoffFrequency: 100
+    data_retention_mb: 12
+
+  - name: "cpu"
+    poll_ms: 5000
+    data_retention_mb: 5
+`
+
+  const loadFreshConfig = async () => {
+    vi.resetModules()
+    return import("./config.js")
+  }
+
+  const readCfg = () => fs.readFileSync(cfgPath, "utf8")
+  const epicFromFile = (name) => YAML.parse(readCfg()).epics.find((e) => e.name === name)
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "config-persist-test-"))
+    cfgPath = path.join(tmpDir, "config.yml")
+    fs.writeFileSync(cfgPath, CONFIG_YML, "utf8")
+
+    const previous = { CONFIG_PATH: process.env.CONFIG_PATH, DATA_DIR: process.env.DATA_DIR, PORT: process.env.PORT }
+    process.env.CONFIG_PATH = cfgPath
+    // Per-node values the process resolves for itself; these must never be
+    // written back into the operator's file.
+    process.env.DATA_DIR = path.join(tmpDir, "data", "node-7002")
+    process.env.PORT = "34567"
+    cleanup = () => {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it("changes only the patched field and keeps the rest of the file intact", async () => {
+    const { updateConfig } = await loadFreshConfig()
+
+    const result = updateConfig({ epics: { monitor: { monitoringDuration: 15000 } } })
+
+    expect(result.success).toBe(true)
+    expect(result.persisted).toBe(true)
+
+    const after = readCfg()
+    expect(epicFromFile("monitor").monitoringDuration).toBe(15000)
+    // Comments, untouched fields and the other epic all survive.
+    expect(after).toContain("# Collection streams. Comments here are the operator's.")
+    expect(after).toContain("# sampling settings for the MONITOR-based hot keys path")
+    expect(epicFromFile("monitor").cutoffFrequency).toBe(100)
+    expect(epicFromFile("cpu")).toEqual({ name: "cpu", poll_ms: 5000, data_retention_mb: 5 })
+
+    // A single field changed; nothing else in the file moved.
+    const changedLines = after.split("\n").filter((line, i) => line !== CONFIG_YML.split("\n")[i])
+    expect(changedLines).toEqual(["    monitoringDuration: 15000"])
+  })
+
+  it("never writes environment-resolved values into the file", async () => {
+    const { updateConfig } = await loadFreshConfig()
+
+    updateConfig({ epics: { monitor: { monitoringDuration: 15000 } } })
+
+    const after = readCfg()
+    // These are this process's own env values, not the operator's config.
+    expect(after).not.toContain("node-7002")
+    expect(after).not.toContain("34567")
+    expect(YAML.parse(after).server).toEqual({ port: 0, data_dir: "/app/data" })
+    // Per-epic defaults are not stamped in either.
+    expect(epicFromFile("monitor").data_retention_days).toBeUndefined()
+  })
+
+  it("applies multiple epics in one write", async () => {
+    const { updateConfig } = await loadFreshConfig()
+
+    const result = updateConfig({
+      epics: { monitor: { cutoffFrequency: 5 }, cpu: { poll_ms: 20000, data_retention_days: 7 } },
+    })
+
+    expect(result.persisted).toBe(true)
+    expect(epicFromFile("monitor").cutoffFrequency).toBe(5)
+    expect(epicFromFile("cpu").poll_ms).toBe(20000)
+    expect(epicFromFile("cpu").data_retention_days).toBe(7)
+  })
+
+  it("survives a restart: a new process reads back what the previous one wrote", async () => {
+    const first = await loadFreshConfig()
+    first.updateConfig({ epics: { monitor: { monitoringDuration: 45000 } } })
+
+    const second = await loadFreshConfig()
+    const monitor = second.getConfig().epics.find((e) => e.name === "monitor")
+
+    expect(monitor.monitoringDuration).toBe(45000)
+  })
+
+  it("patches by name, not by position, when the file holds an unknown epic", async () => {
+    // validEpics drops "legacy_epic", so the runtime index and the document
+    // index diverge; a positional patch would land on the wrong entry.
+    fs.writeFileSync(
+      cfgPath,
+      `epics:
+  - name: "legacy_epic"
+    poll_ms: 1000
+  - name: "monitor"
+    monitoringDuration: 10000
+`,
+      "utf8",
+    )
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { updateConfig } = await loadFreshConfig()
+    updateConfig({ epics: { monitor: { monitoringDuration: 15000 } } })
+
+    const parsed = YAML.parse(readCfg())
+    expect(parsed.epics[0]).toEqual({ name: "legacy_epic", poll_ms: 1000 })
+    expect(parsed.epics[1]).toEqual({ name: "monitor", monitoringDuration: 15000 })
+  })
+
+  it("stages through a process-unique temporary file", async () => {
+    const { updateConfig } = await loadFreshConfig()
+    const writeSpy = vi.spyOn(fs, "writeFileSync")
+
+    updateConfig({ epics: { monitor: { monitoringDuration: 15000 } } })
+
+    const staged = writeSpy.mock.calls.map(([target]) => String(target)).find((t) => t.endsWith(".tmp"))
+    // Sibling metrics processes share one CONFIG_PATH; a shared staging path
+    // lets one rename another's half-written file into place.
+    expect(staged).toBe(`${cfgPath}.${process.pid}.tmp`)
+    expect(fs.readdirSync(tmpDir).filter((f) => f.includes(".tmp"))).toEqual([])
+  })
+
+  it("still applies the update when the config file cannot be written", async () => {
+    fs.chmodSync(tmpDir, 0o500) // no write permission on the directory
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    try {
+      const { getConfig, updateConfig } = await loadFreshConfig()
+      const result = updateConfig({ epics: { monitor: { monitoringDuration: 15000 } } })
+
+      // Durability is best effort; the request is not.
+      expect(result.success).toBe(true)
+      expect(result.statusCode).toBe(200)
+      expect(result.persisted).toBe(false)
+      expect(getConfig().epics.find((e) => e.name === "monitor").monitoringDuration).toBe(15000)
+      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("applies to this process only"))
+      expect(readCfg()).toBe(CONFIG_YML)
+    } finally {
+      fs.chmodSync(tmpDir, 0o700)
+    }
+  })
+
+  it("leaves the file untouched when the payload is rejected", async () => {
+    const { updateConfig } = await loadFreshConfig()
+
+    expect(updateConfig({ server: { data_dir: "/tmp/elsewhere" } }).success).toBe(false)
+    expect(updateConfig({ epics: { monitor: { file_prefix: "../../pwn" } } }).success).toBe(false)
+    expect(updateConfig({ epics: { cpu: { data_retention_mb: 0 } } }).success).toBe(false)
+
+    expect(readCfg()).toBe(CONFIG_YML)
+  })
+})

--- a/apps/metrics/src/config-schema.js
+++ b/apps/metrics/src/config-schema.js
@@ -1,0 +1,71 @@
+import { z } from "zod"
+import { EPIC_FIELD_BOUNDS } from "../../../common/src/constants.js"
+
+/**
+ * Request schema for POST /update-config.
+ *
+ * The endpoint tunes collection settings on epics that already exist in
+ * `config.yml`; it is not a general config writer. Everything is default-deny:
+ *
+ *  - the only accepted top-level key is `epics`
+ *  - `epics` is a map keyed by epic name, so no entry can be created, removed
+ *    or renamed — the key is used purely to look up an existing epic
+ *  - epic identity (`name`) and `server.data_dir` stay YAML/env-only, which is
+ *    what keeps API input out of every filesystem path (see ndjson-writer.js)
+ *  - unknown fields are rejected rather than ignored, so a typo fails loudly
+ *    instead of silently doing nothing
+ *
+ * Field bounds live in `common/src/constants.ts` so the UI inputs that produce
+ * these values and this validator cannot drift apart.
+ */
+
+// Epic names double as NDJSON filename prefixes, so keep them to a safe token.
+const EPIC_NAME_PATTERN = /^[a-z0-9_]+$/
+
+// Map keys that would touch an object's prototype instead of creating a
+// property. Rejected before parsing so they can never reach object assembly.
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"])
+
+const boundedInt = ({ min, max }) => z.number().int().min(min).max(max).optional()
+
+const epicPatchSchema = z
+  .strictObject(
+    Object.fromEntries(
+      Object.entries(EPIC_FIELD_BOUNDS).map(([field, bounds]) => [field, boundedInt(bounds)]),
+    ),
+  )
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: "must contain at least one field to update",
+  })
+
+export const configUpdateSchema = z.strictObject({
+  epics: z
+    .record(
+      z.string().regex(EPIC_NAME_PATTERN, "epic names may only contain lowercase letters, digits and underscores"),
+      epicPatchSchema,
+    )
+    .refine((epics) => Object.keys(epics).length > 0, {
+      message: "epics must name at least one epic to update",
+    }),
+})
+
+/**
+ * Prototype-key guard, run before parsing. Only the two levels the schema can
+ * key an object by are checked (the payload root and the `epics` map), so
+ * there is no recursion over untrusted depth.
+ */
+export const findForbiddenKey = (payload) => {
+  const levels = [payload, payload?.epics]
+  for (const level of levels) {
+    if (level == null || typeof level !== "object") continue
+    const forbidden = Object.keys(level).find((key) => FORBIDDEN_KEYS.has(key))
+    if (forbidden) return forbidden
+  }
+  return null
+}
+
+/** Flatten zod issues into one message, naming the offending path. */
+export const formatIssues = (error) =>
+  error.issues
+    .map((issue) => (issue.path.length > 0 ? `${issue.path.join(".")}: ${issue.message}` : issue.message))
+    .join("; ")

--- a/apps/metrics/src/config.js
+++ b/apps/metrics/src/config.js
@@ -3,6 +3,8 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { mergeDeepLeft } from "ramda"
 import YAML from "yaml"
+import { configUpdateSchema, findForbiddenKey, formatIssues } from "./config-schema.js"
+import { EPIC_KINDS } from "./utils/constants.js"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -25,6 +27,30 @@ const DEFAULTS = {
   epics: [],
 }
 
+const EPIC_NAME_PATTERN = /^[a-z0-9_]+$/
+
+/**
+ * An epic's `name` is its only identifier: it selects the fetcher and becomes
+ * the prefix of the NDJSON files written under `data_dir`. Because it reaches
+ * `path.join`, an unsafe name is a hard configuration error rather than
+ * something to work around. A name that is merely unrecognised collects nothing (no fetcher matches), 
+ * so it is dropped with a warning instead.
+ */
+const validEpics = (epics) => epics.filter((epic) => {
+  const name = epic?.name
+  if (typeof name !== "string" || !EPIC_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid epic name in ${cfgPath}: ${JSON.stringify(name)}. `
+      + "Epic names may only contain lowercase letters, digits and underscores.",
+    )
+  }
+  if (!EPIC_KINDS.includes(name)) {
+    console.error(`[config] Ignoring unknown epic "${name}". Known epics: ${EPIC_KINDS.join(", ")}`)
+    return false
+  }
+  return true
+})
+
 const loadConfig = () => {
   const text = fs.readFileSync(cfgPath, "utf8")
   const parsed = YAML.parse(text) || {}
@@ -38,7 +64,7 @@ const loadConfig = () => {
     }
   }
   if (!Array.isArray(cfg.epics)) cfg.epics = []
-  cfg.epics = cfg.epics.map((e) => ({ ...EPIC_DEFAULTS, ...e }))
+  cfg.epics = validEpics(cfg.epics).map((e) => ({ ...EPIC_DEFAULTS, ...e }))
 
   if (process.env.PORT) cfg.server.port = Number(process.env.PORT)
   if (process.env.DATA_DIR) cfg.server.data_dir = process.env.DATA_DIR
@@ -67,92 +93,51 @@ const setConfig = (newConfig) => {
   config = loadConfig()
 }
 
-const updateConfig = (partialConfig) => {
-  const validationError = validatePartialConfig(partialConfig)
+const badRequestReply = (message) => ({ success: false, statusCode: 400, message, data: {} })
 
-  if (validationError) {
-    return {
-      success: false,
-      statusCode: 400,
-      message: validationError.message,
-      data: validationError,
-    }
-  }
+/**
+ * Apply a validated set of per-epic patches.
+ *
+ * All-or-nothing: the payload is validated, then every named epic is resolved
+ * against the loaded config before anything is written, so a request that
+ * names one bad epic leaves `config.yml` untouched. A successful request
+ * results in exactly one write.
+ *
+ * Only the fields in the schema's allowlist are copied onto the existing
+ * entry; identity (`name`) is never touched, so no API input can reach a
+ * filesystem path.
+ */
+const updateConfig = (partialConfig) => {
+  const forbiddenKey = findForbiddenKey(partialConfig)
+  if (forbiddenKey) return badRequestReply(`Illegal key: ${forbiddenKey}`)
+
+  const parsed = configUpdateSchema.safeParse(partialConfig)
+  if (!parsed.success) return badRequestReply(formatIssues(parsed.error))
+
   const cfg = getConfig()
-  
-  if (partialConfig.epic) {
-    // TODO: use zod for validation
-    const { name, ...fields } = partialConfig.epic
-    const epicIndex = cfg.epics.findIndex((e) => e.name === name)
-    if (epicIndex === -1) {
-      return {
-        success: false,
-        statusCode: 400,
-        message: `Unknown epic: ${name}`,
-        data: {},
-      }
-    }
-    const newConfig = structuredClone(cfg)
-    newConfig.epics[epicIndex] = mergeDeepLeft(fields, newConfig.epics[epicIndex])
-    setConfig(newConfig)
-  } else {
-    const newConfig = mergeDeepLeft(partialConfig, cfg)
-    setConfig(newConfig)
+  const patches = Object.entries(parsed.data.epics)
+
+  const unknownNames = patches
+    .map(([name]) => name)
+    .filter((name) => !cfg.epics.some((epic) => epic.name === name))
+  if (unknownNames.length > 0) {
+    return badRequestReply(`Unknown epics: ${unknownNames.join(", ")}`)
   }
+
+  const newConfig = structuredClone(cfg)
+  for (const [name, fields] of patches) {
+    const epicIndex = newConfig.epics.findIndex((epic) => epic.name === name)
+    newConfig.epics[epicIndex] = { ...newConfig.epics[epicIndex], ...fields }
+  }
+  setConfig(newConfig)
 
   return {
     success: true,
     statusCode: 200,
     message: "",
-    data: partialConfig,
+    data: parsed.data,
   }
 }
-
-const validatePartialConfig = (partialConfig) => {
-  if (partialConfig == null || typeof partialConfig !== "object" || Array.isArray(partialConfig)) {
-    return new Error("Config update must be an object")
-  }
-
-  if (partialConfig.epic !== undefined) {
-    if (typeof partialConfig.epic !== "object" || Array.isArray(partialConfig.epic)) {
-      return new Error("epic must be an object")
-    }
-
-    const { name, monitoringDuration, monitoringInterval, maxCommandsPerRun } = partialConfig.epic
-
-    if (typeof name !== "string" || name.length === 0) {
-      return new Error("epic.name must be a non-empty string")
-    }
-
-    if (
-      monitoringDuration !== undefined &&
-      !isPositiveNumber(monitoringDuration)
-    ) {
-      return new Error("monitoringDuration must be a positive non-zero number")
-    }
-
-    if (
-      monitoringInterval !== undefined &&
-      !isPositiveNumber(monitoringInterval)
-    ) {
-      return new Error("monitoringInterval must be a positive non-zero number")
-    }
-
-    if (
-      maxCommandsPerRun !== undefined &&
-      !isPositiveNumber(maxCommandsPerRun)
-    ) {
-      return new Error("maxCommandsPerRun must be a positive non-zero number")
-    }
-  }
-
-  return null
-}
-
-const isPositiveNumber = (value) =>
-  typeof value === "number" &&
-  Number.isFinite(value) &&
-  value > 0
 
 export { getConfig, updateConfig }
 

--- a/apps/metrics/src/config.js
+++ b/apps/metrics/src/config.js
@@ -82,15 +82,52 @@ const loadConfig = () => {
 
   return cfg
 }
+
 const getConfig = () => config ? config : loadConfig()
 
-const setConfig = (newConfig) => {
-  const tmpPath = `${cfgPath}.tmp`
+/**
+ * Locate an epic inside the parsed YAML document by name.
+ */
+const epicDocumentIndex = (doc, name) => {
+  const items = doc.get("epics")?.items ?? []
+  return items.findIndex((item) => (typeof item?.get === "function" ? item.get("name") : item?.name) === name)
+}
 
-  fs.writeFileSync(tmpPath, YAML.stringify(newConfig), "utf8")
-  fs.renameSync(tmpPath, cfgPath)
+/**
+ * Write the patch back into the operator's config file, best effort.
+ *
+ * The file is patched as a YAML document rather than re-serialized from the
+ * runtime config, so comments, key order and quoting survive and no
+ * environment-resolved value (`data_dir`, `port`, `batch_*`) is ever written back.
+ *
+ * Returns whether the write succeeded. A failure is logged and reported, never
+ * thrown: the update has already been applied in memory, and refusing the
+ * request would make the endpoint unusable wherever the config file is mounted
+ * read-only.
+ */
+const persistPatches = (patchesByEpic) => {
+  try {
+    const doc = YAML.parseDocument(fs.readFileSync(cfgPath, "utf8"))
 
-  config = loadConfig()
+    for (const [name, fields] of Object.entries(patchesByEpic)) {
+      const epicIndex = epicDocumentIndex(doc, name)
+      if (epicIndex === -1) continue // the name came from this file, so this is unreachable in practice
+      for (const [field, value] of Object.entries(fields)) {
+        doc.setIn(["epics", epicIndex, field], value)
+      }
+    }
+
+    const tmpPath = `${cfgPath}.${process.pid}.tmp`
+    fs.writeFileSync(tmpPath, doc.toString(), "utf8")
+    fs.renameSync(tmpPath, cfgPath)
+    return true
+  } catch (error) {
+    console.error(
+      `[config] Could not persist the update to ${cfgPath}; it applies to this process only `
+      + `and will be lost on restart: ${error.message}`,
+    )
+    return false
+  }
 }
 
 const badRequestReply = (message) => ({ success: false, statusCode: 400, message, data: {} })
@@ -98,10 +135,13 @@ const badRequestReply = (message) => ({ success: false, statusCode: 400, message
 /**
  * Apply a validated set of per-epic patches.
  *
- * All-or-nothing: the payload is validated, then every named epic is resolved
- * against the loaded config before anything is written, so a request that
- * names one bad epic leaves `config.yml` untouched. A successful request
- * results in exactly one write.
+ * All-or-nothing: the payload is validated and every named epic resolved
+ * against the loaded config before anything changes, so a request naming one
+ * bad epic changes nothing at all.
+ *
+ * The patch is applied to the in-memory config first and then persisted to the
+ * overrides file, so an unwritable data dir costs durability but never the
+ * update itself — `persisted` reports which happened.
  *
  * Only the fields in the schema's allowlist are copied onto the existing
  * entry; identity (`name`) is never touched, so no API input can reach a
@@ -129,13 +169,14 @@ const updateConfig = (partialConfig) => {
     const epicIndex = newConfig.epics.findIndex((epic) => epic.name === name)
     newConfig.epics[epicIndex] = { ...newConfig.epics[epicIndex], ...fields }
   }
-  setConfig(newConfig)
+  config = newConfig
 
   return {
     success: true,
     statusCode: 200,
     message: "",
     data: parsed.data,
+    persisted: persistPatches(parsed.data.epics),
   }
 }
 

--- a/apps/metrics/src/config.test.js
+++ b/apps/metrics/src/config.test.js
@@ -15,8 +15,23 @@ vi.mock("yaml", () => ({
   default: {
     parse: vi.fn(),
     stringify: vi.fn(),
+    parseDocument: vi.fn(),
   },
 }))
+
+/**
+ * Stand-in for a parsed YAML document. Only what the persist path touches:
+ * `get("epics").items` to resolve an epic by name, `setIn` to patch a field,
+ * and `toString` to serialize. Byte-level behaviour is covered against a real
+ * parser in config-persistence.test.js.
+ */
+const mockDocument = (epicNames = ["monitor", "cpu"]) => ({
+  setIn: vi.fn(),
+  toString: () => "patched yaml",
+  get: (key) => (key === "epics"
+    ? { items: epicNames.map((name) => ({ get: (field) => (field === "name" ? name : undefined) })) }
+    : undefined),
+})
 
 describe("config", () => {
   let fs
@@ -35,6 +50,7 @@ describe("config", () => {
     fs.readFileSync.mockReturnValue("")
     YAML.parse.mockReturnValue({})
     YAML.stringify.mockReturnValue("")
+    YAML.parseDocument.mockImplementation(() => mockDocument())
   })
 
   afterEach(() => {
@@ -321,28 +337,49 @@ describe("config", () => {
   })
 
   describe("updateConfig", () => {
-    it("should apply and persist a valid patch", async () => {
+    it("should apply the patch in memory and report it as persisted", async () => {
       YAML.parse.mockReturnValue({
         epics: [{ name: "monitor", monitoringDuration: 10000, cutoffFrequency: 100 }],
       })
+      const doc = mockDocument(["monitor"])
+      YAML.parseDocument.mockReturnValue(doc)
 
-      const { updateConfig } = await import("./config.js")
+      const { getConfig, updateConfig } = await import("./config.js")
       const result = updateConfig({ epics: { monitor: { monitoringDuration: 20000 } } })
 
       expect(result.success).toBe(true)
-      expect(YAML.stringify).toHaveBeenCalled()
-      expect(fs.writeFileSync).toHaveBeenCalled()
-      expect(fs.renameSync).toHaveBeenCalled()
+      expect(result.persisted).toBe(true)
 
-      // Only the patched field changes; identity and untouched fields survive.
-      const written = YAML.stringify.mock.calls[0][0]
-      expect(written.epics[0]).toEqual({
+      // In memory: only the patched field changes, identity and siblings survive.
+      expect(getConfig().epics[0]).toEqual({
         name: "monitor",
         monitoringDuration: 20000,
         cutoffFrequency: 100,
         data_retention_mb: 10,
         data_retention_days: 30,
       })
+
+      // On disk: the document is patched in place, not re-serialized.
+      expect(doc.setIn).toHaveBeenCalledWith(["epics", 0, "monitoringDuration"], 20000)
+      expect(doc.setIn).toHaveBeenCalledTimes(1)
+      expect(YAML.stringify).not.toHaveBeenCalled()
+    })
+
+    it("should report persisted: false when the config file cannot be written", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor", monitoringDuration: 10000 }] })
+      fs.writeFileSync.mockImplementationOnce(() => { throw new Error("EROFS: read-only file system") })
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+      const { getConfig, updateConfig } = await import("./config.js")
+      const result = updateConfig({ epics: { monitor: { monitoringDuration: 20000 } } })
+
+      // The update still applies: durability is best effort, the request is not.
+      expect(result.success).toBe(true)
+      expect(result.statusCode).toBe(200)
+      expect(result.persisted).toBe(false)
+      expect(getConfig().epics[0].monitoringDuration).toBe(20000)
+      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("applies to this process only"))
+      consoleError.mockRestore()
     })
 
     it("should apply multiple epics in a single write", async () => {
@@ -363,11 +400,7 @@ describe("config", () => {
 
       expect(result.success).toBe(true)
       expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
-
-      const written = YAML.stringify.mock.calls[0][0]
-      expect(written.epics[0].monitoringDuration).toBe(20000)
-      expect(written.epics[1].poll_ms).toBe(10000)
-      expect(written.epics[1].data_retention_days).toBe(7)
+      expect(fs.renameSync).toHaveBeenCalledTimes(1)
     })
 
     it("should write nothing when any epic in the payload is invalid", async () => {
@@ -419,43 +452,34 @@ describe("config", () => {
       expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
 
-    it("should create temporary file before renaming (atomic write)", async () => {
+    it("should stage through a process-unique temporary file before renaming", async () => {
       YAML.parse.mockReturnValue({ epics: [{ name: "monitor" }] })
       const { updateConfig } = await import("./config.js")
       updateConfig({ epics: { monitor: { monitoringDuration: 5000 } } })
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining(".tmp"),
-        expect.any(String),
-        "utf8",
-      )
-
       const tmpPath = fs.writeFileSync.mock.calls[0][0]
       const finalPath = fs.renameSync.mock.calls[0][1]
 
-      expect(tmpPath).toContain(".tmp")
+      // The pid keeps sibling metrics processes from staging through one path.
+      expect(tmpPath).toContain(`.${process.pid}.tmp`)
       expect(finalPath).not.toContain(".tmp")
       expect(fs.renameSync).toHaveBeenCalledWith(tmpPath, finalPath)
     })
 
-    it("should reload config after update", async () => {
-      const initialConfig = { epics: [{ name: "monitor", monitoringDuration: 10000 }] }
-      const updatedConfig = { epics: [{ name: "monitor", monitoringDuration: 20000 }] }
-
-      YAML.parse.mockReturnValueOnce(initialConfig)
-      YAML.parse.mockReturnValueOnce(initialConfig) // for getConfig call inside updateConfig
-      YAML.parse.mockReturnValueOnce(updatedConfig) // for reload after write
+    it("should serve the applied patch from memory, not a re-read", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor", monitoringDuration: 10000 }] })
+      YAML.parseDocument.mockReturnValue(mockDocument(["monitor"]))
 
       const { getConfig, updateConfig } = await import("./config.js")
 
-      const before = getConfig()
-      expect(before.epics[0].monitoringDuration).toBe(10000)
+      expect(getConfig().epics[0].monitoringDuration).toBe(10000)
 
       updateConfig({ epics: { monitor: { monitoringDuration: 20000 } } })
 
-      // getConfig should reflect the updated value (from reload)
-      const after = getConfig()
-      expect(after.epics[0].monitoringDuration).toBe(20000)
+      // The in-memory value stands even though the mocked file still parses to
+      // the old one, so a failed or partial write cannot roll the update back.
+      expect(getConfig().epics[0].monitoringDuration).toBe(20000)
+      expect(getConfig().epics[0].monitoringDuration).toBe(20000)
     })
   })
 })

--- a/apps/metrics/src/config.test.js
+++ b/apps/metrics/src/config.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { EPIC_FIELD_BOUNDS } from "../../../common/src/constants.js"
 import { mockEnv } from "./__tests__/test-helpers.js"
 
 // Mock node:fs and yaml modules
@@ -44,88 +45,157 @@ describe("config", () => {
     }
   })
 
-  describe("validatePartialConfig", () => {
-    it("should accept valid config with epic object", async () => {
+  describe("request validation", () => {
+    it("should accept a patch for a wired epic", async () => {
       YAML.parse.mockReturnValue({
         epics: [{ name: "monitor", monitoringDuration: 10000 }],
       })
       const { updateConfig } = await import("./config.js")
       const result = updateConfig({
-        epic: { name: "monitor", monitoringDuration: 15000 },
+        epics: { monitor: { monitoringDuration: 15000 } },
       })
       expect(result.success).toBe(true)
     })
 
-    it("should reject null or non-object configs", async () => {
+    it("should reject null or non-object payloads", async () => {
       const { updateConfig } = await import("./config.js")
 
       expect(updateConfig(null).success).toBe(false)
-      expect(updateConfig(null).message).toContain("must be an object")
-
       expect(updateConfig("string").success).toBe(false)
       expect(updateConfig(123).success).toBe(false)
       expect(updateConfig([]).success).toBe(false)
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
 
-    it("should reject invalid epic object", async () => {
+    it("should reject every top-level key other than epics", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor" }] })
       const { updateConfig } = await import("./config.js")
 
-      expect(updateConfig({ epic: "not an object" }).success).toBe(false)
-      expect(updateConfig({ epic: "not an object" }).message).toContain(
-        "epic must be an object",
-      )
+      // data_dir is a second, traversal-free way to redirect where NDJSON is
+      // written, so it must not be settable through the API.
+      const dataDir = updateConfig({ server: { data_dir: "/etc" } })
+      expect(dataDir.success).toBe(false)
+      expect(dataDir.statusCode).toBe(400)
+      expect(dataDir.message).toContain("server")
 
-      expect(updateConfig({ epic: 123 }).success).toBe(false)
-      expect(updateConfig({ epic: [] }).success).toBe(false)
+      expect(updateConfig({ collector: { batch_ms: 1 } }).success).toBe(false)
+      expect(updateConfig({ backend: { ping_interval: 1 } }).success).toBe(false)
+      expect(updateConfig({ valkey: { mode: "cluster" } }).success).toBe(false)
+      expect(updateConfig({
+        epics: { monitor: { monitoringDuration: 5000 } },
+        server: { data_dir: "/etc" },
+      }).success).toBe(false)
+
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
 
-    it("should reject epic without name", async () => {
+    it("should reject a wholesale epics array", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor" }] })
       const { updateConfig } = await import("./config.js")
 
-      expect(updateConfig({ epic: {} }).success).toBe(false)
-      expect(updateConfig({ epic: {} }).message).toContain("epic.name must be a non-empty string")
-
-      expect(updateConfig({ epic: { name: "" } }).success).toBe(false)
-      expect(updateConfig({ epic: { name: 123 } }).success).toBe(false)
+      // An array would replace cfg.epics outright, letting a caller invent
+      // epics (and their filename prefixes) instead of tuning existing ones.
+      const result = updateConfig({ epics: [{ name: "evil", poll_ms: 5000 }] })
+      expect(result.success).toBe(false)
+      expect(result.statusCode).toBe(400)
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
 
-    it("should reject invalid epic fields", async () => {
+    it("should reject an empty epics map or an empty patch", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor" }] })
       const { updateConfig } = await import("./config.js")
 
-      // Invalid monitoringDuration (0, negative, non-number)
-      expect(
-        updateConfig({ epic: { name: "monitor", monitoringDuration: 0 } }).success,
-      ).toBe(false)
-      expect(
-        updateConfig({ epic: { name: "monitor", monitoringDuration: -100 } }).message,
-      ).toContain("monitoringDuration must be a positive")
-
-      expect(
-        updateConfig({ epic: { name: "monitor", monitoringDuration: NaN } }).success,
-      ).toBe(false)
-      expect(
-        updateConfig({ epic: { name: "monitor", monitoringDuration: "1000" } }).success,
-      ).toBe(false)
-
-      // Invalid monitoringInterval
-      expect(
-        updateConfig({ epic: { name: "monitor", monitoringInterval: 0 } }).success,
-      ).toBe(false)
-
-      // Invalid maxCommandsPerRun
-      expect(
-        updateConfig({ epic: { name: "monitor", maxCommandsPerRun: -1 } }).success,
-      ).toBe(false)
+      expect(updateConfig({}).success).toBe(false)
+      expect(updateConfig({ epics: {} }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: {} } }).success).toBe(false)
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
 
-    it("should reject unknown epic name", async () => {
+    it("should reject prototype-polluting epic keys", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor" }] })
+      const { updateConfig } = await import("./config.js")
+
+      const payload = JSON.parse("{\"epics\":{\"__proto__\":{\"poll_ms\":5000}}}")
+      const result = updateConfig(payload)
+      expect(result.success).toBe(false)
+      expect(result.message).toContain("__proto__")
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
+    })
+
+    it("should reject epic names outside the safe token pattern", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor" }] })
+      const { updateConfig } = await import("./config.js")
+
+      expect(updateConfig({ epics: { "../../etc/cron.d": { poll_ms: 5000 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { "Monitor": { poll_ms: 5000 } } }).success).toBe(false)
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
+    })
+
+    it("should reject unknown fields inside an epic patch", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor", file_prefix: "monitor" }] })
+      const { updateConfig } = await import("./config.js")
+
+      // file_prefix reaches path.join() in the NDJSON writer, so it must never
+      // be settable from a request.
+      const traversal = updateConfig({ epics: { monitor: { file_prefix: "../../../tmp/pwn" } } })
+      expect(traversal.success).toBe(false)
+      expect(traversal.statusCode).toBe(400)
+      expect(traversal.message).toContain("file_prefix")
+
+      expect(updateConfig({ epics: { monitor: { name: "other" } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { type: "monitor" } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { nonsense: 1 } } }).success).toBe(false)
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
+    })
+
+    it("should reject out-of-range and non-integer field values", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor" }, { name: "cpu" }] })
+      const { updateConfig } = await import("./config.js")
+
+      expect(updateConfig({ epics: { monitor: { monitoringDuration: 0 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { monitoringDuration: -100 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { monitoringDuration: NaN } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { monitoringDuration: "1000" } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { monitoringDuration: 1.5 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { monitoringDuration: 3_600_001 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { monitoringInterval: 0 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { maxCommandsPerRun: -1 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { monitor: { cutoffFrequency: 0 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { cpu: { poll_ms: 999 } } }).success).toBe(false)
+      // Retention below 1 MB would make computeCapacity disable rotation.
+      expect(updateConfig({ epics: { cpu: { data_retention_mb: 0 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { cpu: { data_retention_mb: "x" } } }).success).toBe(false)
+      expect(updateConfig({ epics: { cpu: { data_retention_days: 0 } } }).success).toBe(false)
+      expect(updateConfig({ epics: { cpu: { data_retention_days: 366 } } }).success).toBe(false)
+
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
+    })
+
+    it("should accept values at the bounds the UI can produce", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor" }] })
+      const { updateConfig } = await import("./config.js")
+
+      expect(updateConfig({
+        epics: {
+          monitor: {
+            monitoringDuration: EPIC_FIELD_BOUNDS.monitoringDuration.min,
+            monitoringInterval: EPIC_FIELD_BOUNDS.monitoringInterval.max,
+            maxCommandsPerRun: EPIC_FIELD_BOUNDS.maxCommandsPerRun.max,
+            cutoffFrequency: EPIC_FIELD_BOUNDS.cutoffFrequency.min,
+          },
+        },
+      }).success).toBe(true)
+    })
+
+    it("should reject unknown epic names", async () => {
       YAML.parse.mockReturnValue({
         epics: [{ name: "monitor" }],
       })
       const { updateConfig } = await import("./config.js")
-      const result = updateConfig({ epic: { name: "nonexistent", monitoringDuration: 5000 } })
+      const result = updateConfig({ epics: { nonexistent: { monitoringDuration: 5000 } } })
       expect(result.success).toBe(false)
       expect(result.message).toContain("Unknown epic")
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
   })
 
@@ -144,6 +214,29 @@ describe("config", () => {
       expect(fs.readFileSync).toHaveBeenCalled()
       expect(YAML.parse).toHaveBeenCalled()
       expect(config.valkey.url).toBe("valkey://localhost:6380")
+    })
+
+    it("should refuse to load an epic whose name is not a safe token", async () => {
+      // The name becomes a filename prefix under data_dir, so an unsafe one is
+      // a hard configuration error rather than something to work around.
+      YAML.parse.mockReturnValue({ epics: [{ name: "../../etc/cron.d" }] })
+
+      const { getConfig } = await import("./config.js")
+      expect(() => getConfig()).toThrow(/Invalid epic name/)
+    })
+
+    it("should drop epics whose name is not a known kind", async () => {
+      YAML.parse.mockReturnValue({
+        epics: [{ name: "monitor" }, { name: "not_a_collector" }],
+      })
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+      const { getConfig } = await import("./config.js")
+      const config = getConfig()
+
+      expect(config.epics.map((e) => e.name)).toEqual(["monitor"])
+      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("not_a_collector"))
+      consoleError.mockRestore()
     })
 
     it("should apply default values when parsed config is empty", async () => {
@@ -228,26 +321,97 @@ describe("config", () => {
   })
 
   describe("updateConfig", () => {
-    it("should merge and persist valid partial config", async () => {
-      const existingConfig = {
-        valkey: { url: "valkey://localhost:6379" },
-        server: { port: 3000, data_dir: "/app/data" },
-      }
-
-      YAML.parse.mockReturnValue(existingConfig)
+    it("should apply and persist a valid patch", async () => {
+      YAML.parse.mockReturnValue({
+        epics: [{ name: "monitor", monitoringDuration: 10000, cutoffFrequency: 100 }],
+      })
 
       const { updateConfig } = await import("./config.js")
-      const result = updateConfig({ server: { port: 4000 } })
+      const result = updateConfig({ epics: { monitor: { monitoringDuration: 20000 } } })
 
       expect(result.success).toBe(true)
       expect(YAML.stringify).toHaveBeenCalled()
       expect(fs.writeFileSync).toHaveBeenCalled()
       expect(fs.renameSync).toHaveBeenCalled()
+
+      // Only the patched field changes; identity and untouched fields survive.
+      const written = YAML.stringify.mock.calls[0][0]
+      expect(written.epics[0]).toEqual({
+        name: "monitor",
+        monitoringDuration: 20000,
+        cutoffFrequency: 100,
+        data_retention_mb: 10,
+        data_retention_days: 30,
+      })
+    })
+
+    it("should apply multiple epics in a single write", async () => {
+      YAML.parse.mockReturnValue({
+        epics: [
+          { name: "monitor", monitoringDuration: 10000 },
+          { name: "cpu", poll_ms: 5000 },
+        ],
+      })
+
+      const { updateConfig } = await import("./config.js")
+      const result = updateConfig({
+        epics: {
+          monitor: { monitoringDuration: 20000 },
+          cpu: { poll_ms: 10000, data_retention_days: 7 },
+        },
+      })
+
+      expect(result.success).toBe(true)
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
+
+      const written = YAML.stringify.mock.calls[0][0]
+      expect(written.epics[0].monitoringDuration).toBe(20000)
+      expect(written.epics[1].poll_ms).toBe(10000)
+      expect(written.epics[1].data_retention_days).toBe(7)
+    })
+
+    it("should write nothing when any epic in the payload is invalid", async () => {
+      YAML.parse.mockReturnValue({
+        epics: [
+          { name: "monitor", monitoringDuration: 10000 },
+          { name: "cpu", poll_ms: 5000 },
+        ],
+      })
+
+      const { updateConfig } = await import("./config.js")
+      const result = updateConfig({
+        epics: {
+          monitor: { monitoringDuration: 20000 },
+          cpu: { poll_ms: 1 },
+        },
+      })
+
+      expect(result.success).toBe(false)
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
+      expect(fs.renameSync).not.toHaveBeenCalled()
+    })
+
+    it("should write nothing when any epic in the payload is unknown", async () => {
+      YAML.parse.mockReturnValue({
+        epics: [{ name: "monitor", monitoringDuration: 10000 }],
+      })
+
+      const { updateConfig } = await import("./config.js")
+      const result = updateConfig({
+        epics: {
+          monitor: { monitoringDuration: 20000 },
+          ghost: { poll_ms: 5000 },
+        },
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain("ghost")
+      expect(fs.writeFileSync).not.toHaveBeenCalled()
     })
 
     it("should return error response for invalid config", async () => {
       const { updateConfig } = await import("./config.js")
-      const result = updateConfig({ epic: "not an object" })
+      const result = updateConfig({ epics: "not an object" })
 
       expect(result.success).toBe(false)
       expect(result.statusCode).toBe(400)
@@ -256,8 +420,9 @@ describe("config", () => {
     })
 
     it("should create temporary file before renaming (atomic write)", async () => {
+      YAML.parse.mockReturnValue({ epics: [{ name: "monitor" }] })
       const { updateConfig } = await import("./config.js")
-      updateConfig({ server: { port: 5000 } })
+      updateConfig({ epics: { monitor: { monitoringDuration: 5000 } } })
 
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         expect.stringContaining(".tmp"),
@@ -274,8 +439,8 @@ describe("config", () => {
     })
 
     it("should reload config after update", async () => {
-      const initialConfig = { server: { port: 3000 } }
-      const updatedConfig = { server: { port: 4000 } }
+      const initialConfig = { epics: [{ name: "monitor", monitoringDuration: 10000 }] }
+      const updatedConfig = { epics: [{ name: "monitor", monitoringDuration: 20000 }] }
 
       YAML.parse.mockReturnValueOnce(initialConfig)
       YAML.parse.mockReturnValueOnce(initialConfig) // for getConfig call inside updateConfig
@@ -284,13 +449,13 @@ describe("config", () => {
       const { getConfig, updateConfig } = await import("./config.js")
 
       const before = getConfig()
-      expect(before.server.port).toBe(3000)
+      expect(before.epics[0].monitoringDuration).toBe(10000)
 
-      updateConfig({ server: { port: 4000 } })
+      updateConfig({ epics: { monitor: { monitoringDuration: 20000 } } })
 
       // getConfig should reflect the updated value (from reload)
       const after = getConfig()
-      expect(after.server.port).toBe(4000)
+      expect(after.epics[0].monitoringDuration).toBe(20000)
     })
   })
 })

--- a/apps/metrics/src/effects/fetchers.js
+++ b/apps/metrics/src/effects/fetchers.js
@@ -65,7 +65,7 @@ const parseKeyCount = R.pipe(
 )
 
 export const makeFetcher = (client) => ({
-  memory_stats: async () => {
+  memory: async () => {
     const memoryInfo = normalizeNodeScopedResponse(
       await client.info([InfoOptions.Memory]),
     )
@@ -73,8 +73,8 @@ export const makeFetcher = (client) => ({
       await client.info([InfoOptions.Keyspace]),
     )
     if (debugMetrics) {
-      log.info("[memory_stats] raw info preview", String(memoryInfo).split(/\r?\n/).slice(0, 20).join("\n"))
-      log.info("[memory_stats] raw keyspace preview", String(keyspaceInfo).split(/\r?\n/).slice(0, 10).join("\n"))
+      log.info("[memory] raw info preview", String(memoryInfo).split(/\r?\n/).slice(0, 20).join("\n"))
+      log.info("[memory] raw keyspace preview", String(keyspaceInfo).split(/\r?\n/).slice(0, 10).join("\n"))
     }
     const ts = Date.now()
     const metrics = Object.fromEntries(parseInfoToPairs(memoryInfo))
@@ -104,13 +104,13 @@ export const makeFetcher = (client) => ({
       kvPairsToRows(ts),
     )(derivedPairs)
     if (debugMetrics) {
-      log.info("[memory_stats] normalized row count", rows.length)
-      log.info("[memory_stats] normalized row preview", rows.slice(0, 10))
+      log.info("[memory] normalized row count", rows.length)
+      log.info("[memory] normalized row preview", rows.slice(0, 10))
     }
     return rows
   },
 
-  info_cpu: async () => {
+  cpu: async () => {
     const raw = normalizeNodeScopedResponse(
       await client.info([InfoOptions.Cpu]),
     )

--- a/apps/metrics/src/effects/fetchers.test.js
+++ b/apps/metrics/src/effects/fetchers.test.js
@@ -23,7 +23,7 @@ describe("fetchers", () => {
     delete process.env.VALKEY_PORT
   })
 
-  describe("memory_stats", () => {
+  describe("memory", () => {
     it("should parse INFO MEMORY output correctly", async () => {
       client.info
         .mockResolvedValueOnce(
@@ -40,7 +40,7 @@ allocator_rss_ratio:1.11`,
         )
         .mockResolvedValueOnce("db0:keys=50,expires=0,avg_ttl=0")
 
-      const result = await fetcher.memory_stats()
+      const result = await fetcher.memory()
 
       expect(result.find((r) => r.metric === "used_memory")?.value).toBe(800000)
       expect(result.find((r) => r.metric === "peak_allocated")?.value).toBe(1100000)
@@ -57,7 +57,7 @@ used_memory:900000`,
         )
         .mockResolvedValueOnce("db0:keys=100,expires=0,avg_ttl=0")
 
-      const result = await fetcher.memory_stats()
+      const result = await fetcher.memory()
 
       expect(result.find((r) => r.metric === "keys_bytes_per_key")?.value).toBe(8000)
     })
@@ -71,7 +71,7 @@ mem_fragmentation_ratio:1.25`,
         )
         .mockResolvedValueOnce("")
 
-      const result = await fetcher.memory_stats()
+      const result = await fetcher.memory()
 
       expect(result).toHaveLength(2)
       expect(result.find((r) => r.metric === "used_memory")?.value).toBe(800000)
@@ -81,7 +81,7 @@ mem_fragmentation_ratio:1.25`,
     it("should return empty rows when INFO MEMORY is empty", async () => {
       client.info.mockResolvedValueOnce("").mockResolvedValueOnce("")
 
-      const result = await fetcher.memory_stats()
+      const result = await fetcher.memory()
 
       expect(result).toEqual([])
     })
@@ -91,7 +91,7 @@ mem_fragmentation_ratio:1.25`,
         .mockResolvedValueOnce("used_memory:100\nused_memory_peak:200")
         .mockResolvedValueOnce("")
 
-      const result = await fetcher.memory_stats()
+      const result = await fetcher.memory()
 
       expect(result.every((r) => r.ts === Date.now())).toBe(true)
     })
@@ -109,7 +109,7 @@ mem_fragmentation_ratio:1.25`,
           "valkey-5.valkey-headless.valkey.svc.cluster.local:6379": "db0:keys=2,expires=0,avg_ttl=0",
         })
 
-      const result = await fetcher.memory_stats()
+      const result = await fetcher.memory()
 
       expect(result).toHaveLength(2)
       expect(result.find((r) => r.metric === "used_memory")?.value).toBe(200)
@@ -117,7 +117,7 @@ mem_fragmentation_ratio:1.25`,
     })
   })
 
-  describe("info_cpu", () => {
+  describe("cpu", () => {
     it("should parse INFO CPU output correctly", async () => {
       client.info.mockResolvedValue(
         `used_cpu_sys:10.5
@@ -125,7 +125,7 @@ mem_fragmentation_ratio:1.25`,
         used_cpu_sys_children:0.1`,
       )
 
-      const result = await fetcher.info_cpu()
+      const result = await fetcher.cpu()
 
       expect(result).toHaveLength(3)
       expect(result.find((r) => r.metric === "used_cpu_sys").value).toBe(10.5)
@@ -143,7 +143,7 @@ mem_fragmentation_ratio:1.25`,
         used_cpu_user:20.3`,
       )
 
-      const result = await fetcher.info_cpu()
+      const result = await fetcher.cpu()
 
       // Should only have 2 metrics, not the headers
       expect(result).toHaveLength(2)
@@ -159,7 +159,7 @@ mem_fragmentation_ratio:1.25`,
         used_cpu_sys_children:0.1`,
       )
 
-      const result = await fetcher.info_cpu()
+      const result = await fetcher.cpu()
 
       expect(result).toHaveLength(3)
     })
@@ -169,12 +169,12 @@ mem_fragmentation_ratio:1.25`,
       client.info.mockResolvedValue(
         "used_cpu_sys:10.5\r\nused_cpu_user:20.3\r\n",
       )
-      let result = await fetcher.info_cpu()
+      let result = await fetcher.cpu()
       expect(result).toHaveLength(2)
 
       // Test with LF
       client.info.mockResolvedValue("used_cpu_sys:10.5\nused_cpu_user:20.3\n")
-      result = await fetcher.info_cpu()
+      result = await fetcher.cpu()
       expect(result).toHaveLength(2)
     })
 
@@ -186,7 +186,7 @@ mem_fragmentation_ratio:1.25`,
         another_invalid:abc`,
       )
 
-      const result = await fetcher.info_cpu()
+      const result = await fetcher.cpu()
 
       expect(result).toHaveLength(2)
       expect(result.find((r) => r.metric === "used_cpu_sys")).toBeTruthy()
@@ -202,7 +202,7 @@ mem_fragmentation_ratio:1.25`,
         "valkey-5.valkey-headless.valkey.svc.cluster.local:6379": "used_cpu_sys:2.5",
       })
 
-      const result = await fetcher.info_cpu()
+      const result = await fetcher.cpu()
 
       expect(result).toHaveLength(1)
       expect(result[0].metric).toBe("used_cpu_sys")

--- a/apps/metrics/src/effects/ndjson-cleaner.js
+++ b/apps/metrics/src/effects/ndjson-cleaner.js
@@ -17,7 +17,7 @@ const retentionForFile = (fileName, retentionByPrefix) => {
 }
 
 export const setupNdjsonCleaner = ( cfg ) => {
-  const retentionByPrefix = cfg.epics.map((e) => [e.file_prefix || e.name, e.data_retention_days])
+  const retentionByPrefix = cfg.epics.map((e) => [e.name, e.data_retention_days])
 
   const pipeline$ = timer(0, METRICS_EVICTION_POLICY.INTERVAL).pipe(
     exhaustMap(() => 

--- a/apps/metrics/src/effects/ndjson-cleaner.test.js
+++ b/apps/metrics/src/effects/ndjson-cleaner.test.js
@@ -34,8 +34,8 @@ describe("ndjson-cleaner", () => {
     cfg = {
       server: { data_dir: "/app/data" },
       epics: [
-        { name: "memory", file_prefix: "memory", data_retention_days: 30 },
-        { name: "cpu", file_prefix: "cpu", data_retention_days: 30 },
+        { name: "memory", data_retention_days: 30 },
+        { name: "cpu", data_retention_days: 30 },
       ],
     }
   })

--- a/apps/metrics/src/effects/ndjson-streamer.js
+++ b/apps/metrics/src/effects/ndjson-streamer.js
@@ -1,19 +1,22 @@
 import fs from "node:fs"
 import readline from "node:readline"
 import path from "node:path"
-import { COMMANDLOG_LARGE_REPLY, COMMANDLOG_LARGE_REQUEST, COMMANDLOG_SLOW, MONITOR } from "../utils/constants.js"
+import { getConfig } from "../config.js"
+import { EPIC_KINDS } from "../utils/constants.js"
 import { dayStr, parseSeq } from "../utils/helpers.js"
 
-const DATA_DIR = process.env.DATA_DIR || path.resolve(process.cwd(), "data")
+// Read per call rather than at import time so a config reload is picked up.
+const dataDir = () => getConfig().server.data_dir
 
 const filePathsFor = async (prefix, dates) => {
+  const dir = dataDir()
   const dayStrs = new Set(dates.map(dayStr))
-  const allFiles = (await fs.promises.readdir(DATA_DIR))
+  const allFiles = (await fs.promises.readdir(dir))
     .filter((file) => file.startsWith(`${prefix}_`) && file.endsWith(".ndjson"))
 
   const withStatsSeq = await Promise.all(
     allFiles.map(async (file) => {
-      const filePath = path.join(DATA_DIR, file)
+      const filePath = path.join(dir, file)
       const stat = await fs.promises.stat(filePath)
       return { file, filePath, birthtime: stat.birthtime, seq: parseSeq(file) }
     }),
@@ -88,6 +91,16 @@ export async function streamNdjson(
   return finalize(acc)
 }
 
-export const [memory_stats, info_cpu, slowlog_len, commandlog_slow, commandlog_large_reply, commandlog_large_request, monitor] =
-  ["memory", "cpu", "slowlog_len", COMMANDLOG_SLOW, COMMANDLOG_LARGE_REPLY, COMMANDLOG_LARGE_REQUEST, MONITOR]
-    .map((filePrefix) => (options = {}) => streamNdjson(filePrefix, options))
+// One streamer per epic kind, keyed by the epic name that also prefixes its
+// NDJSON files, so readers and writers cannot drift apart.
+const streamerFor = (filePrefix) => (options = {}) => streamNdjson(filePrefix, options)
+
+export const {
+  memory,
+  cpu,
+  slowlog_len,
+  commandlog_slow,
+  commandlog_large_reply,
+  commandlog_large_request,
+  monitor,
+} = Object.fromEntries(EPIC_KINDS.map((kind) => [kind, streamerFor(kind)]))

--- a/apps/metrics/src/effects/ndjson-streamer.test.js
+++ b/apps/metrics/src/effects/ndjson-streamer.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { mockEnv, createAsyncIterator, createNdjsonLines } from "../__tests__/test-helpers.js"
+import { createAsyncIterator, createNdjsonLines } from "../__tests__/test-helpers.js"
 
 // Mock node modules
 vi.mock("node:fs", () => ({
@@ -19,10 +19,16 @@ vi.mock("node:readline", () => ({
   },
 }))
 
+// The streamer reads its directory from the loaded config (which already folds
+// in DATA_DIR), so tests drive it through the config module.
+const mockConfig = { server: { data_dir: "/test/data" } }
+vi.mock("../config.js", () => ({
+  getConfig: () => mockConfig,
+}))
+
 describe("ndjson-streamer", () => {
   let fs
   let readline
-  let cleanupEnv
 
   beforeEach(async () => {
     vi.resetModules()
@@ -68,10 +74,6 @@ describe("ndjson-streamer", () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    if (cleanupEnv) {
-      cleanupEnv()
-      cleanupEnv = null
-    }
   })
 
   describe("streamNdjson", () => {
@@ -237,8 +239,8 @@ describe("ndjson-streamer", () => {
       expect(file1).toMatch(/my_metric_\d{8}_\d+\.ndjson$/)
     })
 
-    it("should use DATA_DIR environment variable", async () => {
-      cleanupEnv = mockEnv({ DATA_DIR: "/custom/data/dir" })
+    it("should read from the data dir resolved in config", async () => {
+      mockConfig.server.data_dir = "/custom/data/dir"
 
       const today = new Date().toISOString().slice(0, 10).replace(/-/g, "")
       fs.promises.readdir.mockResolvedValue([`test_${today}_0.ndjson`])
@@ -251,6 +253,8 @@ describe("ndjson-streamer", () => {
 
       const file1 = fs.createReadStream.mock.calls[0][0]
       expect(file1).toContain("/custom/data/dir")
+
+      mockConfig.server.data_dir = "/test/data"
     })
   })
 
@@ -260,8 +264,8 @@ describe("ndjson-streamer", () => {
       readline.createInterface.mockReturnValue(createAsyncIterator(lines))
 
       const {
-        memory_stats,
-        info_cpu,
+        memory,
+        cpu,
         slowlog_len,
         commandlog_slow,
         commandlog_large_reply,
@@ -269,8 +273,8 @@ describe("ndjson-streamer", () => {
         monitor,
       } = await import("./ndjson-streamer.js")
 
-      expect(typeof memory_stats).toBe("function")
-      expect(typeof info_cpu).toBe("function")
+      expect(typeof memory).toBe("function")
+      expect(typeof cpu).toBe("function")
       expect(typeof slowlog_len).toBe("function")
       expect(typeof commandlog_slow).toBe("function")
       expect(typeof commandlog_large_reply).toBe("function")
@@ -278,7 +282,7 @@ describe("ndjson-streamer", () => {
       expect(typeof monitor).toBe("function")
 
       // Test that they work
-      const result = await memory_stats()
+      const result = await memory()
       expect(Array.isArray(result)).toBe(true)
     })
   })

--- a/apps/metrics/src/effects/ndjson-writer.js
+++ b/apps/metrics/src/effects/ndjson-writer.js
@@ -35,6 +35,20 @@ export const makeNdjsonWriter = ({ dataDir, filePrefix, maxFiles, maxFileSize })
   let prevDay
   let seq
 
+  const resolvedDir = path.resolve(dataDir)
+
+  /**
+   * Asserts that `filePrefix` comes from operator-controlled config
+   * and the API cannot set it.
+   */
+  const containedPath = (fileName) => {
+    const candidate = path.resolve(dataDir, fileName)
+    if (candidate !== resolvedDir && !candidate.startsWith(resolvedDir + path.sep)) {
+      throw new Error(`Refusing to write outside the data dir: ${candidate}`)
+    }
+    return candidate
+  }
+
   const fileWithSizeFor = async (ts) => {
     const day = dayStr(ts)
     if (day !== prevDay) {
@@ -42,11 +56,11 @@ export const makeNdjsonWriter = ({ dataDir, filePrefix, maxFiles, maxFileSize })
       seq = await discoverMaxSeq(dataDir, filePrefix, day)
     }
 
-    const currentFile = path.join(dataDir, `${filePrefix}_${day}_${seq}.ndjson`)
+    const currentFile = containedPath(`${filePrefix}_${day}_${seq}.ndjson`)
     const currentSize = await fs.promises.stat(currentFile).then((s) => s.size).catch(() => 0)
     if (currentSize >= maxFileSize) {
       await advanceSeq()
-      return { file: path.join(dataDir, `${filePrefix}_${day}_${seq}.ndjson`), size: 0 }
+      return { file: containedPath(`${filePrefix}_${day}_${seq}.ndjson`), size: 0 }
     }
 
     return { file: currentFile, size: currentSize }

--- a/apps/metrics/src/effects/ndjson-writer.test.js
+++ b/apps/metrics/src/effects/ndjson-writer.test.js
@@ -20,6 +20,32 @@ describe("ndjson-writer", () => {
       .filter((f) => f.startsWith(`${prefix}_`) && f.endsWith(".ndjson"))
       .sort()
 
+  describe("path containment", () => {
+    it("refuses to write outside the data dir", async () => {
+      // Tripwire: nothing reachable from the API can set filePrefix today, so
+      // this guards against a future regression reintroducing that path.
+      const writer = makeNdjsonWriter({
+        dataDir: tmpDir,
+        filePrefix: "../escaped",
+        maxFiles: 4,
+        maxFileSize: 1024 * 1024,
+      })
+
+      await expect(writer.appendRows([{ ts: Date.now(), value: 1 }]))
+        .rejects.toThrow(/Refusing to write outside the data dir/)
+
+      const parentDir = path.dirname(tmpDir)
+      expect(fs.readdirSync(parentDir).filter((f) => f.startsWith("escaped_"))).toHaveLength(0)
+    })
+
+    it("writes normally for a plain prefix", async () => {
+      const writer = makeNdjsonWriter({ dataDir: tmpDir, filePrefix: "safe", maxFiles: 4, maxFileSize: 1024 * 1024 })
+      await writer.appendRows([{ ts: Date.now(), value: 1 }])
+
+      expect(listFiles("safe")).toHaveLength(1)
+    })
+  })
+
   describe("basic writing", () => {
     it("creates a file and appends rows", async () => {
       const writer = makeNdjsonWriter({ dataDir: tmpDir, filePrefix: "test", maxFiles: 4, maxFileSize: 1024 * 1024 })

--- a/apps/metrics/src/handlers/update-config-handler.js
+++ b/apps/metrics/src/handlers/update-config-handler.js
@@ -1,0 +1,36 @@
+import { getConfig, updateConfig } from "../config.js"
+import { ACTION, MONITOR } from "../utils/constants.js"
+import { monitorHandler, readMonitorMetadata } from "./monitor-handler.js"
+
+/**
+ * `POST /update-config`: apply a validated set of per-epic tuning patches.
+ *
+ * Validation, the field allowlist and the atomic write all live in
+ * `config.js`; this handler owns the HTTP shape and the one side effect the
+ * config write cannot do for itself. A running monitor has already baked its
+ * settings into the live stream, so it has to be restarted whenever its own
+ * settings were part of the update. The restart is unconditional for a
+ * successful `monitor` patch — it does not compare old and new values.
+ */
+export const updateConfigHandler = async (req, res) => {
+  try {
+    const result = updateConfig(req.body)
+
+    if (result.success && Object.hasOwn(result.data.epics, MONITOR)) {
+      const { isRunning } = readMonitorMetadata()
+      if (isRunning) {
+        await monitorHandler(ACTION.STOP, getConfig())
+        await monitorHandler(ACTION.START, getConfig())
+      }
+    }
+
+    return res.status(result.statusCode).json(result)
+  }
+  catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: error instanceof Error ? error.message : String(error),
+      data: error,
+    })
+  }
+}

--- a/apps/metrics/src/handlers/update-config-handler.test.js
+++ b/apps/metrics/src/handlers/update-config-handler.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { ACTION } from "../utils/constants.js"
+
+vi.mock("../config.js", () => ({
+  getConfig: vi.fn(() => ({ epics: [{ name: "monitor" }, { name: "cpu" }] })),
+  updateConfig: vi.fn(),
+}))
+
+vi.mock("./monitor-handler.js", () => ({
+  monitorHandler: vi.fn().mockResolvedValue({}),
+  readMonitorMetadata: vi.fn(),
+}))
+
+// Minimal express-shaped response recorder.
+const mockRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: vi.fn((code) => { res.statusCode = code; return res }),
+    json: vi.fn((body) => { res.body = body; return res }),
+  }
+  return res
+}
+
+const accepted = (epics) => ({ success: true, statusCode: 200, message: "", data: { epics } })
+
+describe("update-config-handler", () => {
+  let updateConfig
+  let monitorHandler
+  let readMonitorMetadata
+  let updateConfigHandler
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const configModule = await import("../config.js")
+    const monitorModule = await import("./monitor-handler.js")
+    updateConfig = configModule.updateConfig
+    monitorHandler = monitorModule.monitorHandler
+    readMonitorMetadata = monitorModule.readMonitorMetadata
+    updateConfigHandler = (await import("./update-config-handler.js")).updateConfigHandler
+  })
+
+  it("restarts a running monitor when the monitor epic was updated", async () => {
+    updateConfig.mockReturnValue(accepted({ monitor: { monitoringDuration: 15000 } }))
+    readMonitorMetadata.mockReturnValue({ isRunning: true })
+    const res = mockRes()
+
+    await updateConfigHandler({ body: { epics: { monitor: { monitoringDuration: 15000 } } } }, res)
+
+    // Stop before start, so the live stream cannot keep sampling with stale settings.
+    expect(monitorHandler.mock.calls.map(([action]) => action)).toEqual([ACTION.STOP, ACTION.START])
+    expect(res.statusCode).toBe(200)
+    expect(res.body.success).toBe(true)
+  })
+
+  it("does not restart the monitor when it is not running", async () => {
+    updateConfig.mockReturnValue(accepted({ monitor: { monitoringDuration: 15000 } }))
+    readMonitorMetadata.mockReturnValue({ isRunning: false })
+    const res = mockRes()
+
+    await updateConfigHandler({ body: { epics: { monitor: { monitoringDuration: 15000 } } } }, res)
+
+    expect(monitorHandler).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("does not restart the monitor when only other epics were updated", async () => {
+    updateConfig.mockReturnValue(accepted({ cpu: { poll_ms: 10000 } }))
+    readMonitorMetadata.mockReturnValue({ isRunning: true })
+    const res = mockRes()
+
+    await updateConfigHandler({ body: { epics: { cpu: { poll_ms: 10000 } } } }, res)
+
+    expect(monitorHandler).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(200)
+  })
+
+  it("passes a rejected update through with its status and touches no monitor", async () => {
+    updateConfig.mockReturnValue({
+      success: false,
+      statusCode: 400,
+      message: "epics.monitor: Unrecognized key: \"file_prefix\"",
+      data: {},
+    })
+    readMonitorMetadata.mockReturnValue({ isRunning: true })
+    const res = mockRes()
+
+    await updateConfigHandler({ body: { epics: { monitor: { file_prefix: "../../pwn" } } } }, res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body.message).toContain("file_prefix")
+    expect(monitorHandler).not.toHaveBeenCalled()
+    expect(readMonitorMetadata).not.toHaveBeenCalled()
+  })
+
+  it("returns 500 when the update throws", async () => {
+    updateConfig.mockImplementation(() => { throw new Error("disk on fire") })
+    const res = mockRes()
+
+    await updateConfigHandler({ body: { epics: { monitor: { monitoringDuration: 15000 } } } }, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toMatchObject({ success: false, message: "disk on fire" })
+  })
+
+  it("returns 500 when the monitor restart fails", async () => {
+    updateConfig.mockReturnValue(accepted({ monitor: { monitoringDuration: 15000 } }))
+    readMonitorMetadata.mockReturnValue({ isRunning: true })
+    monitorHandler.mockRejectedValueOnce(new Error("monitor stuck"))
+    const res = mockRes()
+
+    await updateConfigHandler({ body: { epics: { monitor: { monitoringDuration: 15000 } } } }, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body.message).toBe("monitor stuck")
+  })
+})

--- a/apps/metrics/src/index.js
+++ b/apps/metrics/src/index.js
@@ -1,11 +1,12 @@
 import fs from "node:fs"
 import express from "express"
-import { getConfig, updateConfig } from "./config.js"
+import { getConfig } from "./config.js"
 import * as Streamer from "./effects/ndjson-streamer.js"
 import { setupCollectors, stopCollectors } from "./init-collectors.js"
 import { getCommandLogs } from "./handlers/commandlog-handler.js"
 import { getDashboardInfo } from "./handlers/info-handler.js"
-import { monitorHandler, readMonitorMetadata, useMonitor } from "./handlers/monitor-handler.js"
+import { updateConfigHandler } from "./handlers/update-config-handler.js"
+import { monitorHandler, useMonitor } from "./handlers/monitor-handler.js"
 import { calculateHotKeysFromHotSlots } from "./analyzers/calculate-hot-keys.js"
 import { enrichHotKeys } from "./analyzers/enrich-hot-keys.js"
 import cpuFold from "./analyzers/calculate-cpu-usage.js"
@@ -14,7 +15,6 @@ import { bigKeysQuerySchema, cpuQuerySchema, memoryQuerySchema, parseQuery } fro
 import { sanitizeUrl } from "./utils/helpers.js"
 import { setupNdjsonCleaner, stopNdjsonCleaner } from "./effects/ndjson-cleaner.js"
 import { createValkeyClient } from "./valkey-client.js"
-import { ACTION, MONITOR } from "./utils/constants.js"
 import { scanBigKeys } from "./analyzers/scan-big-keys.js"
 
 async function main() {
@@ -107,29 +107,7 @@ async function main() {
     else useMonitor(res, client, ownNodeId, Number(req.query.count) || 50)
   })
 
-  app.post("/update-config", async (req, res) => {
-    try {
-      const result = updateConfig(req.body)
-
-      // Restart the running monitor when its own settings were part of the update
-      if (result.success && Object.hasOwn(result.data.epics, MONITOR)) {
-        const { isRunning } = readMonitorMetadata()
-        if (isRunning) {
-          await monitorHandler(ACTION.STOP, getConfig())
-          await monitorHandler(ACTION.START, getConfig())
-        }
-      }
-
-      return res.status(result.statusCode).json(result)
-    }
-    catch (error) {
-      return res.status(500).json({
-        success: false,
-        message: error instanceof Error ? error.message : String(error),
-        data: error,
-      })
-    }
-  })
+  app.post("/update-config", (req, res) => updateConfigHandler(req, res))
 
   app.post("/connection/close", async (req, res) => {
     try {

--- a/apps/metrics/src/index.js
+++ b/apps/metrics/src/index.js
@@ -24,7 +24,7 @@ async function main() {
   if (process.env.DEBUG_METRICS === "1") {
     console.log("Metrics config loaded:", JSON.stringify({
       data_dir: cfg.server.data_dir,
-      epics: cfg.epics?.map(({ name, type, file_prefix }) => ({ name, type, file_prefix })),
+      epics: cfg.epics?.map(({ name, poll_ms }) => ({ name, poll_ms })),
     }))
   }
 
@@ -43,7 +43,7 @@ async function main() {
   app.get("/memory", async (req, res) => {
     try {
       const { maxPoints, since, until } = parseQuery(memoryQuerySchema)(req.query)
-      const series = await Streamer.memory_stats(memoryFold({ maxPoints, since, until }))
+      const series = await Streamer.memory(memoryFold({ maxPoints, since, until }))
       res.json(series)
     } catch (e) {
       console.error(e)
@@ -54,7 +54,7 @@ async function main() {
   app.get("/cpu", async (req, res) => {
     try {
       const { maxPoints, tolerance, since, until } = parseQuery(cpuQuerySchema)(req.query)
-      const series = await Streamer.info_cpu(cpuFold({ maxPoints, tolerance, since, until }))
+      const series = await Streamer.cpu(cpuFold({ maxPoints, tolerance, since, until }))
       res.json(series)
     } catch (e) {
       res.status(500).json({ error: e.message })
@@ -111,7 +111,8 @@ async function main() {
     try {
       const result = updateConfig(req.body)
 
-      if (result.success && result.data.epic?.name === MONITOR) {
+      // Restart the running monitor when its own settings were part of the update
+      if (result.success && Object.hasOwn(result.data.epics, MONITOR)) {
         const { isRunning } = readMonitorMetadata()
         if (isRunning) {
           await monitorHandler(ACTION.STOP, getConfig())

--- a/apps/metrics/src/init-collectors.js
+++ b/apps/metrics/src/init-collectors.js
@@ -51,7 +51,7 @@ const startMonitor = async (cfg) => {
   const { maxFiles, maxFileSize } = computeCapacity(monitorEpic.data_retention_mb)
   const nd = makeNdjsonWriter({
     dataDir: cfg.server.data_dir,
-    filePrefix: monitorEpic.file_prefix || MONITOR,
+    filePrefix: monitorEpic.name,
     maxFiles,
     maxFileSize,
   })
@@ -116,15 +116,15 @@ const stopMonitor = async () => await monitorStopper()
 
 const setupCollectors = async (client, cfg) => {
   const fetcher = makeFetcher(client)
+  // An epic's name is its kind: it selects the fetcher and prefixes the files.
   await Promise.all(cfg.epics
-    .filter((f) => f.name !== MONITOR && fetcher[f.type])
+    .filter((f) => f.name !== MONITOR && fetcher[f.name])
     .map(async (f) => {
-      const fn = fetcher[f.type]
-      const prefix = f.file_prefix || f.name
+      const fn = fetcher[f.name]
       const { maxFiles, maxFileSize } = computeCapacity(f.data_retention_mb)
       const nd = makeNdjsonWriter({
         dataDir: cfg.server.data_dir,
-        filePrefix: prefix,
+        filePrefix: f.name,
         maxFiles,
         maxFileSize,
       })

--- a/apps/metrics/src/init-collectors.js
+++ b/apps/metrics/src/init-collectors.js
@@ -43,6 +43,12 @@ updateCollectorMeta(MONITOR, {
 })
 const startMonitor = async (cfg) => {
   const monitorEpic = cfg.epics.find((e) => e.name === MONITOR)
+  if (!monitorEpic) {
+    throw new Error(
+      `No "${MONITOR}" epic is configured, so monitoring cannot start. `
+      + "Add it to the metrics config file (CONFIG_PATH).",
+    )
+  }
 
   // Phase 1: Verify MONITOR command is supported (fast — throws if not)
   await connectMonitor()

--- a/apps/metrics/src/init-collectors.test.js
+++ b/apps/metrics/src/init-collectors.test.js
@@ -250,6 +250,17 @@ describe("init-collectors", () => {
       makeMonitorStream.mockReturnValue(mockSubject)
     })
 
+    it("should fail with a legible error when no monitor epic is configured", async () => {
+      const monitorConfig = createMockConfig({ epics: [{ name: "cpu", poll_ms: 5000 }] })
+
+      const { startMonitor } = await import("./init-collectors.js")
+
+      // Without this guard the missing epic surfaces as
+      // "Cannot read properties of undefined (reading 'data_retention_mb')".
+      await expect(startMonitor(monitorConfig)).rejects.toThrow(/No "monitor" epic is configured/)
+      expect(makeMonitorStream).not.toHaveBeenCalled()
+    })
+
     it("should create monitor stream with correct config", async () => {
       const monitorConfig = createMockConfig({
         epics: [

--- a/apps/metrics/src/init-collectors.test.js
+++ b/apps/metrics/src/init-collectors.test.js
@@ -51,16 +51,12 @@ describe("init-collectors", () => {
       epics: [
         {
           name: "cpu",
-          type: "info_cpu",
           poll_ms: 1000,
-          file_prefix: "cpu",
           data_retention_mb: 5,
         },
         {
           name: "memory",
-          type: "memory_stats",
           poll_ms: 2000,
-          file_prefix: "memory",
           data_retention_mb: 10,
         },
       ],
@@ -74,8 +70,8 @@ describe("init-collectors", () => {
     makeNdjsonWriter.mockReturnValue(mockWriter)
 
     const mockFetcher = {
-      info_cpu: vi.fn().mockResolvedValue([{ ts: Date.now(), metric: "cpu", value: 10 }]),
-      memory_stats: vi.fn().mockResolvedValue([{ ts: Date.now(), metric: "mem", value: 100 }]),
+      cpu: vi.fn().mockResolvedValue([{ ts: Date.now(), metric: "cpu", value: 10 }]),
+      memory: vi.fn().mockResolvedValue([{ ts: Date.now(), metric: "mem", value: 100 }]),
     }
     makeFetcher.mockReturnValue(mockFetcher)
 
@@ -96,17 +92,17 @@ describe("init-collectors", () => {
       expect(startCollector).toHaveBeenCalledTimes(2)
     })
 
-    it("should skip epics without matching fetcher type", async () => {
+    it("should skip epics with no matching fetcher", async () => {
       const configWithUnknown = createMockConfig({
         epics: [
-          { name: "cpu", type: "info_cpu", poll_ms: 1000, data_retention_mb: 5 },
-          { name: "unknown", type: "unknown_type", poll_ms: 1000, data_retention_mb: 5 },
+          { name: "cpu", poll_ms: 1000, data_retention_mb: 5 },
+          { name: "unknown", poll_ms: 1000, data_retention_mb: 5 },
         ],
       })
 
       const mockFetcher = {
-        info_cpu: vi.fn().mockResolvedValue([]),
-        // unknown_type doesn't exist
+        cpu: vi.fn().mockResolvedValue([]),
+        // no fetcher named "unknown"
       }
       makeFetcher.mockReturnValue(mockFetcher)
 
@@ -149,12 +145,12 @@ describe("init-collectors", () => {
 
     it("should perform initial fetch before starting polling", async () => {
       const mockFetcher = {
-        info_cpu: vi.fn().mockResolvedValue([{ ts: Date.now(), metric: "cpu", value: 10 }]),
+        cpu: vi.fn().mockResolvedValue([{ ts: Date.now(), metric: "cpu", value: 10 }]),
       }
       makeFetcher.mockReturnValue(mockFetcher)
 
       const configWithOneCpu = createMockConfig({
-        epics: [{ name: "cpu", type: "info_cpu", poll_ms: 1000, data_retention_mb: 5 }],
+        epics: [{ name: "cpu", poll_ms: 1000, data_retention_mb: 5 }],
       })
 
       const { setupCollectors } = await import("./init-collectors.js")
@@ -162,7 +158,7 @@ describe("init-collectors", () => {
       await setupCollectors(client, configWithOneCpu)
 
       // Fetcher should be called at least once for initial fetch
-      expect(mockFetcher.info_cpu).toHaveBeenCalled()
+      expect(mockFetcher.cpu).toHaveBeenCalled()
 
       // Writer should have been called with initial data
       const writer = makeNdjsonWriter.mock.results[0].value
@@ -172,13 +168,13 @@ describe("init-collectors", () => {
     it("should filter out monitor epic", async () => {
       const configWithMonitor = createMockConfig({
         epics: [
-          { name: "cpu", type: "info_cpu", poll_ms: 1000, data_retention_mb: 5 },
-          { name: "monitor", type: "monitor_stream", poll_ms: 1000, data_retention_mb: 10 },
+          { name: "cpu", poll_ms: 1000, data_retention_mb: 5 },
+          { name: "monitor", poll_ms: 1000, data_retention_mb: 10 },
         ],
       })
 
       const mockFetcher = {
-        info_cpu: vi.fn().mockResolvedValue([]),
+        cpu: vi.fn().mockResolvedValue([]),
         monitor_stream: vi.fn().mockResolvedValue([]),
       }
       makeFetcher.mockReturnValue(mockFetcher)
@@ -208,7 +204,7 @@ describe("init-collectors", () => {
       makeFetcher.mockReturnValue(mockFetcher)
 
       const testConfig = createMockConfig({
-        epics: [{ name: "test_collector", type: "test_collector", poll_ms: 1000, data_retention_mb: 5 }],
+        epics: [{ name: "test_collector", poll_ms: 1000, data_retention_mb: 5 }],
       })
 
       const { setupCollectors } = await import("./init-collectors.js")
@@ -228,7 +224,7 @@ describe("init-collectors", () => {
       makeFetcher.mockReturnValue(mockFetcher)
 
       const testConfig = createMockConfig({
-        epics: [{ name: "test_collector", type: "test_collector", poll_ms: 1000, data_retention_mb: 5 }],
+        epics: [{ name: "test_collector", poll_ms: 1000, data_retention_mb: 5 }],
       })
 
       const { setupCollectors, getCollectorMeta } = await import("./init-collectors.js")
@@ -259,7 +255,6 @@ describe("init-collectors", () => {
         epics: [
           {
             name: "monitor",
-            type: "monitor",
             monitoringDuration: 5000,
             monitoringInterval: 10000,
             data_retention_mb: 10,

--- a/apps/metrics/src/utils/constants.js
+++ b/apps/metrics/src/utils/constants.js
@@ -1,9 +1,25 @@
 // TODO: merge with common/src/constants.ts
 
 export const MONITOR = "monitor"
+export const MEMORY = "memory"
+export const CPU = "cpu"
+export const SLOWLOG_LEN = "slowlog_len"
 export const COMMANDLOG_SLOW = "commandlog_slow"
 export const COMMANDLOG_LARGE_REPLY = "commandlog_large_reply"
 export const COMMANDLOG_LARGE_REQUEST = "commandlog_large_request"
+
+/**
+ * The collection streams ("epics"), one identifier per data kind.
+ */
+export const EPIC_KINDS = [
+  MEMORY,
+  CPU,
+  SLOWLOG_LEN,
+  COMMANDLOG_SLOW,
+  COMMANDLOG_LARGE_REPLY,
+  COMMANDLOG_LARGE_REQUEST,
+  MONITOR,
+]
 
 export const ALLKEYS_LFU = "allkeys-lfu"
 export const VOLATILE_LFU = "volatile-lfu"

--- a/apps/server/src/__tests__/config.test.ts
+++ b/apps/server/src/__tests__/config.test.ts
@@ -93,7 +93,7 @@ describe("config actions", () => {
 
       const action = {
         type: VALKEY.CONFIG.updateConfig,
-        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epic: { name: "monitor" } } },
+        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epics: { monitor: { monitoringDuration: 5000 } } } },
       }
 
       await runConfigPushSession(deps())(action as any)
@@ -133,7 +133,7 @@ describe("config actions", () => {
 
       const action = {
         type: VALKEY.CONFIG.updateConfig,
-        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epic: { name: "monitor" } } },
+        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epics: { monitor: { monitoringDuration: 5000 } } } },
       }
 
       await runConfigPushSession(deps())(action as any)
@@ -152,7 +152,7 @@ describe("config actions", () => {
       // The failed reply is PARTIAL here (node-1 succeeded), so it still
       // carries the applied config: node-1 DID apply it and the frontend
       // shows it.
-      assert.deepStrictEqual(sent[0].payload.appliedConfig, { epic: { name: "monitor" } })
+      assert.deepStrictEqual(sent[0].payload.appliedConfig, { epics: { monitor: { monitoringDuration: 5000 } } })
     })
 
     it("omits appliedConfig from a total-failure reply (no node applied it)", async () => {
@@ -164,7 +164,7 @@ describe("config actions", () => {
 
       const action = {
         type: VALKEY.CONFIG.updateConfig,
-        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epic: { name: "monitor" } } },
+        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epics: { monitor: { monitoringDuration: 5000 } } } },
       }
 
       await runConfigPushSession(deps())(action as any)
@@ -193,7 +193,7 @@ describe("config actions", () => {
 
       const makeAction = () => ({
         type: VALKEY.CONFIG.updateConfig,
-        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epic: { name: "monitor" } } },
+        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epics: { monitor: { monitoringDuration: 5000 } } } },
       })
 
       const first = runConfigPushSession(deps())(makeAction() as any)
@@ -241,7 +241,7 @@ describe("config actions", () => {
 
       const action = {
         type: VALKEY.CONFIG.updateConfig,
-        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epic: { name: "monitor" } } },
+        payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epics: { monitor: { monitoringDuration: 5000 } } } },
       }
 
       await runConfigPushSession(deps())(action as any)

--- a/apps/server/src/__tests__/monitorAction.test.ts
+++ b/apps/server/src/__tests__/monitorAction.test.ts
@@ -486,7 +486,7 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
 
     const action = {
       type: VALKEY.CONFIG.updateConfig,
-      payload: { connectionId: "conn-1", config: { epic: { name: "monitor" } } },
+      payload: { connectionId: "conn-1", config: { epics: { monitor: { monitoringDuration: 5000 } } } },
       meta: undefined,
     }
 
@@ -529,7 +529,7 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
 
     const action = {
       type: VALKEY.CONFIG.updateConfig,
-      payload: { connectionId: "conn-1", config: { epic: { name: "monitor" } }, monitorAction: "start" },
+      payload: { connectionId: "conn-1", config: { epics: { monitor: { monitoringDuration: 5000 } } }, monitorAction: "start" },
       meta: undefined,
     }
 
@@ -568,7 +568,7 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
 
     const action = {
       type: VALKEY.CONFIG.updateConfig,
-      payload: { connectionId: "conn-1", config: { epic: { name: "monitor" } }, monitorAction: "start" },
+      payload: { connectionId: "conn-1", config: { epics: { monitor: { monitoringDuration: 5000 } } }, monitorAction: "start" },
       meta: undefined,
     }
 
@@ -611,7 +611,12 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
 
     const action = {
       type: VALKEY.CONFIG.updateConfig,
-      payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epic: { name: "monitor" } }, monitorAction: "start" },
+      payload: {
+        connectionId: "node-1",
+        clusterId: "cluster-1",
+        config: { epics: { monitor: { monitoringDuration: 5000 } } },
+        monitorAction: "start",
+      },
       meta: undefined,
     }
 
@@ -655,7 +660,7 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
 
     const action = {
       type: VALKEY.CONFIG.updateConfig,
-      payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epic: { name: "monitor" } } },
+      payload: { connectionId: "node-1", clusterId: "cluster-1", config: { epics: { monitor: { monitoringDuration: 5000 } } } },
       meta: undefined,
     }
 
@@ -675,7 +680,7 @@ describe("config/updateConfig orchestration (config session + monitorAction ride
 
     const action = {
       type: VALKEY.CONFIG.updateConfig,
-      payload: { connectionId: "host-6379-db0", config: { epic: { name: "monitor" } } },
+      payload: { connectionId: "host-6379-db0", config: { epics: { monitor: { monitoringDuration: 5000 } } } },
       meta: undefined,
     }
 

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -253,6 +253,26 @@ export const METRICS_EVICTION_POLICY = {
   INTERVAL: 1 * MILLISECONDS_IN_A_DAY,
 }
 
+/**
+ * Bounds for the epic (collection stream) fields that `POST /update-config`
+ * may tune. Shared so the metrics validator and the UI inputs that produce
+ * these values cannot drift apart.
+ *
+ * Calibrated against `apps/metrics/config.yml`:
+ *  - `data_retention_mb` below 1 MB yields a capacity smaller than a single
+ *    file, which disables the writer's rotation and eviction
+ *  - `poll_ms` below a second would hammer the node being sampled
+ */
+export const EPIC_FIELD_BOUNDS = {
+  monitoringDuration: { min: 1, max: 3_600_000 },   // capture window, up to 1h
+  monitoringInterval: { min: 1, max: MILLISECONDS_IN_A_DAY }, // pause between runs
+  maxCommandsPerRun: { min: 1, max: 10_000_000 },
+  cutoffFrequency: { min: 1, max: 1_000_000 },
+  poll_ms: { min: 1_000, max: 3_600_000 },
+  data_retention_mb: { min: 1, max: 10_240 },
+  data_retention_days: { min: 1, max: 365 },
+} as const
+
 export type EndpointType = "node" | "cluster-endpoint"
 
 export const CONNECTION_TEARDOWN_DELAY_MS = Number(nodeEnv.CONNECTION_TEARDOWN_DELAY_MS ?? 10000)

--- a/docs-site/src/content/docs/configuration/metrics.md
+++ b/docs-site/src/content/docs/configuration/metrics.md
@@ -34,24 +34,24 @@ After the YAML is parsed, a small set of environment variables is allowed to ove
 
 ## Per-Epic Settings
 
-Each entry in the `epics` array describes one collector. The fields below apply to every epic; the `monitor` epic adds a few extras for sampling behavior.
+Each entry in the `epics` array describes one collection stream. The fields below apply to every epic; the `monitor` epic adds a few extras for sampling behavior.
 
 ### Common fields
 
 | Field | Description | Default |
 |-------|-------------|---------|
-| `name` | Identifier used in logs and the orchestrator registry. | required |
-| `type` | Collector implementation. One of `memory_stats`, `info_cpu`, `commandlog_slow`, `commandlog_large_request`, `commandlog_large_reply`, `slowlog_len`, `monitor`. | required |
+| `name` | The epic's only identifier. It selects the collector implementation, prefixes the NDJSON files written under `DATA_DIR`, and labels the epic in logs and the orchestrator registry. One of `memory`, `cpu`, `slowlog_len`, `commandlog_slow`, `commandlog_large_request`, `commandlog_large_reply`, `monitor`. | required |
 | `poll_ms` | How often (ms) the collector runs. | varies per epic |
-| `file_prefix` | Filename prefix for the NDJSON output written under `DATA_DIR`. | required |
 | `data_retention_mb` | Max disk space (MB) this epic's NDJSON files may use. Oldest files are evicted when the budget is exceeded. | `10` |
 | `data_retention_days` | Files older than this (by birthtime) are deleted during the daily cleanup sweep. | `30` |
+
+Names must match `^[a-z0-9_]+$`; the metrics process refuses to start on anything else, because the name becomes part of a file path. An epic whose name is not one of the values above collects nothing and is dropped at load with an error logged.
 
 The `Default` column shows the **fallback defaults applied by the YAML merge**. `apps/metrics/config.yml` overrides these with lower values per epic (3–15 MB, 5 days). See the file itself for the full per-epic configuration.
 
 ### Monitor-only fields
 
-These apply only when `type: monitor` and control the `MONITOR`-based hot keys sampling cycle:
+These apply only to the epic named `monitor` and control the `MONITOR`-based hot keys sampling cycle:
 
 | Field | Description | Default |
 |-------|-------------|---------------------------|
@@ -167,7 +167,7 @@ TCP port the metrics HTTP server listens on. Setting `PORT=0` lets the OS assign
 
 Directory where NDJSON metric files are written and rotated. The server passes a per-node subdirectory here when spawning children, so each child gets its own slice of disk.
 
-- **Default:** `cfg.server.data_dir` from `config.yml` (`/app/data`); the cleaner module falls back to `./data` if no value is available
+- **Default:** `cfg.server.data_dir` from `config.yml` (`/app/data`)
 - **Overrides:** `cfg.server.data_dir`
 
 ### `CONFIG_PATH`

--- a/docs-site/src/content/docs/configuration/metrics.md
+++ b/docs-site/src/content/docs/configuration/metrics.md
@@ -174,6 +174,8 @@ Directory where NDJSON metric files are written and rotated. The server passes a
 
 Absolute path to the `config.yml` file. When set, the metrics process loads its config from this location instead of the bundled `apps/metrics/config.yml`. The Electron build uses this to point at a config file packaged inside the app bundle.
 
+`POST /update-config` writes tuning changes back into this file. Mounting it read-only or serving it from a ConfigMap is supported — updates then apply to the running process only and report `"persisted": false`.
+
 ## Collector Tuning
 
 These also override fields under `collector` in `config.yml`. Use them to change batch behavior without editing the YAML.

--- a/examples/k8s/metrics-configmap.yaml
+++ b/examples/k8s/metrics-configmap.yaml
@@ -17,32 +17,18 @@ data:
       retention_days: 5
     epics:
       - name: "memory"
-        type: "memory_stats"
         poll_ms: 5000
-        file_prefix: "memory"
       - name: "cpu"
-        type: "info_cpu"
         poll_ms: 5000
-        file_prefix: "cpu"
       - name: "commandlog_large_reply"
-        type: "commandlog_large_reply"
         poll_ms: 10000
-        file_prefix: "commandlog_large_reply"
       - name: "commandlog_large_request"
-        type: "commandlog_large_request"
         poll_ms: 10000
-        file_prefix: "commandlog_large_request"
       - name: "commandlog_slow"
-        type: "commandlog_slow"
         poll_ms: 10000
-        file_prefix: "commandlog_slow"
       - name: "slowlog_len"
-        type: "slowlog_len"
         poll_ms: 60000
-        file_prefix: "slowlog_len"
       - name: "monitor"
-        type: "monitor"
         monitoringDuration: 10000
         monitoringInterval: 10000
         maxCommandsPerRun: 1000000
-        file_prefix: "monitor"


### PR DESCRIPTION
## Description

Refactors config to consolidate and harden.
- Unify epic identity on name
    - Collapse name, type, file_prefix into a single name
    - Remove file_prefix from update-config to harden
- Harden update-config 
    - Rework validator into zod validator
    - Update shape from `epic: { name, ... }` to `epics: { <name>: { ... } }`
    - Updates are all-or-nothing for named epics
- Isolate config updates for each process
    - Previously, metrics children were spawned with the same `CONFIG_PATH` which led to them each overwriting the other's config files.
    - This change stages them config changes through `config.yml.<pid>.tmp`.
-  Patch config updates as a YAML document rather than re-serializing runtime config
- Apply patch in memory before persisting, so deployments with read-only memory can still use the changes, without persistence.