### PR TITLE
implementation of cluster hot slots version 1

### DIFF
--- a/apps/frontend/src/components/activity-view/hotkeys/heatmap-legend.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/heatmap-legend.tsx
@@ -1,0 +1,40 @@
+import { Typography } from "../../ui/typography"
+import { getColor, LEGEND_STEPS } from "./heatmap-scale"
+
+interface HeatmapLegendProps {
+  label: string
+  selectedBuckets: Set<number>
+  onToggle: (step: number) => void
+}
+
+export function HeatmapLegend({ label, selectedBuckets, onToggle }: HeatmapLegendProps) {
+  const hasBucketFilter = selectedBuckets.size > 0
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <Typography variant="bodyXs">{label}</Typography>
+      <div className="flex gap-1 shrink-0">
+        {LEGEND_STEPS.map((step) => {
+          const isSelected = selectedBuckets.has(step)
+          return (
+            <button
+              aria-label={`Filter band ${LEGEND_STEPS.indexOf(step) + 1}`}
+              aria-pressed={isSelected}
+              className={`w-5 h-5 rounded-full transition-all focus:outline-none
+                ${isSelected
+              ? "ring-2 ring-offset-1 ring-foreground scale-110"
+              : hasBucketFilter
+                ? "opacity-30 hover:opacity-70"
+                : "hover:scale-110 hover:ring-1 hover:ring-border"
+            }`}
+              key={step}
+              onClick={() => onToggle(step)}
+              style={{ backgroundColor: getColor(step) }}
+              type="button"
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/activity-view/hotkeys/heatmap-scale.ts
+++ b/apps/frontend/src/components/activity-view/hotkeys/heatmap-scale.ts
@@ -1,0 +1,19 @@
+// for heatmap legend and color scale
+export const LEGEND_STEPS = [0, 0.25, 0.5, 0.75, 1]
+
+// Returns the color for a given ratio
+export function getColor(ratio: number): string {
+  const lightness = Math.round(90 - ratio * 62)
+  const saturation = Math.round(70 + ratio * 15)
+  return `hsl(0, ${saturation}%, ${lightness}%)`
+}
+
+// Snaps a ratio to the nearest bucket (0, 0.25, 0.5, 0.75, 1)
+export function snapToBucket(ratio: number): number {
+  return Math.round(ratio * 4) / 4
+}
+
+// Converts a value to a ratio between 0 and 1 based on the given min and max
+export function toRatio(value: number, min: number, max: number): number {
+  return max === min ? 0 : (value - min) / (max - min)
+}

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-heatmap.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-heatmap.tsx
@@ -1,83 +1,50 @@
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import * as Dialog from "@radix-ui/react-dialog"
-import { Flame, Server, X } from "lucide-react"
-import { truncateText } from "@common/src/truncate-text"
+import { X } from "lucide-react"
 import { Typography } from "../../ui/typography"
 import { Button } from "../../ui/button"
+import { TabGroup } from "../../ui/tab-group"
+import { NodeHeatmap } from "./node-heatmap"
+import { SlotHeatmap } from "./slot-heatmap"
+import type { HotKeyEntry } from "./hot-keys"
+
+type HeatmapTab = "nodes" | "slots"
+
+const TABS: Record<HeatmapTab, { title: string; description: string }> = {
+  nodes: {
+    title: "Node Heatmap",
+    description: "Hot key concentration across cluster nodes",
+  },
+  slots: {
+    title: "Slot Heatmap",
+    description: "Hot key concentration across cluster slots — select a slot to see its keys",
+  },
+}
 
 interface HotKeysHeatmapModalProps {
   open: boolean
   onClose: () => void
-  data: [string, number, number | null, number, string?][]
+  data: HotKeyEntry[]
+  showSlots: boolean
+  failedNodeCount: number
+  onKeyClick?: (keyName: string) => void
 }
 
-interface NodeStat {
-  nodeId: string
-  count: number
-  totalAccess: number
-}
+export function HotKeysHeatmapModal({
+  open, onClose, data, showSlots, failedNodeCount, onKeyClick,
+}: HotKeysHeatmapModalProps) {
+  const [activeTab, setActiveTab] = useState<HeatmapTab>("nodes")
 
-interface HoveredTile {
-  nodeId: string
-  count: number
-  totalAccess: number
-  x: number
-  y: number
-}
+  const tabs = [
+    { id: "nodes" as HeatmapTab, label: "Nodes" },
+    ...(showSlots ? [{ id: "slots" as HeatmapTab, label: "Slots" }] : []),
+  ]
+  const tab = showSlots ? activeTab : "nodes"
 
-const LEGEND_STEPS = [0, 0.25, 0.5, 0.75, 1]
-
-function getColor(ratio: number): string {
-  const lightness = Math.round(90 - ratio * 62)
-  const saturation = Math.round(70 + ratio * 15)
-  return `hsl(0, ${saturation}%, ${lightness}%)`
-}
-
-function snapToBucket(ratio: number): number {
-  return Math.round(ratio * 4) / 4
-}
-
-export function HotKeysHeatmapModal({ open, onClose, data }: HotKeysHeatmapModalProps) {
-  const [hovered, setHovered] = useState<HoveredTile | null>(null)
-  const [selectedBuckets, setSelectedBuckets] = useState<Set<number>>(new Set())
-
-  const { sorted, max, min } = useMemo(() => {
-    const nodeStats = data.reduce((acc, [, accessCount, , , nodeId]) => {
-      const key = nodeId ?? "Unknown"
-      acc[key] ??= { nodeId: key, count: 0, totalAccess: 0 }
-      acc[key].count += 1
-      acc[key].totalAccess += accessCount
-      return acc
-    }, {} as Record<string, NodeStat>)
-
-    const sorted: NodeStat[] = Object.values(nodeStats).sort((a, b) => b.count - a.count)
-    return {
-      sorted,
-      max: sorted[0]?.count ?? 1,
-      min: sorted.at(-1)?.count ?? 0,
-    }
-  }, [data])
-
-  const hasBucketFilter = selectedBuckets.size > 0
-
-  const isActive = (ratio: number) =>
-    !hasBucketFilter || selectedBuckets.has(snapToBucket(ratio))
-
-  const toggleBucket = (step: number) => {
-    setSelectedBuckets((prev) => {
-      const next = new Set(prev)
-      if (next.has(step)) { next.delete(step) } else { next.add(step) }
-      return next
-    })
+  const handleKeyClick = (keyName: string) => {
+    onClose()
+    onKeyClick?.(keyName)
   }
-
-  const handleMouseEnter = (stat: NodeStat, e: React.MouseEvent) => {
-    setHovered({ ...stat, x: e.clientX, y: e.clientY })
-  }
-  const handleMouseMove = (e: React.MouseEvent) => {
-    if (hovered) setHovered((prev) => prev ? { ...prev, x: e.clientX, y: e.clientY } : null)
-  }
-  const handleMouseLeave = () => setHovered(null)
 
   return (
     <Dialog.Root onOpenChange={onClose} open={open}>
@@ -85,120 +52,44 @@ export function HotKeysHeatmapModal({ open, onClose, data }: HotKeysHeatmapModal
         <Dialog.Overlay className="fixed inset-0 z-30 bg-black/50" />
         <Dialog.Content asChild>
           <div className="fixed inset-0 z-40 flex items-center justify-center p-4">
-            <div className="w-1/2 h-1/2 bg-background rounded-xl border border-border shadow-xl flex flex-col">
+            <div className="w-[90vw] max-w-6xl h-[80vh] bg-background rounded-xl border border-border shadow-xl flex flex-col">
 
-              {/* Header */}
-              <div className="flex items-start justify-between px-6 py-4 border-b border-border">
+              <div className="flex items-start justify-between gap-4 px-6 py-4 border-b border-border">
                 <div className="flex flex-col gap-0.5">
                   <Dialog.Title asChild>
-                    <Typography variant="subheading">Node Heatmap</Typography>
+                    <Typography variant="subheading">{TABS[tab].title}</Typography>
                   </Dialog.Title>
                   <Dialog.Description asChild>
-                    <Typography variant="bodyXs">
-                      Hot key concentration across cluster nodes
-                    </Typography>
+                    <Typography variant="bodyXs">{TABS[tab].description}</Typography>
                   </Dialog.Description>
                 </div>
-                <Dialog.Close asChild>
-                  <Button className="hover:text-primary p-1 shrink-0 -mt-1 -mr-1" size="sm" variant="ghost">
-                    <X size={16} />
-                  </Button>
-                </Dialog.Close>
+                <div className="flex items-start gap-4">
+                  {showSlots && (
+                    <TabGroup activeTab={tab} onChange={setActiveTab} tabs={tabs} />
+                  )}
+                  <Dialog.Close asChild>
+                    <Button className="hover:text-primary p-1 shrink-0 -mt-1 -mr-1" size="sm" variant="ghost">
+                      <X size={16} />
+                    </Button>
+                  </Dialog.Close>
+                </div>
               </div>
 
-              {/* Body */}
-              <div className="flex-1 flex flex-col gap-5 px-6 py-5 overflow-y-auto min-h-0">
-
-                {/* Summary chips */}
-                <div className="flex items-center gap-2">
-                  <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-primary/10 border border-primary/20">
-                    <Server className="text-primary" size={12} />
-                    <Typography variant="bodyXs">
-                      {sorted.length} node{sorted.length !== 1 ? "s" : ""}
-                    </Typography>
-                  </div>
-                  <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-primary/10 border border-primary/20">
-                    <Flame className="text-primary" size={12} />
-                    <Typography variant="bodyXs">
-                      {data.length} hot key{data.length !== 1 ? "s" : ""}
-                    </Typography>
-                  </div>
-                </div>
-
-                {/* Legend with filter */}
-                <div className="flex flex-col gap-3">
-                  <div className="flex items-center justify-between">
-                    <Typography variant="bodyXs">
-                      Select one or multiple legends to filter nodes by hot key concentration
-                    </Typography>
-                    <div className="flex items-center gap-2">
-                      <div className="flex gap-0.5">
-                        {LEGEND_STEPS.map((step) => {
-                          const isSelected = selectedBuckets.has(step)
-                          return (
-                            <button
-                              className={`w-5 h-5 rounded-lg transition-all focus:outline-none
-                                ${isSelected
-                              ? "ring-2 ring-offset-1 ring-foreground scale-110"
-                              : hasBucketFilter && !isSelected
-                                ? "opacity-30 hover:opacity-70"
-                                : "hover:scale-110 hover:ring-1 hover:ring-border"
-                            }`}
-                              key={step}
-                              onClick={() => toggleBucket(step)}
-                              style={{ backgroundColor: getColor(step) }}
-                              type="button"
-                            />
-                          )
-                        })}
-                      </div>
-
-                    </div>
-                  </div>
-
-                  {/* Tile grid */}
-                  <div className="rounded-lg border border-border bg-muted/40 p-4 min-h-16 max-h-40 overflow-y-auto">
-                    <div className="flex flex-wrap gap-1.5">
-                      {sorted.map((stat) => {
-                        const ratio = max === min ? 0 : (stat.count - min) / (max - min)
-                        return (
-                          <div
-                            className={`w-5 h-5 rounded transition-all relative cursor-default
-                              ${isActive(ratio) ? "hover:scale-125 hover:z-10 hover:shadow-sm" : "opacity-20"}`}
-                            key={stat.nodeId}
-                            onMouseEnter={(e) => handleMouseEnter(stat, e)}
-                            onMouseLeave={handleMouseLeave}
-                            onMouseMove={handleMouseMove}
-                            style={{ backgroundColor: getColor(ratio) }}
-                          />
-                        )
-                      })}
-                    </div>
-                  </div>
-                </div>
+              <div className="flex-1 flex flex-col px-6 py-5 min-h-0">
+                {tab === "slots" ? (
+                  <SlotHeatmap
+                    failedNodeCount={failedNodeCount}
+                    hotKeys={data}
+                    onKeyClick={handleKeyClick}
+                  />
+                ) : (
+                  <NodeHeatmap data={data} />
+                )}
               </div>
             </div>
           </div>
         </Dialog.Content>
       </Dialog.Portal>
-
-      {/* Hover tooltip */}
-      {hovered && (
-        <div
-          className="fixed z-50 pointer-events-none px-3 py-2.5 rounded-lg border border-border bg-popover shadow-lg"
-          style={{ left: hovered.x + 14, top: hovered.y - 12 }}
-        >
-          <Typography variant="code">{truncateText(hovered.nodeId)}</Typography>
-          <div className="flex flex-col gap-0.5 mt-1">
-            <Typography variant="bodyXs">
-              {hovered.count} hot key{hovered.count !== 1 ? "s" : ""}
-            </Typography>
-            <Typography variant="bodyXs">
-              {hovered.totalAccess.toLocaleString()} total accesses
-            </Typography>
-          </div>
-        </div>
-      )}
     </Dialog.Root>
   )
 }

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys-toolbar.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys-toolbar.tsx
@@ -39,7 +39,7 @@ export function HotKeysToolbar({
           variant="outline"
         >
           <ChartPie className="text-primary" />
-          Node Heatmap
+          Heatmap
         </Button>
       )}
 

--- a/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/hot-keys.tsx
@@ -10,7 +10,7 @@ import { MonitorNotRunningBanner, NodeErrorsBanner } from "./hot-keys-banners"
 import { HotKeysToolbar } from "./hot-keys-toolbar"
 import { HotKeysTable } from "./hot-keys-table"
 
-export type HotKeyEntry = [string, number, number | null, number, string?]
+export type HotKeyEntry = [string, number, number | null, number, string?, number?]
 
 interface HotKeysProps {
   data: HotKeyEntry[] | null
@@ -96,8 +96,11 @@ export function HotKeys({
       {banners}
       <HotKeysHeatmapModal
         data={sorted}
+        failedNodeCount={nodeErrors?.length ?? 0}
         onClose={() => setIsHeatmapOpen(false)}
+        onKeyClick={onKeyClick}
         open={isHeatmapOpen}
+        showSlots={!!isHotSlots && sorted.some(([, , , , , slotId]) => slotId !== undefined)}
       />
       <HotKeysToolbar
         countMax={countMax}

--- a/apps/frontend/src/components/activity-view/hotkeys/node-filter-dropdown.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/node-filter-dropdown.tsx
@@ -4,15 +4,20 @@ import { truncateText } from "@common/src/truncate-text"
 import { Button } from "../../ui/button"
 import { Input } from "../../ui/input"
 import { Typography } from "../../ui/typography"
+import { cn } from "@/lib/utils"
 
 interface NodeFilterDropdownProps {
   nodes: string[]
   selectedNode: string
   onSelect: (node: string) => void
   align?: "left" | "right"
+  allLabel?: string
+  className?: string
 }
 
-export function NodeFilterDropdown({ nodes, selectedNode, onSelect, align = "left" }: NodeFilterDropdownProps) {
+export function NodeFilterDropdown({
+  nodes, selectedNode, onSelect, align = "left", allLabel = "All Nodes", className,
+}: NodeFilterDropdownProps) {
   const [open, setOpen] = useState(false)
   const [nodeSearch, setNodeSearch] = useState("")
   const ref = useRef<HTMLDivElement>(null)
@@ -33,20 +38,20 @@ export function NodeFilterDropdown({ nodes, selectedNode, onSelect, align = "lef
   return (
     <div className="relative" ref={ref}>
       <Button
-        className="w-full"
+        className={cn("w-full", className)}
         onClick={() => setOpen((prev) => !prev)}
         type="button"
         variant="outline"
       >
         <ListFilter className="text-primary" size={14} />
         <span className="max-w-32 truncate">
-          {selectedNode === "all" ? "All Nodes" : truncateText(selectedNode, 20)}
+          {selectedNode === "all" ? allLabel : truncateText(selectedNode, 20)}
         </span>
         <ChevronDown className="text-muted-foreground" size={14} />
       </Button>
 
       {open && (
-        <div className={`absolute z-50 ${align === "right" ? "right-0" : "left-0"} top-11 w-64 rounded-md border bg-popover shadow-md p-2`}>
+        <div className={`absolute z-50 ${align === "right" ? "right-0" : "left-0"} top-full mt-1.5 w-64 rounded-md border bg-popover shadow-md p-2`}>
           <div className="relative mb-2">
             <Input
               autoFocus
@@ -64,7 +69,7 @@ export function NodeFilterDropdown({ nodes, selectedNode, onSelect, align = "lef
                 onClick={() => { onSelect("all"); setOpen(false); setNodeSearch("") }}
                 type="button"
               >
-                All Nodes
+                {allLabel}
               </button>
             </li>
             {filtered.length === 0 && (

--- a/apps/frontend/src/components/activity-view/hotkeys/node-heatmap.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/node-heatmap.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react"
+import { Flame, Server } from "lucide-react"
+import { truncateText } from "@common/src/truncate-text"
+import { Typography } from "../../ui/typography"
+import { HeatmapLegend } from "./heatmap-legend"
+import { getColor, snapToBucket, toRatio } from "./heatmap-scale"
+import type { HotKeyEntry } from "./hot-keys"
+
+interface NodeStat {
+  nodeId: string
+  count: number
+  totalAccess: number
+}
+
+interface HoveredTile extends NodeStat {
+  x: number
+  y: number
+}
+
+interface NodeHeatmapProps {
+  data: HotKeyEntry[]
+}
+
+export function NodeHeatmap({ data }: NodeHeatmapProps) {
+  const [hovered, setHovered] = useState<HoveredTile | null>(null)
+  const [selectedBuckets, setSelectedBuckets] = useState<Set<number>>(new Set())
+
+  const nodeStats = data.reduce((acc, [, accessCount, , , nodeId]) => {
+    const key = nodeId ?? "Unknown"
+    acc[key] ??= { nodeId: key, count: 0, totalAccess: 0 }
+    acc[key].count += 1
+    acc[key].totalAccess += accessCount
+    return acc
+  }, {} as Record<string, NodeStat>)
+
+  const sorted: NodeStat[] = Object.values(nodeStats).sort((a, b) => b.count - a.count)
+  const max = sorted[0]?.count ?? 1
+  const min = sorted.at(-1)?.count ?? 0
+
+  const hasBucketFilter = selectedBuckets.size > 0
+  const isActive = (ratio: number) => !hasBucketFilter || selectedBuckets.has(snapToBucket(ratio))
+
+  const toggleBucket = (step: number) => {
+    setSelectedBuckets((prev) => {
+      const next = new Set(prev)
+      if (next.has(step)) { next.delete(step) } else { next.add(step) }
+      return next
+    })
+  }
+
+  const handleMouseEnter = (stat: NodeStat, e: React.MouseEvent) => {
+    setHovered({ ...stat, x: e.clientX, y: e.clientY })
+  }
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (hovered) setHovered((prev) => prev ? { ...prev, x: e.clientX, y: e.clientY } : null)
+  }
+  const handleMouseLeave = () => setHovered(null)
+
+  return (
+    <div className="flex-1 flex flex-col gap-5 min-h-0">
+      <div className="flex items-center gap-2">
+        <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-primary/10 border border-primary/20">
+          <Server className="text-primary" size={12} />
+          <Typography variant="bodyXs">
+            {sorted.length} node{sorted.length !== 1 ? "s" : ""}
+          </Typography>
+        </div>
+        <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-primary/10 border border-primary/20">
+          <Flame className="text-primary" size={12} />
+          <Typography variant="bodyXs">
+            {data.length} hot key{data.length !== 1 ? "s" : ""}
+          </Typography>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 min-h-0">
+        <HeatmapLegend
+          label="Select one or multiple legends to filter nodes by hot key concentration"
+          onToggle={toggleBucket}
+          selectedBuckets={selectedBuckets}
+        />
+
+        <div className="rounded-lg border border-border bg-muted/40 p-4 min-h-16 overflow-y-auto">
+          <div className="flex flex-wrap gap-1.5">
+            {sorted.map((stat) => {
+              const ratio = toRatio(stat.count, min, max)
+              return (
+                <div
+                  className={`w-5 h-5 rounded transition-all relative cursor-default
+                    ${isActive(ratio) ? "hover:scale-125 hover:z-10 hover:shadow-sm" : "opacity-20"}`}
+                  key={stat.nodeId}
+                  onMouseEnter={(e) => handleMouseEnter(stat, e)}
+                  onMouseLeave={handleMouseLeave}
+                  onMouseMove={handleMouseMove}
+                  style={{ backgroundColor: getColor(ratio) }}
+                />
+              )
+            })}
+          </div>
+        </div>
+      </div>
+
+      {hovered && (
+        <div
+          className="fixed z-50 pointer-events-none px-3 py-2.5 rounded-lg border border-border bg-popover shadow-lg"
+          style={{ left: hovered.x + 14, top: hovered.y - 12 }}
+        >
+          <Typography variant="code">{truncateText(hovered.nodeId)}</Typography>
+          <div className="flex flex-col gap-0.5 mt-1">
+            <Typography variant="bodyXs">
+              {hovered.count} hot key{hovered.count !== 1 ? "s" : ""}
+            </Typography>
+            <Typography variant="bodyXs">
+              {hovered.totalAccess.toLocaleString()} total accesses
+            </Typography>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/activity-view/hotkeys/slot-heatmap.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/slot-heatmap.tsx
@@ -6,6 +6,7 @@ import { truncateText } from "@common/src/truncate-text"
 import { Typography } from "../../ui/typography"
 import { EmptyState } from "../../ui/empty-state"
 import { HeatmapLegend } from "./heatmap-legend"
+import { NodeFilterDropdown } from "./node-filter-dropdown"
 import { getColor, snapToBucket } from "./heatmap-scale"
 import type { HotKeyEntry } from "./hot-keys"
 
@@ -136,11 +137,12 @@ function SlotDetails({ group, totalHotKeys, onKeyClick }: {
 export function SlotHeatmap({ hotKeys, failedNodeCount, onKeyClick }: SlotHeatmapProps) {
   const [selectedBuckets, setSelectedBuckets] = useState<Set<number>>(new Set())
   const [selectedSlotId, setSelectedSlotId] = useState<number | null>(null)
+  const [selectedNode, setSelectedNode] = useState("all")
   const [hovered, setHovered] = useState<HoveredSlot | null>(null)
 
-  const groups = groupKeysBySlot(hotKeys)
+  const allGroups = groupKeysBySlot(hotKeys)
 
-  if (groups.length === 0) {
+  if (allGroups.length === 0) {
     return (
       <EmptyState
         icon={<Grid2x2X size={48} />}
@@ -149,10 +151,20 @@ export function SlotHeatmap({ hotKeys, failedNodeCount, onKeyClick }: SlotHeatma
     )
   }
 
+  const nodes = [...new Set(allGroups.flatMap((group) => group.nodeId ?? []))].sort()
+  const activeNode = nodes.includes(selectedNode) ? selectedNode : "all"
+  const groups = activeNode === "all"
+    ? allGroups
+    : allGroups.filter((group) => group.nodeId === activeNode)
+
   const max = groups[0].rows.length
   const min = groups.at(-1)!.rows.length
   const totalHotKeys = groups.reduce((sum, group) => sum + group.rows.length, 0)
-  const nodeCount = new Set(groups.map((group) => group.nodeId ?? "Unknown")).size
+
+  const handleNodeSelect = (node: string) => {
+    setSelectedNode(node)
+    setSelectedSlotId(null)
+  }
 
   const hasBucketFilter = selectedBuckets.size > 0
   const isActive = (ratio: number) => !hasBucketFilter || selectedBuckets.has(snapToBucket(ratio))
@@ -170,7 +182,6 @@ export function SlotHeatmap({ hotKeys, failedNodeCount, onKeyClick }: SlotHeatma
   const chips = [
     `${groups.length} hot slot${groups.length !== 1 ? "s" : ""}`,
     `${totalHotKeys} hot key${totalHotKeys !== 1 ? "s" : ""}`,
-    `${nodeCount} node${nodeCount !== 1 ? "s" : ""}`,
   ]
 
   return (
@@ -184,6 +195,13 @@ export function SlotHeatmap({ hotKeys, failedNodeCount, onKeyClick }: SlotHeatma
             <Typography variant="bodyXs">{chip}</Typography>
           </span>
         ))}
+        <NodeFilterDropdown
+          allLabel={`${nodes.length} node${nodes.length !== 1 ? "s" : ""}`}
+          className="w-auto h-7 rounded-full px-3 py-1 text-xs font-normal bg-primary/10 border-primary/20 dark:bg-primary/10"
+          nodes={nodes}
+          onSelect={handleNodeSelect}
+          selectedNode={activeNode}
+        />
         {failedNodeCount > 0 && (
           <Typography className="text-destructive" variant="bodyXs">
             Partial — {failedNodeCount} node{failedNodeCount !== 1 ? "s" : ""} failed to report

--- a/apps/frontend/src/components/activity-view/hotkeys/slot-heatmap.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/slot-heatmap.tsx
@@ -151,7 +151,10 @@ export function SlotHeatmap({ hotKeys, failedNodeCount, onKeyClick }: SlotHeatma
     )
   }
 
-  const nodes = [...new Set(allGroups.flatMap((group) => group.nodeId ?? []))].sort()
+  const nodes = [
+    ...new Set(allGroups.map((group) => group.nodeId).filter((nodeId) => nodeId !== undefined)),
+  ].sort()
+
   const activeNode = nodes.includes(selectedNode) ? selectedNode : "all"
   const groups = activeNode === "all"
     ? allGroups

--- a/apps/frontend/src/components/activity-view/hotkeys/slot-heatmap.tsx
+++ b/apps/frontend/src/components/activity-view/hotkeys/slot-heatmap.tsx
@@ -1,0 +1,250 @@
+import { useState } from "react"
+import { Grid2x2X } from "lucide-react"
+import { convertTTL } from "@common/src/ttl-conversion"
+import { formatBytes } from "@common/src/bytes-conversion"
+import { truncateText } from "@common/src/truncate-text"
+import { Typography } from "../../ui/typography"
+import { EmptyState } from "../../ui/empty-state"
+import { HeatmapLegend } from "./heatmap-legend"
+import { getColor, snapToBucket } from "./heatmap-scale"
+import type { HotKeyEntry } from "./hot-keys"
+
+interface SlotGroup {
+  slotId: number
+  rows: HotKeyEntry[]
+  totalFreq: number
+  nodeId?: string
+}
+
+interface HoveredSlot {
+  group: SlotGroup
+  x: number
+  y: number
+}
+
+interface SlotHeatmapProps {
+  hotKeys: HotKeyEntry[]
+  failedNodeCount: number
+  onKeyClick?: (keyName: string) => void
+}
+
+const toTileRatio = (value: number, min: number, max: number) =>
+  max === min ? 1 : (value - min) / (max - min)
+
+const groupKeysBySlot = (hotKeys: HotKeyEntry[]): SlotGroup[] => {
+  const grouped = new Map<number, SlotGroup>()
+
+  for (const row of hotKeys) {
+    const slotId = row[5]
+    if (slotId === undefined || slotId === null) continue
+
+    const group = grouped.get(slotId) ?? {
+      slotId,
+      rows: [],
+      totalFreq: 0,
+      nodeId: row[4],
+    }
+    group.rows.push(row)
+    group.totalFreq += row[1]
+    grouped.set(slotId, group)
+  }
+
+  return [...grouped.values()].sort(
+    (a, b) => b.rows.length - a.rows.length || b.totalFreq - a.totalFreq,
+  )
+}
+
+function SlotTile({ group, ratio, dimmed, selected, onSelect, onHover, onMove, onLeave }: {
+  group: SlotGroup
+  ratio: number
+  dimmed: boolean
+  selected: boolean
+  onSelect: () => void
+  onHover: (e: React.MouseEvent) => void
+  onMove: (e: React.MouseEvent) => void
+  onLeave: () => void
+}) {
+  return (
+    <button
+      className={`flex flex-col items-center justify-center gap-0.5 rounded-md py-3 px-2 transition-all
+        ${dimmed ? "opacity-20" : "hover:scale-105 hover:z-10 hover:shadow-sm"}
+        ${selected ? "ring-2 ring-offset-1 ring-foreground" : ""}`}
+      onClick={onSelect}
+      onMouseEnter={onHover}
+      onMouseLeave={onLeave}
+      onMouseMove={onMove}
+      style={{ backgroundColor: getColor(ratio), color: ratio > 0.5 ? "hsl(0, 0%, 100%)" : "hsl(0, 0%, 12%)" }}
+      type="button"
+    >
+      <span className="text-sm font-semibold leading-tight">{group.slotId}</span>
+      <span className="text-xs leading-tight">
+        {group.rows.length} Key{group.rows.length !== 1 ? "s" : ""}
+      </span>
+    </button>
+  )
+}
+
+function SlotDetails({ group, totalHotKeys, onKeyClick }: {
+  group: SlotGroup | null
+  totalHotKeys: number
+  onKeyClick?: (keyName: string) => void
+}) {
+  if (!group) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-6">
+        <Typography variant="bodySm">Select a slot to see the hot keys it holds</Typography>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      <header className="flex items-baseline justify-between gap-4 px-4 py-3 border-b border-border">
+        <Typography variant="label">Slot {group.slotId}</Typography>
+        <Typography variant="bodyXs">
+          {group.rows.length} of your top {totalHotKeys} hot key{totalHotKeys !== 1 ? "s" : ""}
+        </Typography>
+      </header>
+
+      <ul className="flex-1 overflow-y-auto min-h-0 px-4 py-2">
+        {group.rows.map(([keyName, , size, ttl], index) => (
+          <li key={`${keyName}-${index}`}>
+            <button
+              className="w-full flex items-center justify-between gap-4 py-1.5 rounded-sm text-left hover:bg-accent"
+              onClick={() => onKeyClick?.(keyName)}
+              type="button"
+            >
+              <Typography className="truncate" variant="code">{keyName}</Typography>
+              <span className="flex items-center gap-4 shrink-0">
+                <Typography variant="bodyXs">Size: {size === null ? "—" : formatBytes(size)}</Typography>
+                <Typography variant="bodyXs">TTL: {convertTTL(ttl)}</Typography>
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <footer className="px-4 py-2 border-t border-border">
+        <Typography variant="bodyXs">
+          Owned by Node {truncateText(group.nodeId ?? "—")}
+        </Typography>
+      </footer>
+    </div>
+  )
+}
+
+export function SlotHeatmap({ hotKeys, failedNodeCount, onKeyClick }: SlotHeatmapProps) {
+  const [selectedBuckets, setSelectedBuckets] = useState<Set<number>>(new Set())
+  const [selectedSlotId, setSelectedSlotId] = useState<number | null>(null)
+  const [hovered, setHovered] = useState<HoveredSlot | null>(null)
+
+  const groups = groupKeysBySlot(hotKeys)
+
+  if (groups.length === 0) {
+    return (
+      <EmptyState
+        icon={<Grid2x2X size={48} />}
+        title="No Hot Slots Found"
+      />
+    )
+  }
+
+  const max = groups[0].rows.length
+  const min = groups.at(-1)!.rows.length
+  const totalHotKeys = groups.reduce((sum, group) => sum + group.rows.length, 0)
+  const nodeCount = new Set(groups.map((group) => group.nodeId ?? "Unknown")).size
+
+  const hasBucketFilter = selectedBuckets.size > 0
+  const isActive = (ratio: number) => !hasBucketFilter || selectedBuckets.has(snapToBucket(ratio))
+
+  const toggleBucket = (step: number) => {
+    setSelectedBuckets((prev) => {
+      const next = new Set(prev)
+      if (next.has(step)) { next.delete(step) } else { next.add(step) }
+      return next
+    })
+  }
+
+  const selectedGroup = groups.find((group) => group.slotId === selectedSlotId) ?? null
+
+  const chips = [
+    `${groups.length} hot slot${groups.length !== 1 ? "s" : ""}`,
+    `${totalHotKeys} hot key${totalHotKeys !== 1 ? "s" : ""}`,
+    `${nodeCount} node${nodeCount !== 1 ? "s" : ""}`,
+  ]
+
+  return (
+    <div className="flex-1 flex flex-col gap-4 min-h-0">
+      <div className="flex items-center gap-2 flex-wrap">
+        {chips.map((chip) => (
+          <span
+            className="inline-flex items-center px-3 py-1 rounded-full bg-primary/10 border border-primary/20"
+            key={chip}
+          >
+            <Typography variant="bodyXs">{chip}</Typography>
+          </span>
+        ))}
+        {failedNodeCount > 0 && (
+          <Typography className="text-destructive" variant="bodyXs">
+            Partial — {failedNodeCount} node{failedNodeCount !== 1 ? "s" : ""} failed to report
+          </Typography>
+        )}
+      </div>
+
+      <HeatmapLegend
+        label="Select one or multiple legends to filter slots by hot key concentration"
+        onToggle={toggleBucket}
+        selectedBuckets={selectedBuckets}
+      />
+
+      <div className="flex-1 flex gap-4 min-h-0">
+        <section className="w-1/2 flex flex-col gap-2 min-h-0">
+          <div className="flex-1 rounded-lg border border-border p-4 overflow-y-auto min-h-0">
+            <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-2">
+              {groups.map((group) => {
+                const ratio = toTileRatio(group.rows.length, min, max)
+                return (
+                  <SlotTile
+                    dimmed={!isActive(ratio)}
+                    group={group}
+                    key={`${group.nodeId ?? "unknown"}-${group.slotId}`}
+                    onHover={(e) => setHovered({ group, x: e.clientX, y: e.clientY })}
+                    onLeave={() => setHovered(null)}
+                    onMove={(e) => setHovered((prev) => prev ? { ...prev, x: e.clientX, y: e.clientY } : null)}
+                    onSelect={() => setSelectedSlotId(group.slotId)}
+                    ratio={ratio}
+                    selected={selectedSlotId === group.slotId}
+                  />
+                )
+              })}
+            </div>
+          </div>
+          <Typography variant="bodyXs">
+            Shows the slots holding your top {totalHotKeys} hot key{totalHotKeys !== 1 ? "s" : ""}, not every slot in the cluster.
+          </Typography>
+        </section>
+
+        <section className="w-1/2 flex flex-col rounded-lg border border-border min-h-0">
+          <SlotDetails group={selectedGroup} onKeyClick={onKeyClick} totalHotKeys={totalHotKeys} />
+        </section>
+      </div>
+
+      {hovered && (
+        <div
+          className="fixed z-50 pointer-events-none px-3 py-2.5 rounded-lg border border-border bg-popover shadow-lg"
+          style={{ left: hovered.x + 14, top: hovered.y - 12 }}
+        >
+          <Typography variant="code">Slot {hovered.group.slotId}</Typography>
+          <div className="flex flex-col gap-0.5 mt-1">
+            <Typography variant="bodyXs">
+              {hovered.group.rows.length} of your top {totalHotKeys} hot key{totalHotKeys !== 1 ? "s" : ""}
+            </Typography>
+            <Typography variant="bodyXs">
+              {truncateText(hovered.group.nodeId ?? "—")}
+            </Typography>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
+++ b/apps/frontend/src/state/valkey-features/hotkeys/hotKeysSlice.ts
@@ -27,7 +27,7 @@ export const selectHotKeysLastCollectedAt = (targetId: string) => (state: RootSt
 interface HotKeysState {
   // Keyed by `targetId`: `clusterId` (cluster) or db-less `nodeId` (standalone).
   [targetId: string]: {
-    hotKeys: [string, number, number | null, number, string?][]
+    hotKeys: [string, number, number | null, number, string?, number?][]
     checkAt: string | null,
     monitorRunning: boolean,
     nodeId: string | null,
@@ -82,7 +82,7 @@ const hotKeysSlice = createSlice({
       if (!state[targetId]) {
         state[targetId] = {
           hotKeys: [],
-          checkAt: null, 
+          checkAt: null,
           monitorRunning: false,
           nodeId: null,
           status: ERROR,

--- a/apps/frontend/src/state/valkey-features/keys/keyBrowserSlice.test.ts
+++ b/apps/frontend/src/state/valkey-features/keys/keyBrowserSlice.test.ts
@@ -152,16 +152,72 @@ describe("keyBrowserSlice", () => {
         getKeyTypeFulfilled({
           connectionId: "conn-1",
           key: "mykey",
-          keyType: "String",
+          name: "mykey",
+          type: "string",
           ttl: -1,
           size: 100,
+          elements: "myvalue",
         }),
       )
 
-      expect(state["conn-1"].keys[0].type).toBe("String")
+      expect(state["conn-1"].keys[0].type).toBe("string")
       expect(state["conn-1"].keys[0].ttl).toBe(-1)
       expect(state["conn-1"].keys[0].size).toBe(100)
+      expect(state["conn-1"].keys[0].elements).toBe("myvalue")
       expect(state["conn-1"].keyTypeLoading["mykey"]).toBeUndefined()
+    })
+
+    it("should add the key when it is not already in the keys array", () => {
+      const previousState = {
+        "conn-1": {
+          ...defaultConnectionState,
+          keyTypeLoading: { hotkey: true },
+        },
+      }
+
+      const state = keyBrowserReducer(
+        previousState,
+        getKeyTypeFulfilled({
+          connectionId: "conn-1",
+          key: "hotkey",
+          name: "hotkey",
+          type: "string",
+          ttl: -1,
+          size: 56,
+          elements: "hotvalue",
+        }),
+      )
+
+      expect(state["conn-1"].keys).toEqual([
+        { name: "hotkey", type: "string", ttl: -1, size: 56, elements: "hotvalue" },
+      ])
+      expect(state["conn-1"].keyTypeLoading["hotkey"]).toBeUndefined()
+    })
+
+    it("should store elementsWarning when the value is too large to display", () => {
+      const previousState = {
+        "conn-1": {
+          ...defaultConnectionState,
+          keyTypeLoading: { bigkey: true },
+        },
+      }
+
+      const state = keyBrowserReducer(
+        previousState,
+        getKeyTypeFulfilled({
+          connectionId: "conn-1",
+          key: "bigkey",
+          name: "bigkey",
+          type: "list",
+          ttl: -1,
+          size: 99999999,
+          collectionSize: 1000,
+          elementsWarning: "too big",
+        }),
+      )
+
+      expect(state["conn-1"].keys[0].elementsWarning).toBe("too big")
+      expect(state["conn-1"].keys[0].elements).toBeUndefined()
     })
 
     it("should update collection size if provided", () => {
@@ -178,7 +234,8 @@ describe("keyBrowserSlice", () => {
         getKeyTypeFulfilled({
           connectionId: "conn-1",
           key: "mylist",
-          keyType: "List",
+          name: "mylist",
+          type: "list",
           ttl: -1,
           size: 50,
           collectionSize: 10,

--- a/apps/frontend/src/state/valkey-features/keys/keyBrowserSlice.ts
+++ b/apps/frontend/src/state/valkey-features/keys/keyBrowserSlice.ts
@@ -6,6 +6,9 @@ interface KeyInfo {
   ttl?: number;
   size?: number;
   collectionSize?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  elements?: any;
+  elementsWarning?: string;
 }
 
 interface KeyBrowserState {
@@ -19,14 +22,17 @@ interface KeyBrowserState {
   };
 }
 
-export const defaultConnectionState = {
+// Called per connection so each gets its own nested objects, not frozen shared ones.
+export const createConnectionState = (): KeyBrowserState[string] => ({
   keys: [],
   cursor: "0",
   loading: false,
   error: null,
   keyTypeLoading: {},
   totalKeys: 0,
-}
+})
+
+export const defaultConnectionState = createConnectionState()
 
 const initialState: KeyBrowserState = {}
 
@@ -44,7 +50,7 @@ const keyBrowserSlice = createSlice({
     ) => {
       const { connectionId } = action.payload
       if (!state[connectionId]) {
-        state[connectionId] = { ...defaultConnectionState }
+        state[connectionId] = createConnectionState()
       }
       state[connectionId].loading = true
       state[connectionId].error = null
@@ -85,40 +91,29 @@ const keyBrowserSlice = createSlice({
     ) => {
       const { connectionId, key } = action.payload
       if (!state[connectionId]) {
-        state[connectionId] = { ...defaultConnectionState }
+        state[connectionId] = createConnectionState()
       }
       state[connectionId].keyTypeLoading[key] = true
     },
     getKeyTypeFulfilled: (
       state,
-      action: PayloadAction<{
-        connectionId: string;
-        key: string;
-        keyType: string;
-        ttl: number;
-        size: number;
-        collectionSize?: number;
-      }>,
+      action: PayloadAction<
+        {
+          connectionId: string;
+          key: string;
+        } & Omit<KeyInfo, "name"> & { name?: string }
+      >,
     ) => {
-      const { connectionId, key, keyType, ttl, size, collectionSize } =
-        action.payload
+      const { connectionId, key, name, ...keyInfo } = action.payload
       if (!state[connectionId]) {
-        state[connectionId] = { ...defaultConnectionState }
+        state[connectionId] = createConnectionState()
       }
-      const existingKey = state[connectionId].keys.find(
-        (k) => k.name === key,
-      )
-      if (existingKey) {
-        existingKey.type = keyType
-        existingKey.ttl = ttl
-        if (size !== undefined) existingKey.size = size
-        if (collectionSize !== undefined)
-          existingKey.collectionSize = collectionSize
+      const updatedKey: KeyInfo = { name: name ?? key, ...keyInfo }
+      const index = state[connectionId].keys.findIndex((k) => k.name === key)
+      if (index === -1) {
+        state[connectionId].keys.push(updatedKey)
       } else {
-        state[connectionId].keys.push({
-          name: key, type: keyType, ttl, size,
-          ...(collectionSize !== undefined ? { collectionSize } : {}),
-        })
+        state[connectionId].keys[index] = updatedKey
       }
       delete state[connectionId].keyTypeLoading[key]
     },
@@ -141,7 +136,7 @@ const keyBrowserSlice = createSlice({
     ) => {
       const { connectionId, key } = action.payload
       if (!state[connectionId]) {
-        state[connectionId] = { ...defaultConnectionState }
+        state[connectionId] = createConnectionState()
       }
       state[connectionId].keyTypeLoading[key] = true
     },
@@ -194,7 +189,7 @@ const keyBrowserSlice = createSlice({
     ) => {
       const { connectionId } = action.payload
       if (!state[connectionId]) {
-        state[connectionId] = { ...defaultConnectionState }
+        state[connectionId] = createConnectionState()
       }
       state[connectionId].loading = true
       state[connectionId].error = null
@@ -247,7 +242,7 @@ const keyBrowserSlice = createSlice({
     ) => {
       const { connectionId } = action.payload
       if (!state[connectionId]) {
-        state[connectionId] = { ...defaultConnectionState }
+        state[connectionId] = createConnectionState()
       }
       state[connectionId].loading = true
       state[connectionId].error = null

--- a/apps/metrics/src/analyzers/calculate-hot-keys.js
+++ b/apps/metrics/src/analyzers/calculate-hot-keys.js
@@ -94,12 +94,12 @@ export const calculateHotKeysFromHotSlots = async (client, { count = 50 } = {}) 
       cursorToSlot = Number(cursor) & 0x3FFF
 
     } while (cursorToSlot === slotId && cursor !== 0)
-    
-    return keys
+
+    return { slotId, keys }
   })
 
-  const slotKeys = await Promise.all(slotPromises)
-  const allKeys = slotKeys.flat()
+  const slotEntries = await Promise.all(slotPromises)
+  const allKeys = slotEntries.flatMap(({ slotId, keys }) => keys.map((key) => ({ key, slotId })))
 
   // Pipeline OBJECT FREQ in chunks to avoid overwhelming the server
   const { PIPELINE_CHUNK_SIZE } = VALKEY_CLIENT
@@ -107,7 +107,7 @@ export const calculateHotKeysFromHotSlots = async (client, { count = 50 } = {}) 
   for (let i = 0; i < allKeys.length; i += PIPELINE_CHUNK_SIZE) {
     const chunk = allKeys.slice(i, i + PIPELINE_CHUNK_SIZE)
     const batch = new Batch(false)
-    for (const key of chunk) {
+    for (const { key } of chunk) {
       batch.customCommand(["OBJECT", "FREQ", key])
     }
     const chunkResults = await client.exec(batch)
@@ -118,13 +118,15 @@ export const calculateHotKeysFromHotSlots = async (client, { count = 50 } = {}) 
   for (let i = 0; i < allKeys.length; i++) {
     const freq = parseInt(freqResults[i])
     if (isNaN(freq) || freq <= 1) continue
+
+    const { key, slotId } = allKeys[i]
     if (heap.size() < count) {
-      heap.push({ key: allKeys[i], freq })
+      heap.push({ key, freq, slotId })
     } else if (freq > heap.peek().freq) {
       heap.pop()
-      heap.push({ key: allKeys[i], freq })
+      heap.push({ key, freq, slotId })
     }
   }
-  return heap.toArray().map(({ key, freq }) => [key, freq])
 
-} 
+  return heap.toArray().map(({ key, freq, slotId }) => [key, freq, slotId])
+}

--- a/apps/metrics/src/analyzers/enrich-hot-keys.js
+++ b/apps/metrics/src/analyzers/enrich-hot-keys.js
@@ -22,8 +22,8 @@ export const enrichHotKeys = (client) => async (hotKeyPairs) => {
     }
   }
 
-  return hotKeyPairs.map(([keyName, count], i) => {
+  return hotKeyPairs.map(([keyName, count, ...rest], i) => {
     const [ttl, memoryUsage] = results.slice(i * 2, i * 2 + 2)
-    return [keyName, count, memoryUsage ?? null, ttl ?? -1]
+    return [keyName, count, memoryUsage ?? null, ttl ?? -1, ...rest]
   })
 }

--- a/apps/server/src/actions/hotkeys.ts
+++ b/apps/server/src/actions/hotkeys.ts
@@ -133,16 +133,16 @@ export const hotKeysRequested = withDeps<Deps, void>(
       return
     }
 
-    type HotKeyTuple = [string, number, number | null, number, string]
+    type HotKeyTuple = [string, number, number | null, number, string, number?]
     const aggregatedHotKeys = R.pipe(
       R.chain(({ hotKeys, nodeId: nId }: HotKeysResponse) =>
-        (hotKeys as unknown as [string, number, number | null, number][]).map(
-          ([key, count, size, ttl]) => [key, count, size, ttl, nId] as HotKeyTuple,
+        (hotKeys as unknown as [string, number, number | null, number, number?][]).map(
+          ([key, count, size, ttl, slotId]) => [key, count, size, ttl, nId, slotId] as HotKeyTuple,
         ),
       ),
-      R.reduce((acc: Record<string, HotKeyTuple>, [key, count, size, ttl, nId]: HotKeyTuple) => ({
+      R.reduce((acc: Record<string, HotKeyTuple>, [key, count, size, ttl, nId, slotId]: HotKeyTuple) => ({
         ...acc,
-        [key]: [key, (acc[key]?.[1] ?? 0) + count, acc[key]?.[2] ?? size, acc[key]?.[3] ?? ttl, nId] as HotKeyTuple,
+        [key]: [key, (acc[key]?.[1] ?? 0) + count, acc[key]?.[2] ?? size, acc[key]?.[3] ?? ttl, nId, acc[key]?.[5] ?? slotId] as HotKeyTuple,
       }), {}),
       R.values,
       R.sort(R.descend(R.nth(1) as (x: HotKeyTuple) => number)),
@@ -151,6 +151,8 @@ export const hotKeysRequested = withDeps<Deps, void>(
     const { checkAt, nodeId } = results[0]
     const monitorRunning = results.every((r) => r.monitorRunning)
     const lastCollectedAt = results.reduce((max, r) => Math.max(max, r.lastCollectedAt ?? 0), 0) || null
-    const aggregatedResponse = { hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId, lastCollectedAt } as unknown as HotKeysResponse
+    const aggregatedResponse = {
+      hotKeys: aggregatedHotKeys, monitorRunning, checkAt, nodeId, lastCollectedAt,
+    } as unknown as HotKeysResponse
     sendHotKeysFulfilled(ws, { clusterId: clusterId as string }, aggregatedResponse, nodeErrors)
   })


### PR DESCRIPTION
## Description

Adds a Slot Heatmap view to the Hot Keys feature and threads slotId through the full pipeline (metrics collector → server aggregation → Redux → UI). The existing single-view "Node Heatmap" modal becomes a tabbed Heatmap modal with Nodes and Slots tabs.

Include a summary of the change.

  - Hot-slots scanner now keeps each key's slotId; returns [key, freq, slotId] instead of [key, freq].
  - enrichHotKeys passes trailing tuple fields through, so slotId survives TTL/size enrichment.
  - Server cluster aggregation carries slotId as a 6th tuple element (next to nodeId), keeping first-seen slot per key.
  - HotKeyEntry type and hotKeysSlice state widened to [key, count, size, ttl, nodeId?, slotId?].
  - Heatmap modal converted to tabbed Nodes / Slots view; enlarged to 90vw × 80vh; per-tab title/description.
  - Slots tab only shows in hot-slots mode when at least one entry has a slotId.
  - Node-heatmap logic extracted unchanged into new node-heatmap.tsx.
  - New shared heatmap-scale.ts (color/bucket/ratio helpers) and heatmap-legend.tsx (clickable legend).
  - New slot-heatmap.tsx: groups keys by slot, slot-tile grid + selected-slot key list (size/TTL/owner); key click closes modal and navigates.
  - SlotHeatmap shows empty state and "Partial — N nodes failed to report" from failedNodeCount (nodeErrors.length).
  - hot-keys.tsx passes failedNodeCount, onKeyClick, and showSlots into the modal.
  - Toolbar button relabeled "Node Heatmap" → "Heatmap".

### Change Visualization

<img width="1908" height="958" alt="Screenshot 2026-08-31 at 4 36 21 PM" src="https://github.com/user-attachments/assets/485c5277-f8b2-4012-81bf-0d1447983f27" />

Include a screenshot/video of before and after the change.
